### PR TITLE
CI: Fix docs exist check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,7 +305,7 @@ jobs:
         id: exist
         run: |
           r=false
-          [ -d "docs" ] && r=true
+          [ -d "docs/sources" ] && r=true
           echo "exist=$r" >> "$GITHUB_OUTPUT"
         shell: bash
 


### PR DESCRIPTION
Fixes output for "Check docs exist" step in ci.yml.

Example failure: https://github.com/grafana/google-bigquery-datasource/actions/runs/12832573816/job/35786278398