### PR TITLE
Publish: Add support for scopes, add --dry-run to publish script

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -288,9 +288,9 @@ jobs:
           vault_instance: ${{ env.VAULT_INSTANCE }}
           # common_secrets: |
           repo_secrets: |
-            GCOM_PUBLISH_TOKEN_DEV=plugins/gcom-publish-token:dev
-            GCOM_PUBLISH_TOKEN_OPS=plugins/gcom-publish-token:ops
-            GCOM_PUBLISH_TOKEN_PROD=plugins/gcom-publish-token:prod
+            GCOM_PUBLISH_TOKEN_DEV=gcom-publish-token:dev
+            GCOM_PUBLISH_TOKEN_OPS=gcom-publish-token:ops
+            GCOM_PUBLISH_TOKEN_PROD=gcom-publish-token:prod
 
       - name: Determine which token to use
         run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -289,7 +289,7 @@ jobs:
           gcloud-auth-token: ${{ steps.gcloud.outputs.id_token }}
 
       - name: Publish to catalog
-        uses: grafana/plugin-ci-workflows/actions/plugins/publish/publish@giuseppe/publish-scope
+        uses: grafana/plugin-ci-workflows/actions/plugins/publish/publish@main
         with:
           zips: ${{ needs.ci.outputs.gcs-zip-urls-commit }}
           environment: ${{ matrix.environment }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,10 +30,10 @@ on:
         type: string
       scopes:
         description: |
-          Array of scopes for the plugin version.
-          Default is ["universal"].
+          Comma-separated list of scopes for the plugin version.
+          Default is 'universal'.
         required: false
-        default: '["universal"]'
+        default: universal
         type: string
       docs-only:
         description: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -136,7 +136,7 @@ permissions:
   id-token: write
 
 env:
-  VAULT_INSTANCE: ops
+  VAULT_INSTANCE: dev
 
 jobs:
   setup:
@@ -286,7 +286,8 @@ jobs:
         uses: grafana/shared-workflows/actions/get-vault-secrets@main
         with:
           vault_instance: ${{ env.VAULT_INSTANCE }}
-          common_secrets: |
+          # common_secrets: |
+          repo_secrets: |
             GCOM_PUBLISH_TOKEN_DEV=plugins/gcom-publish-token:dev
             GCOM_PUBLISH_TOKEN_OPS=plugins/gcom-publish-token:ops
             GCOM_PUBLISH_TOKEN_PROD=plugins/gcom-publish-token:prod

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -289,7 +289,7 @@ jobs:
           gcloud-auth-token: ${{ steps.gcloud.outputs.id_token }}
 
       - name: Publish to catalog
-        uses: grafana/plugin-ci-workflows/actions/plugins/publish/publish@main
+        uses: grafana/plugin-ci-workflows/actions/plugins/publish/publish@giuseppe/publish-scope
         with:
           zips: ${{ needs.ci.outputs.gcs-zip-urls-commit }}
           environment: ${{ matrix.environment }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -319,7 +319,7 @@ jobs:
           gcloud-auth-token: ${{ steps.gcloud.outputs.id_token }}
 
       - name: Publish to catalog
-        uses: grafana/plugin-ci-workflows/actions/plugins/publish/publish@giuseppe/publish-scope
+        uses: grafana/plugin-ci-workflows/actions/plugins/publish/publish@main
         with:
           zips: ${{ needs.ci.outputs.gcs-zip-urls-commit }}
           environment: ${{ matrix.environment }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -319,7 +319,7 @@ jobs:
           gcloud-auth-token: ${{ steps.gcloud.outputs.id_token }}
 
       - name: Publish to catalog
-        uses: grafana/plugin-ci-workflows/actions/plugins/publish/publish@main
+        uses: grafana/plugin-ci-workflows/actions/plugins/publish/publish@giuseppe/publish-scope
         with:
           zips: ${{ needs.ci.outputs.gcs-zip-urls-commit }}
           environment: ${{ matrix.environment }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -136,7 +136,7 @@ permissions:
   id-token: write
 
 env:
-  VAULT_INSTANCE: dev
+  VAULT_INSTANCE: ops
 
 jobs:
   setup:
@@ -286,8 +286,7 @@ jobs:
         uses: grafana/shared-workflows/actions/get-vault-secrets@main
         with:
           vault_instance: ${{ env.VAULT_INSTANCE }}
-          # common_secrets: |
-          repo_secrets: |
+          common_secrets: |
             GCOM_PUBLISH_TOKEN_DEV=plugins/gcom-publish-token:dev
             GCOM_PUBLISH_TOKEN_OPS=plugins/gcom-publish-token:ops
             GCOM_PUBLISH_TOKEN_PROD=plugins/gcom-publish-token:prod

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -288,9 +288,9 @@ jobs:
           vault_instance: ${{ env.VAULT_INSTANCE }}
           # common_secrets: |
           repo_secrets: |
-            GCOM_PUBLISH_TOKEN_DEV=gcom-publish-token:dev
-            GCOM_PUBLISH_TOKEN_OPS=gcom-publish-token:ops
-            GCOM_PUBLISH_TOKEN_PROD=gcom-publish-token:prod
+            GCOM_PUBLISH_TOKEN_DEV=plugins/gcom-publish-token:dev
+            GCOM_PUBLISH_TOKEN_OPS=plugins/gcom-publish-token:ops
+            GCOM_PUBLISH_TOKEN_PROD=plugins/gcom-publish-token:prod
 
       - name: Determine which token to use
         run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,6 +28,13 @@ on:
           Docs will only be published to the website when targeting 'prod'.
         required: true
         type: string
+      scopes:
+        description: |
+          Array of scopes for the plugin version.
+          Default is ["universal"].
+        required: false
+        default: '["universal"]'
+        type: string
       docs-only:
         description: |
           Only publish docs to the website, do not publish the plugin.
@@ -111,7 +118,7 @@ jobs:
         id: checkout-specified-branch
         uses: actions/checkout@v4.2.2
         with:
-          ref: ${{ inputs.branch }}      
+          ref: ${{ inputs.branch }}
 
   ci:
     name: CI
@@ -256,6 +263,7 @@ jobs:
         with:
           zips: ${{ needs.ci.outputs.gcs-zip-urls-commit }}
           environment: ${{ matrix.environment }}
+          scopes: ${{ inputs.scopes }}
           gcom-publish-token: ${{ env.GCOM_PUBLISH_TOKEN }}
           gcloud-auth-token: ${{ steps.gcloud.outputs.id_token }}
 

--- a/actions/plugins/publish/publish/action.yml
+++ b/actions/plugins/publish/publish/action.yml
@@ -17,8 +17,11 @@ inputs:
     required: true
 
   scopes:
-    description: Comma-separated list of scopes for the plugin version.
-    required: true
+    description: |
+      Comma-separated list of scopes for the plugin version.
+      Defaults to 'universal'.
+    required: false
+    default: universal
 
   gcom-publish-token:
     description: GCOM token used to publish the plugin to the catalog.

--- a/actions/plugins/publish/publish/action.yml
+++ b/actions/plugins/publish/publish/action.yml
@@ -20,8 +20,7 @@ inputs:
     description: |
       Array of scopes for the plugin version.
       Default is ["universal"].
-    required: false
-    default: '["universal"]'
+    required: true
 
   gcom-publish-token:
     description: GCOM token used to publish the plugin to the catalog.

--- a/actions/plugins/publish/publish/action.yml
+++ b/actions/plugins/publish/publish/action.yml
@@ -17,9 +17,7 @@ inputs:
     required: true
 
   scopes:
-    description: |
-      Array of scopes for the plugin version.
-      Default is ["universal"].
+    description: Comma-separated list of scopes for the plugin version.
     required: true
 
   gcom-publish-token:

--- a/actions/plugins/publish/publish/action.yml
+++ b/actions/plugins/publish/publish/action.yml
@@ -16,6 +16,13 @@ inputs:
       Can be 'dev', 'ops', or 'prod'.
     required: true
 
+  scopes:
+    description: |
+      Array of scopes for the plugin version.
+      Default is ["universal"].
+    required: false
+    default: '["universal"]'
+
   gcom-publish-token:
     description: GCOM token used to publish the plugin to the catalog.
     required: true
@@ -42,5 +49,6 @@ runs:
 
         ${{ github.action_path }}/publish.sh \
           --environment "${{ inputs.environment }}" \
+          --scopes '${{ inputs.scopes }}' \
           "${files[@]}"
       shell: bash

--- a/actions/plugins/publish/publish/publish.sh
+++ b/actions/plugins/publish/publish/publish.sh
@@ -2,7 +2,7 @@
 set -e
 
 usage() {
-    echo "Usage: $0 --environment <dev|ops|prod> [--scopes <scopes_json_array> --dry-run] <plugin_zip_urls...>"
+    echo "Usage: $0 --environment <dev|ops|prod> --scopes <scopes_json_array> [--dry-run] <plugin_zip_urls...>"
 }
 
 json_obj() {
@@ -10,7 +10,7 @@ json_obj() {
 }
 
 gcs_zip_urls=()
-scopes='["universal"]'
+scopes=''
 dry_run=false
 while [[ "$#" -gt 0 ]]; do
     case $1 in
@@ -42,6 +42,12 @@ fi
 
 if [ -z $gcom_env ]; then
     echo "Environment not provided"
+    usage
+    exit 1
+fi
+
+if [ -z $scopes ]; then
+    echo "Scopes not provided"
     usage
     exit 1
 fi

--- a/actions/plugins/publish/publish/publish.sh
+++ b/actions/plugins/publish/publish/publish.sh
@@ -2,7 +2,7 @@
 set -e
 
 usage() {
-    echo "Usage: $0 --environment <dev|ops|prod> --scopes <comma_separated_scopes> [--dry-run] <plugin_zip_urls...>"
+    echo "Usage: $0 --environment <dev|ops|prod> [--scopes <comma_separated_scopes>] [--dry-run] <plugin_zip_urls...>"
 }
 
 json_obj() {
@@ -47,9 +47,7 @@ if [ -z $gcom_env ]; then
 fi
 
 if [ -z $scopes ]; then
-    echo "Scopes not provided"
-    usage
-    exit 1
+    scopes='["universal"]'
 fi
 
 has_iap=false

--- a/actions/plugins/publish/publish/publish.sh
+++ b/actions/plugins/publish/publish/publish.sh
@@ -2,7 +2,7 @@
 set -e
 
 usage() {
-    echo "Usage: $0 --environment <dev|ops|prod> --scopes <scopes_json_array> [--dry-run] <plugin_zip_urls...>"
+    echo "Usage: $0 --environment <dev|ops|prod> --scopes <comma_separated_scopes> [--dry-run] <plugin_zip_urls...>"
 }
 
 json_obj() {
@@ -15,7 +15,7 @@ dry_run=false
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         --environment) gcom_env=$2; shift 2;;
-        --scopes) scopes=$2; shift 2;;
+        --scopes) scopes=$(echo $2 | jq -Rc 'split(",")'); shift 2;;
         --dry-run) dry_run=true; shift;;
         --help)
             usage


### PR DESCRIPTION
Adds support for plugin version publishing scopes when publishing plugins to the catalog.

Part of https://github.com/grafana/grafana-community-team/issues/220

Example run/payload:

```
GCLOUD_AUTH_TOKEN=abc GCOM_PUBLISH_TOKEN=abc ./publish/publish.sh --environment dev --scopes 'grafana_cloud,something' --dry-run "https://storage.googleapis.com/integration-artifacts/grafana-clock-panel/2.1.8/main/aa015b727d60e4dcf23345d3c4fb71a491a6df55/grafana-clock-panel-2.1.8.zip"
https://storage.googleapis.com/integration-artifacts/grafana-clock-panel/2.1.8/main/aa015b727d60e4dcf23345d3c4fb71a491a6df55/grafana-clock-panel-2.1.8.zip
Publishing to https://grafana-dev.com/api
{
  "download": {
    "any": {
      "url": "https://storage.googleapis.com/integration-artifacts/grafana-clock-panel/2.1.8/main/aa015b727d60e4dcf23345d3c4fb71a491a6df55/grafana-clock-panel-2.1.8.zip",
      "md5": "d7906b874a7c3199488a0ef98f53f9d3"
    }
  },
  "url": "/",
  "commit": "e4f12d42fb8d6d315941a4dffbd0d03b5331ae33",
  "scopes": [
    "grafana_cloud",
    "something"
  ]
}
```

Example run in GitHub Actions can be found here: https://github.com/grafana/plugins-drone-to-gha/actions/runs/12690464045/job/35371585801

During the step, plugin `grafana-scopestest-datasource` gets published with the `["grafana_cloud"]` scope to the dev catalog.