### PR TITLE
CI: Add Trufflehog secrets scanning for packaged plugin ZIP files

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -66,6 +66,16 @@ on:
         required: false
         type: boolean
         default: false
+      run-trufflehog:
+        description: Whether to run Trufflehog secrets scanning.
+        type: boolean
+        required: false
+        default: true
+      trufflehog-version:
+        description: Trufflehog version to use
+        type: string
+        required: false
+        default: "3.88.1"
       trufflehog-include-detectors:
         description: |
           Comma-separated list of detector types to include.
@@ -141,6 +151,8 @@ jobs:
       run-playwright-with-skip-grafana-dev-image: ${{ inputs.run-playwright-with-skip-grafana-dev-image }}
       run-playwright-with-version-resolver-type: ${{ inputs.run-playwright-with-version-resolver-type }}
       upload-playwright-artifacts: ${{ github.event.inputs.upload-playwright-artifacts == true }}
+      run-trufflehog: ${{ github.event.inputs.run-trufflehog == true }}
+      trufflehog-version: ${{ inputs.trufflehog-version }}
       trufflehog-include-detectors: ${{ inputs.trufflehog-include-detectors }}
       trufflehog-exclude-detectors: ${{ inputs.trufflehog-exclude-detectors }}
       plugin-version-suffix: >-

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -66,7 +66,23 @@ on:
         required: false
         type: boolean
         default: false
-
+      trufflehog-include-detectors:
+        description: |
+          Comma-separated list of detector types to include.
+          Protobuf name or IDs may be used, as well as ranges.
+          This value will be passed via the `--include-detectors` option to Trufflehog.
+          If not provided, the flag is not passed.
+        type: string
+        required: false
+      trufflehog-exclude-detectors:
+        description: |
+          Comma-separated list of detector types to exclude.
+          Protobuf name or IDs may be used, as well as ranges.
+          IDs defined here take precedence over the include list.
+          This value will be passed via the `--exclude-detectors` option to Trufflehog.
+          If not provided, the flag is not passed.
+        type: string
+        required: false
 concurrency:
   group: cd-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -111,7 +127,7 @@ jobs:
         id: checkout-specified-branch
         uses: actions/checkout@v4.2.2
         with:
-          ref: ${{ inputs.branch }}      
+          ref: ${{ inputs.branch }}
 
   ci:
     name: CI
@@ -125,6 +141,8 @@ jobs:
       run-playwright-with-skip-grafana-dev-image: ${{ inputs.run-playwright-with-skip-grafana-dev-image }}
       run-playwright-with-version-resolver-type: ${{ inputs.run-playwright-with-version-resolver-type }}
       upload-playwright-artifacts: ${{ github.event.inputs.upload-playwright-artifacts == true }}
+      trufflehog-include-detectors: ${{ inputs.trufflehog-include-detectors }}
+      trufflehog-exclude-detectors: ${{ inputs.trufflehog-exclude-detectors }}
       plugin-version-suffix: >-
         ${{
           github.event.inputs.branch != 'main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
           ref: ${{ inputs.branch }}
 
       - name: Setup
-        uses: grafana/plugin-ci-workflows/actions/plugins/setup@giuseppe/trufflehog
+        uses: grafana/plugin-ci-workflows/actions/plugins/setup@main
         with:
           go-version: ${{ inputs.go-version }}
           node-version: ${{ inputs.node-version }}
@@ -184,17 +184,17 @@ jobs:
         shell: bash
 
       - name: Test and build frontend
-        uses: grafana/plugin-ci-workflows/actions/plugins/frontend@giuseppe/trufflehog
+        uses: grafana/plugin-ci-workflows/actions/plugins/frontend@main
 
       - name: Test and build backend
         if: ${{ steps.check-for-backend.outputs.has-backend == 'true' }}
-        uses: grafana/plugin-ci-workflows/actions/plugins/backend@giuseppe/trufflehog
+        uses: grafana/plugin-ci-workflows/actions/plugins/backend@main
 
       # TODO: security scan?
 
       - name: Package universal ZIP
         id: universal-zip
-        uses: grafana/plugin-ci-workflows/actions/plugins/package@giuseppe/trufflehog
+        uses: grafana/plugin-ci-workflows/actions/plugins/package@main
         with:
           universal: "true"
           dist-folder: dist
@@ -203,7 +203,7 @@ jobs:
 
       - name: Package os/arch ZIPs
         id: os-arch-zips
-        uses: grafana/plugin-ci-workflows/actions/plugins/package@giuseppe/trufflehog
+        uses: grafana/plugin-ci-workflows/actions/plugins/package@main
         with:
           universal: "false"
           dist-folder: dist
@@ -212,7 +212,7 @@ jobs:
 
       - name: Trufflehog secrets scanning
         if: ${{ inputs.run-trufflehog == true }}
-        uses: grafana/plugin-ci-workflows/actions/plugins/trufflehog@giuseppe/trufflehog
+        uses: grafana/plugin-ci-workflows/actions/plugins/trufflehog@main
         with:
           folder: dist-artifacts
 
@@ -274,11 +274,11 @@ jobs:
         shell: bash
 
       - name: Test docs
-        uses: grafana/plugin-ci-workflows/actions/plugins/docs/test@giuseppe/trufflehog
+        uses: grafana/plugin-ci-workflows/actions/plugins/docs/test@main
 
   playwright:
     name: Playwright E2E tests
-    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@giuseppe/trufflehog
+    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@main
     if: ${{ inputs.run-playwright == true }}
     needs:
       - test-and-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,11 @@ on:
         type: string
         required: false
         default: "1.61.0"
+      trufflehog-version:
+        description: Trufflehog version to use
+        type: string
+        required: false
+        default: "3.88.1"
     outputs:
       plugin:
         description: |
@@ -214,6 +219,7 @@ jobs:
         if: ${{ inputs.run-trufflehog == true }}
         uses: grafana/plugin-ci-workflows/actions/plugins/trufflehog@main
         with:
+          trufflehog-version: ${{ inputs.trufflehog-version }}
           folder: dist-artifacts
 
       - name: Define outputs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
           ref: ${{ inputs.branch }}
 
       - name: Setup
-        uses: grafana/plugin-ci-workflows/actions/plugins/setup@main
+        uses: grafana/plugin-ci-workflows/actions/plugins/setup@giuseppe/trufflehog
         with:
           go-version: ${{ inputs.go-version }}
           node-version: ${{ inputs.node-version }}
@@ -156,7 +156,7 @@ jobs:
 
       - name: Get secrets from Vault
         id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@giuseppe/trufflehog
         with:
           vault_instance: ${{ env.VAULT_INSTANCE }}
           common_secrets: |
@@ -190,17 +190,17 @@ jobs:
         shell: bash
 
       - name: Test and build frontend
-        uses: grafana/plugin-ci-workflows/actions/plugins/frontend@main
+        uses: grafana/plugin-ci-workflows/actions/plugins/frontend@giuseppe/trufflehog
 
       - name: Test and build backend
         if: ${{ steps.check-for-backend.outputs.has-backend == 'true' }}
-        uses: grafana/plugin-ci-workflows/actions/plugins/backend@main
+        uses: grafana/plugin-ci-workflows/actions/plugins/backend@giuseppe/trufflehog
 
       # TODO: security scan?
 
       - name: Package universal ZIP
         id: universal-zip
-        uses: grafana/plugin-ci-workflows/actions/plugins/package@main
+        uses: grafana/plugin-ci-workflows/actions/plugins/package@giuseppe/trufflehog
         with:
           universal: "true"
           dist-folder: dist
@@ -209,7 +209,7 @@ jobs:
 
       - name: Package os/arch ZIPs
         id: os-arch-zips
-        uses: grafana/plugin-ci-workflows/actions/plugins/package@main
+        uses: grafana/plugin-ci-workflows/actions/plugins/package@giuseppe/trufflehog
         with:
           universal: "false"
           dist-folder: dist
@@ -218,7 +218,7 @@ jobs:
 
       - name: Trufflehog secrets scanning
         if: ${{ inputs.run-trufflehog == true }}
-        uses: grafana/plugin-ci-workflows/actions/plugins/trufflehog@main
+        uses: grafana/plugin-ci-workflows/actions/plugins/trufflehog@giuseppe/trufflehog
         with:
           folder: dist-artifacts
 
@@ -281,11 +281,11 @@ jobs:
         shell: bash
 
       - name: Test docs
-        uses: grafana/plugin-ci-workflows/actions/plugins/docs/test@main
+        uses: grafana/plugin-ci-workflows/actions/plugins/docs/test@giuseppe/trufflehog
 
   playwright:
     name: Playwright E2E tests
-    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@main
+    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@giuseppe/trufflehog
     if: ${{ inputs.run-playwright == true }}
     needs:
       - test-and-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,28 @@ on:
         type: boolean
         required: false
         default: true
+      trufflehog-version:
+        description: Trufflehog version to use
+        type: string
+        required: false
+        default: "3.88.1"
+      trufflehog-include-detectors:
+        description: |
+          Comma-separated list of detector types to include.
+          Protobuf name or IDs may be used, as well as ranges.
+          This value will be passed via the `--include-detectors` option to Trufflehog.
+          If not provided, the flag is not passed.
+        type: string
+        required: false
+      trufflehog-exclude-detectors:
+        description: |
+          Comma-separated list of detector types to exclude.
+          Protobuf name or IDs may be used, as well as ranges.
+          IDs defined here take precedence over the include list.
+          This value will be passed via the `--exclude-detectors` option to Trufflehog.
+          If not provided, the flag is not passed.
+        type: string
+        required: false
       run-playwright:
         description: Whether to run Playwright E2E tests.
         type: boolean
@@ -75,11 +97,6 @@ on:
         type: string
         required: false
         default: "1.61.0"
-      trufflehog-version:
-        description: Trufflehog version to use
-        type: string
-        required: false
-        default: "3.88.1"
     outputs:
       plugin:
         description: |
@@ -195,8 +212,6 @@ jobs:
         if: ${{ steps.check-for-backend.outputs.has-backend == 'true' }}
         uses: grafana/plugin-ci-workflows/actions/plugins/backend@main
 
-      # TODO: security scan?
-
       - name: Package universal ZIP
         id: universal-zip
         uses: grafana/plugin-ci-workflows/actions/plugins/package@main
@@ -221,6 +236,8 @@ jobs:
         with:
           trufflehog-version: ${{ inputs.trufflehog-version }}
           folder: dist-artifacts
+          include-detectors: ${{ inputs.trufflehog-include-detectors }}
+          exclude-detectors: ${{ inputs.trufflehog-exclude-detectors }}
 
       - name: Define outputs
         id: outputs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,7 @@ jobs:
 
       - name: Trufflehog secrets scanning
         if: ${{ inputs.run-trufflehog == true }}
-        uses: grafana/plugin-ci-workflows/actions/plugins/trufflehog@giuseppe/trufflehog
+        uses: grafana/plugin-ci-workflows/actions/plugins/trufflehog@main
         with:
           trufflehog-version: ${{ inputs.trufflehog-version }}
           folder: dist-artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,11 @@ on:
         type: string
         required: false
         default: ${{ github.head_ref || github.ref_name }}
+      run-trufflehog:
+        description: Whether to run Trufflehog secrets scanning.
+        type: boolean
+        required: false
+        default: true
       run-playwright:
         description: Whether to run Playwright E2E tests.
         type: boolean
@@ -70,6 +75,11 @@ on:
         type: string
         required: false
         default: "1.61.0"
+      trufflehog-version:
+        description: Trufflehog version to use
+        type: string
+        required: false
+        default: "3.87.2"
     outputs:
       plugin:
         description: |
@@ -142,6 +152,7 @@ jobs:
           go-version: ${{ inputs.go-version }}
           node-version: ${{ inputs.node-version }}
           golangci-lint-version: ${{ inputs.golangci-lint-version }}
+          trufflehog-version: ${{ inputs.trufflehog-version }}
 
       - name: Get secrets from Vault
         id: get-secrets
@@ -205,9 +216,15 @@ jobs:
           output-folder: dist-artifacts
           access-policy-token: ${{ env.SIGN_PLUGIN_ACCESS_POLICY_TOKEN }}
 
+      - name: Trufflehog secrets scanning
+        if: ${{ inputs.run-trufflehog == true }}
+        uses: grafana/plugin-ci-workflows/actions/plugins/trufflehog@main
+        with:
+          folder: dist-artifacts
+
       - name: Define outputs
         id: outputs
-        run: |          
+        run: |
           {
             echo plugin="$(jq -n -c \
                 --arg id "$(jq -r .id dist/plugin.json)" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
 
       - name: Get secrets from Vault
         id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@giuseppe/trufflehog
+        uses: grafana/shared-workflows/actions/get-vault-secrets@main
         with:
           vault_instance: ${{ env.VAULT_INSTANCE }}
           common_secrets: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,7 @@ jobs:
           cat "$GITHUB_OUTPUT"
         shell: bash
 
+      # TODO: Block upload if secrets are found
       - name: Upload GitHub artifacts
         uses: actions/upload-artifact@v4.4.3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,6 @@ jobs:
           cat "$GITHUB_OUTPUT"
         shell: bash
 
-      # TODO: Block upload if secrets are found
       - name: Upload GitHub artifacts
         uses: actions/upload-artifact@v4.4.3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,7 @@ jobs:
 
       - name: Trufflehog secrets scanning
         if: ${{ inputs.run-trufflehog == true }}
-        uses: grafana/plugin-ci-workflows/actions/plugins/trufflehog@main
+        uses: grafana/plugin-ci-workflows/actions/plugins/trufflehog@giuseppe/trufflehog
         with:
           trufflehog-version: ${{ inputs.trufflehog-version }}
           folder: dist-artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ on:
         description: Trufflehog version to use
         type: string
         required: false
-        default: "3.87.2"
+        default: "v3.87.2"
     outputs:
       plugin:
         description: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,7 @@ jobs:
           go-version: ${{ inputs.go-version }}
           node-version: ${{ inputs.node-version }}
           golangci-lint-version: ${{ inputs.golangci-lint-version }}
+          # TODO: do not set up trufflehog if not needed
           trufflehog-version: ${{ inputs.trufflehog-version }}
 
       - name: Get secrets from Vault

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,11 +75,6 @@ on:
         type: string
         required: false
         default: "1.61.0"
-      trufflehog-version:
-        description: Trufflehog version to use
-        type: string
-        required: false
-        default: "v3.87.2"
     outputs:
       plugin:
         description: |
@@ -152,8 +147,6 @@ jobs:
           go-version: ${{ inputs.go-version }}
           node-version: ${{ inputs.node-version }}
           golangci-lint-version: ${{ inputs.golangci-lint-version }}
-          # TODO: do not set up trufflehog if not needed
-          trufflehog-version: ${{ inputs.trufflehog-version }}
 
       - name: Get secrets from Vault
         id: get-secrets

--- a/actions/plugins/setup/action.yml
+++ b/actions/plugins/setup/action.yml
@@ -11,9 +11,6 @@ inputs:
   golangci-lint-version:
     description: golangci-lint version to use.
     required: true
-  trufflehog-version:
-    description: Trufflehog version to use.
-    required: true
 
 runs:
   using: composite
@@ -37,8 +34,3 @@ runs:
       shell: bash
       run: |
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v${{ inputs.golangci-lint-version }}
-
-    - name: Install Trufflehog
-      shell: bash
-      run: |
-        curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/${{ inputs.trufflehog-version }}/scripts/install.sh | sh

--- a/actions/plugins/setup/action.yml
+++ b/actions/plugins/setup/action.yml
@@ -11,6 +11,9 @@ inputs:
   golangci-lint-version:
     description: golangci-lint version to use.
     required: true
+  trufflehog-version:
+    description: Trufflehog version to use.
+    required: true
 
 runs:
   using: composite
@@ -34,3 +37,8 @@ runs:
       shell: bash
       run: |
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v${{ inputs.golangci-lint-version }}
+
+    - name: Install Trufflehog
+      shell: bash
+      run: |
+        curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/${{ inputs.trufflehog-version }}/scripts/install.sh | sh

--- a/actions/plugins/trufflehog/action.yml
+++ b/actions/plugins/trufflehog/action.yml
@@ -40,5 +40,5 @@ runs:
       run: >
         ./bin/trufflehog filesystem "${{ inputs.folder }}"
         --no-update --fail --github-actions
-        ${{ inputs.include-detectors && ('--include-detectors="' + inputs.include-detectors + '"') || '' }}
-        ${{ inputs.exclude-detectors && ('--exclude-detectors="' + inputs.exclude-detectors + '"') || '' }}
+        ${{ inputs.include-detectors && '--include-detectors=' + inputs.include-detectors || '' }}
+        ${{ inputs.exclude-detectors && '--exclude-detectors=' + inputs.exclude-detectors || '' }}

--- a/actions/plugins/trufflehog/action.yml
+++ b/actions/plugins/trufflehog/action.yml
@@ -11,6 +11,21 @@ inputs:
       Folder containing plugin zip files to scan.
       It will be scanned recursively.
     required: true
+  include-detectors:
+    description: |
+      Comma-separated list of detector types to include.
+      Protobuf name or IDs may be used, as well as ranges.
+      This value will be passed via the `--include-detectors` option to Trufflehog.
+      If not provided, the flag is not passed.
+    required: false
+  exclude-detectors:
+    description: |
+      Comma-separated list of detector types to exclude.
+      Protobuf name or IDs may be used, as well as ranges.
+      IDs defined here take precedence over the include list.
+      This value will be passed via the `--exclude-detectors` option to Trufflehog.
+      If not provided, the flag is not passed.
+    required: false
 
 runs:
   using: composite
@@ -22,4 +37,8 @@ runs:
 
     - name: Run Trufflehog
       shell: bash
-      run: ./bin/trufflehog filesystem "${{ inputs.folder }}" --no-update --fail --github-actions
+      run: >
+        ./bin/trufflehog filesystem "${{ inputs.folder }}"
+        --no-update --fail --github-actions
+        ${{ inputs.include-detectors && ('--include-detectors="' + inputs.include-detectors + '"') || '' }}
+        ${{ inputs.exclude-detectors && ('--exclude-detectors="' + inputs.exclude-detectors + '"') || '' }}

--- a/actions/plugins/trufflehog/action.yml
+++ b/actions/plugins/trufflehog/action.yml
@@ -2,6 +2,10 @@ name: Plugins - Trufflehog secrets scanning
 description: Scans plugin zip files for secrets using Trufflehog.
 
 inputs:
+  trufflehog-version:
+    description: |
+      Version of Trufflehog to install (e.g.: 3.88.1).
+    required: true
   folder:
     description: |
       Folder containing plugin zip files to scan.
@@ -14,8 +18,8 @@ runs:
     - name: Install Trufflehog
       shell: bash
       run: |
-        curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh
+        curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/v${{ inputs.trufflehog-version }}/scripts/install.sh | sh
 
     - name: Run Trufflehog
       shell: bash
-      run: ./bin/trufflehog filesystem "${{ inputs.folder }}" --fail --github-actions
+      run: ./bin/trufflehog filesystem "${{ inputs.folder }}" --no-update --fail --github-actions

--- a/actions/plugins/trufflehog/action.yml
+++ b/actions/plugins/trufflehog/action.yml
@@ -13,4 +13,4 @@ runs:
   steps:
     - name: Run Trufflehog
       shell: bash
-      run: ./bin/trufflehog filesystem "${{ inputs.folder }}" --fail --github-actions
+      run: ./bin/trufflehog filesystem "${{ inputs.folder }}" --fail --github-actions --debug

--- a/actions/plugins/trufflehog/action.yml
+++ b/actions/plugins/trufflehog/action.yml
@@ -37,8 +37,13 @@ runs:
 
     - name: Run Trufflehog
       shell: bash
-      run: >
-        ./bin/trufflehog filesystem "${{ inputs.folder }}"
-        --no-update --fail --github-actions
-        ${{ inputs.include-detectors && '--include-detectors=' + inputs.include-detectors || '' }}
-        ${{ inputs.exclude-detectors && '--exclude-detectors=' + inputs.exclude-detectors || '' }}
+      run: |
+        include_detectors="all"
+        if [ -n "${{ inputs.include-detectors }}" ]; then
+          include_detectors="${{ inputs.include-detectors }}"
+        fi
+
+        ./bin/trufflehog filesystem "${{ inputs.folder }}" \
+        --no-update --fail --github-actions \
+        --include-detectors="${include_detectors}" \
+        --exclude-detectors="${{ inputs.exclude-detectors }}"

--- a/actions/plugins/trufflehog/action.yml
+++ b/actions/plugins/trufflehog/action.yml
@@ -18,4 +18,4 @@ runs:
 
     - name: Run Trufflehog
       shell: bash
-      run: ./bin/trufflehog filesystem "${{ inputs.folder }}" --fail --github-actions --debug
+      run: ./bin/trufflehog filesystem "${{ inputs.folder }}" --fail --github-actions

--- a/actions/plugins/trufflehog/action.yml
+++ b/actions/plugins/trufflehog/action.yml
@@ -14,7 +14,7 @@ runs:
     - name: Install Trufflehog
       shell: bash
       run: |
-        curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/${{ inputs.trufflehog-version }}/scripts/install.sh | sh
+        curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh
 
     - name: Run Trufflehog
       shell: bash

--- a/actions/plugins/trufflehog/action.yml
+++ b/actions/plugins/trufflehog/action.yml
@@ -1,0 +1,16 @@
+name: Plugins - Trufflehog secrets scanning
+description: Scans plugin zip files for secrets using Trufflehog.
+
+inputs:
+  folder:
+    description: |
+      Folder containing plugin zip files to scan.
+      It will be scanned recursively.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Run Trufflehog
+      shell: bash
+      run: ./bin/trufflehog filesystem "${{ inputs.folder }}" --fail --github-actions

--- a/actions/plugins/trufflehog/action.yml
+++ b/actions/plugins/trufflehog/action.yml
@@ -11,6 +11,11 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Install Trufflehog
+      shell: bash
+      run: |
+        curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/${{ inputs.trufflehog-version }}/scripts/install.sh | sh
+
     - name: Run Trufflehog
       shell: bash
       run: ./bin/trufflehog filesystem "${{ inputs.folder }}" --fail --github-actions --debug


### PR DESCRIPTION
Adds secrets scanning with trufflehog for the packaged plugin zip files.


Example workflow run (with a fake secret): https://github.com/grafana/clock-panel/actions/runs/12655974757/job/35267517194

Fixes https://github.com/grafana/grafana-community-team/issues/224