### PR TITLE
CD: Pass all inputs to ci.yml

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -66,6 +66,18 @@ on:
         required: false
         type: boolean
         default: false
+      go-version:
+        description: Go version to use
+        type: string
+        required: false
+      node-version:
+        description: Node.js version to use
+        type: string
+        required: false
+      golangci-lint-version:
+        description: golangci-lint version to use
+        type: string
+        required: false
 
 concurrency:
   group: cd-${{ github.head_ref || github.run_id }}
@@ -111,7 +123,7 @@ jobs:
         id: checkout-specified-branch
         uses: actions/checkout@v4.2.2
         with:
-          ref: ${{ inputs.branch }}      
+          ref: ${{ inputs.branch }}
 
   ci:
     name: CI
@@ -119,15 +131,18 @@ jobs:
     needs:
       - setup
     with:
-      branch: ${{ github.event.inputs.branch }}
-      run-playwright: ${{ github.event.inputs.run-playwright == true }}
+      branch: ${{ inputs.branch }}
+      go-version: ${{ inputs.go-version }}
+      node-version: ${{ inputs.node-version }}
+      golangci-lint-version: ${{ inputs.golangci-lint-version }}
+      run-playwright: ${{ inputs.run-playwright == true }}
       run-playwright-with-grafana-dependency: ${{ inputs.run-playwright-with-grafana-dependency }}
       run-playwright-with-skip-grafana-dev-image: ${{ inputs.run-playwright-with-skip-grafana-dev-image }}
       run-playwright-with-version-resolver-type: ${{ inputs.run-playwright-with-version-resolver-type }}
-      upload-playwright-artifacts: ${{ github.event.inputs.upload-playwright-artifacts == true }}
+      upload-playwright-artifacts: ${{ inputs.upload-playwright-artifacts == true }}
       plugin-version-suffix: >-
         ${{
-          github.event.inputs.branch != 'main'
+          inputs.branch != 'main'
           && needs.setup.outputs.commit-sha
           || ''
         }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,17 +59,14 @@ on:
         description: Go version to use
         type: string
         required: false
-        default: "1.21"
       node-version:
         description: Node.js version to use
         type: string
         required: false
-        default: "20"
       golangci-lint-version:
         description: golangci-lint version to use
         type: string
         required: false
-        default: "1.61.0"
     outputs:
       plugin:
         description: |
@@ -115,6 +112,11 @@ permissions:
   id-token: write
 
 env:
+  DEFAULT_GO_VERSION: "1.21"
+  DEFAULT_NODE_VERSION: "20"
+  DEFAULT_GOLANGCI_LINT_VERSION: "1.61.0"
+  DEFAULT_TRUFFLEHOG_VERSION: "3.88.1"
+
   GCS_ARTIFACTS_BUCKET: "integration-artifacts"
   VAULT_INSTANCE: ops
 
@@ -139,9 +141,9 @@ jobs:
       - name: Setup
         uses: grafana/plugin-ci-workflows/actions/plugins/setup@main
         with:
-          go-version: ${{ inputs.go-version }}
-          node-version: ${{ inputs.node-version }}
-          golangci-lint-version: ${{ inputs.golangci-lint-version }}
+          go-version: ${{ inputs.go-version || env.DEFAULT_GO_VERSION }}
+          node-version: ${{ inputs.node-version || env.DEFAULT_NODE_VERSION }}
+          golangci-lint-version: ${{ inputs.golangci-lint-version || env.DEFAULT_GOLANGCI_LINT_VERSION }}
 
       - name: Get secrets from Vault
         id: get-secrets
@@ -207,7 +209,7 @@ jobs:
 
       - name: Define outputs
         id: outputs
-        run: |          
+        run: |
           {
             echo plugin="$(jq -n -c \
                 --arg id "$(jq -r .id dist/plugin.json)" \


### PR DESCRIPTION
Ensures the build done during cd (deployments) is the same as the one done during ci by passing all inputs from cd.yml to ci.yml.

Fixes #16.