### PR TITLE
CI: Lint and typecheck frontend, run tests using test:ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,7 @@ jobs:
         shell: bash
 
       - name: Test and build frontend
-        uses: grafana/plugin-ci-workflows/actions/plugins/frontend@main
+        uses: grafana/plugin-ci-workflows/actions/plugins/frontend@giuseppe/frontend-lint-tsc
 
       - name: Test and build backend
         if: ${{ steps.check-for-backend.outputs.has-backend == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
         shell: bash
 
       - name: Test and build frontend
-        uses: grafana/plugin-ci-workflows/actions/plugins/frontend@giuseppe/frontend-lint-tsc
+        uses: grafana/plugin-ci-workflows/actions/plugins/frontend@main
 
       - name: Test and build backend
         if: ${{ steps.check-for-backend.outputs.has-backend == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
         shell: bash
 
       - name: Test and build frontend
-        uses: grafana/plugin-ci-workflows/actions/plugins/frontend@main
+        uses: ./actions/plugins/frontend@main
 
       - name: Test and build backend
         if: ${{ steps.check-for-backend.outputs.has-backend == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,7 @@ jobs:
         shell: bash
 
       - name: Test and build frontend
-        uses: grafana/plugin-ci-workflows/actions/plugins/frontend@giuseppe/frontend-lint-tsc
+        uses: grafana/plugin-ci-workflows/actions/plugins/frontend@main
 
       - name: Test and build backend
         if: ${{ steps.check-for-backend.outputs.has-backend == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
         shell: bash
 
       - name: Test and build frontend
-        uses: ./actions/plugins/frontend@main
+        uses: grafana/plugin-ci-workflows/actions/plugins/frontend@giuseppe/frontend-lint-tsc
 
       - name: Test and build backend
         if: ${{ steps.check-for-backend.outputs.has-backend == 'true' }}

--- a/actions/plugins/frontend/action.yml
+++ b/actions/plugins/frontend/action.yml
@@ -8,9 +8,17 @@ runs:
       shell: bash
       run: ${{ github.action_path }}/pm.sh install
 
+    - name: Lint
+      shell: bash
+      run: ${{ github.action_path }}/pm.sh lint
+
+    - name: Typecheck
+      shell: bash
+      run: ${{ github.action_path }}/pm.sh typecheck
+
     - name: Test
       shell: bash
-      run: ./node_modules/.bin/jest --passWithNoTests --maxWorkers 4
+      run: ${{ github.action_path }}/pm.sh test:ci
 
     - name: Build
       shell: bash

--- a/actions/plugins/frontend/action.yml
+++ b/actions/plugins/frontend/action.yml
@@ -1,5 +1,5 @@
 name: Plugins - Frontend - Test and build
-description: Runs unit tests and builds the frontend
+description: Tests, lints, typechecks and builds the frontend.
 
 runs:
   using: composite


### PR DESCRIPTION
Adds some frontend checks to the build and lint action, which were not present in Drone:

- Runs `npm run typecheck` and `npm run lint` when building the plugin.
- Changes the command used to run tests with `npm run test:ci`

Fixes #9 