### PR TITLE
CD: Add artifact attestations to establish provenance for builds

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -219,11 +219,6 @@ jobs:
       bundle-path: ${{ steps.attestation.outputs.bundle-path }}
 
     steps:
-      #- name: Checkout
-      #  uses: actions/checkout@v4.2.2
-      #  with:
-      #    ref: ${{ inputs.branch }}
-
       - name: Download GitHub artifact
         uses: actions/download-artifact@v4.1.8
         with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -104,6 +104,14 @@ on:
         type: string
         required: false
 
+      # Artifacts attestation for build provenance
+      attestation:
+        description: |
+          Create a verifiable attestation for the plugin using Github OIDC.
+          Requires `id-token: write` and `attestations: writes` permissions.
+        type: boolean
+        required: false
+
       # User inputs
       environment:
         description: |
@@ -198,6 +206,37 @@ jobs:
           && needs.setup.outputs.commit-sha
           || ''
         }}
+
+  build-attestation:
+    name: Build attestation
+    if: ${{ inputs.attestation }}
+    needs:
+      - ci
+    runs-on: ubuntu-latest
+
+    outputs:
+      attestation-id: ${{ steps.attestation.outputs.attestation-id }}
+      attestation-url: ${{ steps.attestation.outputs.attestation-url }}
+      bundle-path: ${{ steps.attestation.outputs.bundle-path }}
+
+    steps:
+      #- name: Checkout
+      #  uses: actions/checkout@v4.2.2
+      #  with:
+      #    ref: ${{ inputs.branch }}
+
+      - name: Download GitHub artifact
+        uses: actions/download-artifact@v4.1.8
+        with:
+          name: dist-artifacts
+          path: /tmp/dist-artifacts
+
+      - name: Generate artifact attestation
+        if: ${{ inputs.attestation }}
+        id: attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: /tmp/dist-artifacts/*.zip
 
   define-variables:
     name: Define variables

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -106,9 +106,7 @@ on:
 
       # Artifacts attestation for build provenance
       attestation:
-        description: |
-          Create a verifiable attestation for the plugin using Github OIDC.
-          Requires `id-token: write` and `attestations: writes` permissions.
+        description: Create a verifiable attestation for the plugin using Github OIDC.
         type: boolean
         required: false
 
@@ -142,6 +140,7 @@ concurrency:
 permissions:
   contents: write
   id-token: write
+  attestations: write
 
 env:
   VAULT_INSTANCE: ops


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana-community-team/issues/294

Example run: https://github.com/grafana/plugins-drone-to-gha/actions/runs/12907460200/job/35991071286

Example attestation: https://github.com/grafana/plugins-drone-to-gha/attestations/4569615

Example verification:

```
╰─❯ gh attestation verify --owner grafana "grafana-datasourcehttpbackendghateststub-datasource-1.3.0+208270056ca3569584a2a926c6a4b4c769842cd6.linux_amd64.zip"
Loaded digest sha256:fb00312c3051d78e6fa7c2b1fb5989c0fd0015c472eb5fb397439ec64c975475 for file://grafana-datasourcehttpbackendghateststub-datasource-1.3.0+208270056ca3569584a2a926c6a4b4c769842cd6.linux_amd64.zip
Loaded 1 attestation from GitHub API

The following policy criteria will be enforced:
- OIDC Issuer must match:................... https://token.actions.githubusercontent.com
- Source Repository Owner URI must match:... https://github.com/grafana
- Predicate type must match:................ https://slsa.dev/provenance/v1
- Subject Alternative Name must match regex: (?i)^https://github.com/grafana/

✓ Verification succeeded!

sha256:fb00312c3051d78e6fa7c2b1fb5989c0fd0015c472eb5fb397439ec64c975475 was attested by:
REPO                         PREDICATE_TYPE                  WORKFLOW                                               
grafana/plugin-ci-workflows  https://slsa.dev/provenance/v1  .github/workflows/cd.yml@refs/heads/giuseppe/provenance
```
