### PR TITLE
Chore: Bump softprops/action-gh-release to v2.2.1

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -422,7 +422,7 @@ jobs:
             })
 
       - name: Create Github release
-        uses: softprops/action-gh-release@v2.2.0
+        uses: softprops/action-gh-release@v2.2.1
         with:
           draft: true
           name: ${{ fromJSON(needs.ci.outputs.plugin).id }} v${{ fromJSON(needs.ci.outputs.plugin).version }}


### PR DESCRIPTION
Bumps [softprops/action-gh-release to v2.2.1](https://github.com/softprops/action-gh-release/releases/tag/v2.2.1)

The patch includes a fix for `Error: Request body length does not match content-length header` when attaching assets to releases.