### PR TITLE
CI: Fix GCS upload path when targeting non-main branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,14 @@ env:
   VAULT_INSTANCE: ops
 
 jobs:
+  debug:
+    name: Debug
+    runs-on: ubuntu-latest
+    steps:
+      - name: Debug
+        run: more $GITHUB_EVENT_PATH
+        shell: bash
+
   test-and-build:
     name: Test and build plugin
     runs-on: ubuntu-latest-8-cores

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,7 +365,7 @@ jobs:
           plugin_version="${plugin_version%%+*}"
           gcs_artifacts_base="${{ env.GCS_ARTIFACTS_BUCKET }}/${{ fromJSON(needs.test-and-build.outputs.plugin).id }}/$plugin_version"
           echo "gcs_artifacts_path_latest=$gcs_artifacts_base/main/latest" >> "$GITHUB_ENV"
-          echo "gcs_artifacts_path_commit=$gcs_artifacts_base/main/${{ github.event.pull_request.head.sha || github.sha }}" >> "$GITHUB_ENV"
+          echo "gcs_artifacts_path_commit=$gcs_artifacts_base/${{ github.event.pull_request.base.ref || 'main' }}/${{ github.event.pull_request.head.sha || github.sha }}" >> "$GITHUB_ENV"
         shell: bash
 
       - name: Upload GCS artifacts (latest)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,14 +159,6 @@ env:
   VAULT_INSTANCE: ops
 
 jobs:
-  debug:
-    name: Debug
-    runs-on: ubuntu-latest
-    steps:
-      - name: Debug
-        run: more $GITHUB_EVENT_PATH
-        shell: bash
-
   test-and-build:
     name: Test and build plugin
     runs-on: ubuntu-latest-8-cores


### PR DESCRIPTION
Fixes the GCS path for PRs that do not target the "main" branch

Example run for a PR targeting the `gcs-only` branch instead of `main`:

https://github.com/grafana/plugins-drone-to-gha/actions/runs/12828535736/job/35772880943?pr=11 (see "Upload GCS artifacts (commit)" step)