### PR TITLE
Temporarily disable Trufflehog by default

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -70,7 +70,7 @@ on:
         description: Whether to run Trufflehog secrets scanning.
         type: boolean
         required: false
-        default: true
+        default: false
       trufflehog-version:
         description: Trufflehog version to use
         type: string

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ on:
         description: Whether to run Trufflehog secrets scanning.
         type: boolean
         required: false
-        default: true
+        default: false
       trufflehog-version:
         description: Trufflehog version to use
         type: string


### PR DESCRIPTION
Trufflehog is failing on plugins that contain backend executables. Disabling temporarily for now.

Related to #20 