### PR TITLE
Add input to publish to GCS only and skip catalog publishing

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -227,11 +227,14 @@ jobs:
       - define-variables
       - ci
       # Update the docs only after a successful GCOM deployment
+      # This dependency can be skipped if gcs-only is true. In that case, this step
+      # is still executed due to the "!(failure() || cancelled())" condition.
       - deploy
     if: >-
       ${{
         (needs.ci.outputs.has-docs == 'true')
         && (needs.define-variables.outputs.publish-docs == 'true')
+        && !(failure() || cancelled())
       }}
     runs-on: ubuntu-latest
     container:
@@ -278,8 +281,14 @@ jobs:
       - define-variables
       - ci
       # Create the release only after a successful GCOM deployment
+      # This dependency can be skipped if gcs-only is true. In that case, this step
+      # is still executed due to the "!(failure() || cancelled())" condition.
       - deploy
-    if: ${{ needs.define-variables.outputs.prod == 'true' }}
+    if: >-
+      ${{
+        (needs.define-variables.outputs.prod == 'true')
+        && !(failure() || cancelled())
+      }}
     steps:
       - name: Checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,6 +32,11 @@ on:
           Only publish docs to the website, do not publish the plugin.
         default: false
         type: boolean
+      gcs-only:
+        description: |
+          Only publish the plugin to GCS, do not publish the plugin to the Grafana Plugin Catalog.
+        default: false
+        type: boolean
       run-playwright:
         description: Whether to run Playwright E2E tests.
         type: boolean
@@ -145,7 +150,7 @@ jobs:
 
   deploy:
     name: Deploy to ${{ matrix.environment }}
-    if: ${{ !inputs.docs-only }}
+    if: ${{ !inputs.docs-only && !inputs.gcs-only }}
     needs:
       - define-variables
       - ci


### PR DESCRIPTION
Adds `gcs-only` input to `cd.yml`, which should be set if the plugin is provisioned via `deployment_tools` rather than the Grafana catalog.