### PR TITLE
CI: Trufflehog: Only report verified and unknown secrets

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -78,7 +78,7 @@ on:
         description: Whether to run Trufflehog secrets scanning.
         type: boolean
         required: false
-        default: false
+        default: true
       trufflehog-include-detectors:
         description: |
           Comma-separated list of detector types to include.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ on:
         description: Whether to run Trufflehog secrets scanning.
         type: boolean
         required: false
-        default: false
+        default: true
       trufflehog-include-detectors:
         description: |
           Comma-separated list of detector types to include.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,7 @@ jobs:
 
       - name: Trufflehog secrets scanning
         if: ${{ inputs.run-trufflehog == true }}
-        uses: grafana/plugin-ci-workflows/actions/plugins/trufflehog@giuseppe/trufflehog-only-verified
+        uses: grafana/plugin-ci-workflows/actions/plugins/trufflehog@main
         with:
           trufflehog-version: ${{ inputs.trufflehog-version || env.DEFAULT_TRUFFLEHOG_VERSION }}
           folder: dist-artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,7 @@ jobs:
 
       - name: Trufflehog secrets scanning
         if: ${{ inputs.run-trufflehog == true }}
-        uses: grafana/plugin-ci-workflows/actions/plugins/trufflehog@main
+        uses: grafana/plugin-ci-workflows/actions/plugins/trufflehog@giuseppe/trufflehog-only-verified
         with:
           trufflehog-version: ${{ inputs.trufflehog-version || env.DEFAULT_TRUFFLEHOG_VERSION }}
           folder: dist-artifacts

--- a/actions/plugins/trufflehog/action.yml
+++ b/actions/plugins/trufflehog/action.yml
@@ -45,5 +45,6 @@ runs:
 
         ./bin/trufflehog filesystem "${{ inputs.folder }}" \
         --no-update --fail --github-actions \
+        --results=verified,unknown \
         --include-detectors="${include_detectors}" \
         --exclude-detectors="${{ inputs.exclude-detectors }}"


### PR DESCRIPTION
Fixes #20

Example run: https://github.com/grafana/plugins-drone-to-gha/actions/runs/12743747079/job/35514320849

The Trufflehog step doesn't fail anymore unlike previously