### PR TITLE
Keeping actions up to date automatically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "monthly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,5 +6,4 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every week
       interval: "monthly"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -273,7 +273,7 @@ jobs:
         - /home/runner/work/_actions:/home/runner/work/_actions
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2 # v4.2.2
+        uses: actions/checkout@v4.2.2
         with:
           ref: ${{ inputs.branch }}
 
@@ -288,7 +288,7 @@ jobs:
 
       - name: Generate GitHub token
         id: generate-github-token
-        uses: actions/create-github-app-token@v1.11.0 # v1.11.0
+        uses: actions/create-github-app-token@v1.11.0
         with:
           app-id: ${{ env.GITHUB_APP_ID }}
           private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
@@ -318,12 +318,12 @@ jobs:
       }}
     steps:
       - name: Checkout
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@v4.2.2
         with:
           ref: ${{ inputs.branch }}
 
       - name: Download GitHub artifact
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: actions/download-artifact@v4.1.8
         with:
           name: dist-artifacts
           path: /tmp/dist-artifacts
@@ -340,7 +340,7 @@ jobs:
         shell: bash
 
       - name: Create tag
-        uses: actions/github-script@v7.0.1 # v7.0.1
+        uses: actions/github-script@v7.0.1
         with:
           script: |
             github.rest.git.createRef({
@@ -351,7 +351,7 @@ jobs:
             })
 
       - name: Create Github release
-        uses: softprops/action-gh-release@v2.1.0 # v2.1.0
+        uses: softprops/action-gh-release@v2.1.0
         with:
           draft: true
           name: ${{ fromJSON(needs.ci.outputs.plugin).id }} v${{ fromJSON(needs.ci.outputs.plugin).version }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -107,7 +107,7 @@ jobs:
         shell: bash
 
       - name: Checkout specified branch
-        uses: actions/checkout@v4.2.2 # v4.2.2
+        uses: actions/checkout@v4.2.2
         with:
           ref: ${{ inputs.branch }}
 
@@ -189,13 +189,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2 # v4.2.2
+        uses: actions/checkout@v4.2.2
         with:
           ref: ${{ inputs.branch }}
 
       - name: Login to Google Cloud (ID token for IAP)
         id: gcloud
-        uses: google-github-actions/auth@v2.1.7 # v2.1.7
+        uses: google-github-actions/auth@v2.1.7
         if: ${{ matrix.environment != 'prod' }}
         with:
           workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -107,7 +107,7 @@ jobs:
         shell: bash
 
       - name: Checkout specified branch
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@v4.2.2 # v4.2.2
         with:
           ref: ${{ inputs.branch }}
 
@@ -189,13 +189,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@v4.2.2 # v4.2.2
         with:
           ref: ${{ inputs.branch }}
 
       - name: Login to Google Cloud (ID token for IAP)
         id: gcloud
-        uses: google-github-actions/auth@8254fb75a33b976a221574d287e93919e6a36f70 # v2.1.6
+        uses: google-github-actions/auth@v2.1.7 # v2.1.7
         if: ${{ matrix.environment != 'prod' }}
         with:
           workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
@@ -273,7 +273,7 @@ jobs:
         - /home/runner/work/_actions:/home/runner/work/_actions
     steps:
       - name: Checkout
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@v4.2.2 # v4.2.2
         with:
           ref: ${{ inputs.branch }}
 
@@ -288,7 +288,7 @@ jobs:
 
       - name: Generate GitHub token
         id: generate-github-token
-        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        uses: actions/create-github-app-token@v1.11.0 # v1.11.0
         with:
           app-id: ${{ env.GITHUB_APP_ID }}
           private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
@@ -340,7 +340,7 @@ jobs:
         shell: bash
 
       - name: Create tag
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@v7.0.1 # v7.0.1
         with:
           script: |
             github.rest.git.createRef({
@@ -351,7 +351,7 @@ jobs:
             })
 
       - name: Create Github release
-        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
+        uses: softprops/action-gh-release@v2.1.0 # v2.1.0
         with:
           draft: true
           name: ${{ fromJSON(needs.ci.outputs.plugin).id }} v${{ fromJSON(needs.ci.outputs.plugin).version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@v4.2.2 # v4.2.2
         with:
           ref: ${{ inputs.branch }}
 
@@ -226,7 +226,7 @@ jobs:
         shell: bash
 
       - name: Upload GitHub artifacts
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@v4.4.3 # v4.4.3
         with:
           name: dist-artifacts
           path: dist-artifacts/
@@ -248,7 +248,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@v4.2.2 # v4.2.2
         with:
           ref: ${{ inputs.branch }}
 
@@ -326,7 +326,7 @@ jobs:
             (github.event_name == 'push')
             && (github.ref == 'refs/heads/main')
           }}
-        uses: google-github-actions/upload-cloud-storage@e485962f2bef914ac9c3bdd571f821f0ba7946c4 # v2.2.0
+        uses: google-github-actions/upload-cloud-storage@v2.2.1 # v2.2.1
         with:
           path: /tmp/dist-artifacts
           destination: ${{ env.gcs_artifacts_path_latest }}
@@ -334,7 +334,7 @@ jobs:
 
       - name: Upload GCS artifacts (commit)
         id: gcs-upload-commit
-        uses: google-github-actions/upload-cloud-storage@e485962f2bef914ac9c3bdd571f821f0ba7946c4 # v2.2.0
+        uses: google-github-actions/upload-cloud-storage@v2.2.1 # v2.2.1
         with:
           path: /tmp/dist-artifacts
           destination: ${{ env.gcs_artifacts_path_commit }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2 # v4.2.2
+        uses: actions/checkout@v4.2.2
         with:
           ref: ${{ inputs.branch }}
 
@@ -226,7 +226,7 @@ jobs:
         shell: bash
 
       - name: Upload GitHub artifacts
-        uses: actions/upload-artifact@v4.4.3 # v4.4.3
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: dist-artifacts
           path: dist-artifacts/
@@ -248,7 +248,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2 # v4.2.2
+        uses: actions/checkout@v4.2.2
         with:
           ref: ${{ inputs.branch }}
 
@@ -298,13 +298,13 @@ jobs:
 
     steps:
       - name: Download GitHub artifact
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: actions/download-artifact@v4.1.8
         with:
           name: dist-artifacts
           path: /tmp/dist-artifacts
 
       - name: Login to Google Cloud
-        uses: google-github-actions/auth@8254fb75a33b976a221574d287e93919e6a36f70 # v2.1.6
+        uses: google-github-actions/auth@v2.1.7
         with:
           workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
           service_account: github-plugin-ci-workflows@grafanalabs-workload-identity.iam.gserviceaccount.com
@@ -326,7 +326,7 @@ jobs:
             (github.event_name == 'push')
             && (github.ref == 'refs/heads/main')
           }}
-        uses: google-github-actions/upload-cloud-storage@v2.2.1 # v2.2.1
+        uses: google-github-actions/upload-cloud-storage@v2.2.1
         with:
           path: /tmp/dist-artifacts
           destination: ${{ env.gcs_artifacts_path_latest }}
@@ -334,7 +334,7 @@ jobs:
 
       - name: Upload GCS artifacts (commit)
         id: gcs-upload-commit
-        uses: google-github-actions/upload-cloud-storage@v2.2.1 # v2.2.1
+        uses: google-github-actions/upload-cloud-storage@v2.2.1
         with:
           path: /tmp/dist-artifacts
           destination: ${{ env.gcs_artifacts_path_commit }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -64,10 +64,10 @@ jobs:
     name: e2e ${{ matrix.GRAFANA_IMAGE.name }}@${{ matrix.GRAFANA_IMAGE.VERSION }}
     runs-on: ubuntu-latest-8-cores
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - uses: actions/checkout@v4.2.2
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
+        uses: actions/setup-node@v4.1.0
         with:
           node-version-file: .nvmrc
 
@@ -85,7 +85,7 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Download GitHub artifact
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: actions/download-artifact@v4.1.8
         with:
           name: dist-artifacts
           path: /tmp/dist-artifacts
@@ -116,7 +116,7 @@ jobs:
         run: npx playwright test
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4.4.3 # v4.4.3
+        uses: actions/upload-artifact@v4.4.3
         if: ${{ (inputs.upload-artifacts == true) && ((always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure')) }}
         with:
           name: playwright-report-${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -116,7 +116,7 @@ jobs:
         run: npx playwright test
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@v4.4.3 # v4.4.3
         if: ${{ (inputs.upload-artifacts == true) && ((always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure')) }}
         with:
           name: playwright-report-${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -44,7 +44,7 @@ jobs:
       matrix: ${{ steps.resolve-versions.outputs.matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@v4.2.2
 
       - name: Resolve Grafana E2E versions
         id: resolve-versions

--- a/actions/plugins/setup/action.yml
+++ b/actions/plugins/setup/action.yml
@@ -16,12 +16,12 @@ runs:
   using: composite
   steps:
     - name: Node
-      uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
+      uses: actions/setup-node@v4.1.0
       with:
         node-version: "${{ inputs.node-version }}"
 
     - name: Go
-      uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+      uses: actions/setup-go@v5.1.0
       with:
         go-version: "${{ inputs.go-version }}"
 


### PR DESCRIPTION
- moving to pin-by-tag instead. Most of the actions are coming from github anyway.
- adding dependabot action to keep the actions up to date