### PR TITLE
Playwright: Make artifacts upload opt-in

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,6 +42,14 @@ on:
         type: boolean
         required: false
         default: true
+      upload-playwright-artifacts:
+        description: |
+          If true, the Playwright E2E artifacts will be uploaded to GitHub.
+          Default is false.
+          IMPORTANT: Make sure there are no unmasked secrets in the E2E tests before turning this on.
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: cd-${{ github.head_ref || github.run_id }}
@@ -100,6 +108,7 @@ jobs:
     with:
       branch: ${{ github.event.inputs.branch }}
       run-playwright: ${{ github.event.inputs.run-playwright == true }}
+      upload-playwright-artifacts: ${{ github.event.inputs.upload-playwright-artifacts == true }}
       plugin-version-suffix: >-
         ${{
           github.event.inputs.branch != 'main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,7 +257,7 @@ jobs:
 
   playwright:
     name: Playwright E2E tests
-    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@main
+    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@giuseppe/playwright-opt-in
     if: ${{ inputs.run-playwright == true }}
     needs:
       - test-and-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,13 +31,13 @@ on:
         type: boolean
         required: false
         default: true
-      # https://github.com/grafana/plugin-actions/blob/main/e2e-version/action.yml        
+      # https://github.com/grafana/plugin-actions/blob/main/e2e-version/action.yml
       run-playwright-with-grafana-dependency:
-        description: 'Optionally, use this input to pass a semver range of supported Grafana versions to test against. This is only used when version-resolver-type is plugin-grafana-dependency. If not provided, the action will try to read grafanaDependency from the plugin.json file.'
+        description: "Optionally, use this input to pass a semver range of supported Grafana versions to test against. This is only used when version-resolver-type is plugin-grafana-dependency. If not provided, the action will try to read grafanaDependency from the plugin.json file."
         type: string
         required: false
       run-playwright-with-skip-grafana-dev-image:
-        description: 'Optionally, you can skip the Grafana dev image'
+        description: "Optionally, you can skip the Grafana dev image"
         type: boolean
         required: false
         default: false
@@ -46,6 +46,14 @@ on:
         type: string
         required: false
         default: plugin-grafana-dependency
+      upload-playwright-artifacts:
+        description: |
+          If true, the Playwright E2E artifacts will be uploaded to GitHub.
+          Default is false.
+          IMPORTANT: Make sure there are no unmasked secrets in the E2E tests before turning this on.
+        required: false
+        type: boolean
+        default: false
       go-version:
         description: Go version to use
         type: string
@@ -268,6 +276,7 @@ jobs:
       grafana-dependency: ${{ inputs.run-playwright-with-grafana-dependency }}
       skip-grafana-dev-image: ${{ inputs.run-playwright-with-skip-grafana-dev-image }}
       version-resolver-type: ${{ inputs.run-playwright-with-version-resolver-type }}
+      upload-artifacts: ${{ inputs.upload-playwright-artifacts }}
 
   upload-to-gcs:
     name: Upload to GCS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,7 @@ jobs:
 
   playwright:
     name: Playwright E2E tests
-    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@giuseppe/playwright-opt-in
+    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@main
     if: ${{ inputs.run-playwright == true }}
     needs:
       - test-and-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,11 @@ on:
         default: true
       # https://github.com/grafana/plugin-actions/blob/main/e2e-version/action.yml
       run-playwright-with-grafana-dependency:
-        description: "Optionally, use this input to pass a semver range of supported Grafana versions to test against. This is only used when version-resolver-type is plugin-grafana-dependency. If not provided, the action will try to read grafanaDependency from the plugin.json file."
+        description: 'Optionally, use this input to pass a semver range of supported Grafana versions to test against. This is only used when version-resolver-type is plugin-grafana-dependency. If not provided, the action will try to read grafanaDependency from the plugin.json file.'
         type: string
         required: false
       run-playwright-with-skip-grafana-dev-image:
-        description: "Optionally, you can skip the Grafana dev image"
+        description: 'Optionally, you can skip the Grafana dev image'
         type: boolean
         required: false
         default: false

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Upload artifacts
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        if: ${{ (inputs.upload-artifacts) && ((always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure')) }}
+        if: ${{ (inputs.upload-artifacts == true) && ((always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure')) }}
         with:
           name: playwright-report-${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}
           path: playwright-report/

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -14,7 +14,7 @@ on:
         description: Plugin version
         type: string
         required: true
-      # https://github.com/grafana/plugin-actions/blob/main/e2e-version/action.yml        
+      # https://github.com/grafana/plugin-actions/blob/main/e2e-version/action.yml
       skip-grafana-dev-image:
         default: false
         required: false
@@ -26,6 +26,14 @@ on:
       grafana-dependency:
         required: false
         type: string
+      upload-artifacts:
+        description: |
+          If true, the E2E will be uploaded to GitHub.
+          Default is false.
+          IMPORTANT: Make sure there are no unmasked secrets in the E2E tests before turning this on.
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -44,7 +52,7 @@ jobs:
 
       - name: Resolve Grafana E2E versions
         id: resolve-versions
-        uses: grafana/plugin-actions/e2e-version@main        
+        uses: grafana/plugin-actions/e2e-version@main
         with:
           skip-grafana-dev-image: ${{ inputs.skip-grafana-dev-image }}
           version-resolver-type: ${{ inputs.version-resolver-type }}
@@ -113,7 +121,7 @@ jobs:
 
       - name: Upload artifacts
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        if: ${{ (always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure') }}
+        if: ${{ (inputs.upload-artifacts) && ((always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure')) }}
         with:
           name: playwright-report-${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}
           path: playwright-report/

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -27,10 +27,6 @@ on:
         required: false
         type: string
       upload-artifacts:
-        description: |
-          If true, the E2E will be uploaded to GitHub.
-          Default is false.
-          IMPORTANT: Make sure there are no unmasked secrets in the E2E tests before turning this on.
         required: false
         type: boolean
         default: false


### PR DESCRIPTION
Makes the Playwright artifacts upload opt-in and disabled by default.

Example run with artifacts: https://github.com/grafana/clock-panel/actions/runs/12086765029
Example run without artifacts: https://github.com/grafana/clock-panel/actions/runs/12086660665