### PR TITLE
Reduce some error noise related to gcloudignore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,6 +331,7 @@ jobs:
           path: /tmp/dist-artifacts
           destination: ${{ env.gcs_artifacts_path_latest }}
           parent: false
+          process_gcloudignore: false
 
       - name: Upload GCS artifacts (commit)
         id: gcs-upload-commit
@@ -339,6 +340,7 @@ jobs:
           path: /tmp/dist-artifacts
           destination: ${{ env.gcs_artifacts_path_commit }}
           parent: false
+          process_gcloudignore: false
 
       - name: Define outputs
         id: outputs


### PR DESCRIPTION
Remove warning like these:

<img width="1534" alt="SCR-20241202-kodm" src="https://github.com/user-attachments/assets/c55bdcbc-5636-4dc4-8a21-a000c3fcc035">

Example: https://github.com/grafana/clock-panel/actions/runs/12117392719

If we want to introduce support for the ignore files we should do it properly and make it easy to pass them through.