### PR TITLE
CI: Fix nested apps zip file names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,7 +227,7 @@ jobs:
 
       - name: Package universal ZIP
         id: universal-zip
-        uses: grafana/plugin-ci-workflows/actions/plugins/package@giuseppe/fix-nested-app-zip-names
+        uses: grafana/plugin-ci-workflows/actions/plugins/package@main
         with:
           universal: "true"
           dist-folder: dist
@@ -236,7 +236,7 @@ jobs:
 
       - name: Package os/arch ZIPs
         id: os-arch-zips
-        uses: grafana/plugin-ci-workflows/actions/plugins/package@giuseppe/fix-nested-app-zip-names
+        uses: grafana/plugin-ci-workflows/actions/plugins/package@main
         with:
           universal: "false"
           dist-folder: dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,7 +227,7 @@ jobs:
 
       - name: Package universal ZIP
         id: universal-zip
-        uses: grafana/plugin-ci-workflows/actions/plugins/package@main
+        uses: grafana/plugin-ci-workflows/actions/plugins/package@giuseppe/fix-nested-app-zip-names
         with:
           universal: "true"
           dist-folder: dist
@@ -236,7 +236,7 @@ jobs:
 
       - name: Package os/arch ZIPs
         id: os-arch-zips
-        uses: grafana/plugin-ci-workflows/actions/plugins/package@main
+        uses: grafana/plugin-ci-workflows/actions/plugins/package@giuseppe/fix-nested-app-zip-names
         with:
           universal: "false"
           dist-folder: dist

--- a/actions/plugins/package/package.sh
+++ b/actions/plugins/package/package.sh
@@ -53,7 +53,6 @@ fi
 mkdir -p $out
 
 cd $dist
-cat plugin.json
 plugin_id=$(jq -r .id plugin.json)
 plugin_version=$(jq -r .info.version plugin.json)
 if [ -z "$plugin_id" ] || [ -z "$plugin_version" ]; then
@@ -99,7 +98,7 @@ fi
 exe_basename=$(basename $exe)
 for file in $(find "$backend_folder" -type f -name "${exe_basename}_*"); do
     # Extract os+arch from the file name
-    os_arch=$(echo $(basename $file) | sed -E "s|${exe}_(\w+)(.exe)?|\1|")
+    os_arch=$(echo $(basename $file) | sed -E "s|${exe_basename}_(\w+)(.exe)?|\1|")
 
     # Temporary folder for the zip file
     tmp=$(mktemp -d)
@@ -107,7 +106,7 @@ for file in $(find "$backend_folder" -type f -name "${exe_basename}_*"); do
 
     # Copy all files but the executables
     mkdir -p "$plugin_id"
-    rsync -a --exclude "${exe}*" "$dist/" "$plugin_id"
+    rsync -a --exclude "${exe_basename}*" "$dist/" "$plugin_id"
     
     # Copy only the current executable
     cp "$dist/$file" "$plugin_id/$backend_folder"


### PR DESCRIPTION
Fixes #32.

Fixes os/arch zip file names for nested datasources.

**Before:**

```
alexanderzobnin-zabbix-app-5.0.0.gpx_zabbix-datasource_darwin_amd64.zip
alexanderzobnin-zabbix-app-5.0.0.gpx_zabbix-datasource_darwin_arm64.zip
alexanderzobnin-zabbix-app-5.0.0.gpx_zabbix-datasource_linux_amd64.zip
alexanderzobnin-zabbix-app-5.0.0.gpx_zabbix-datasource_linux_arm64.zip
alexanderzobnin-zabbix-app-5.0.0.gpx_zabbix-datasource_linux_arm.zip
alexanderzobnin-zabbix-app-5.0.0.gpx_zabbix-datasource_windows_amd64.exe.zip
alexanderzobnin-zabbix-app-5.0.0.zip
```

**After:**
```
alexanderzobnin-zabbix-app-5.0.0.darwin_amd64.zip
alexanderzobnin-zabbix-app-5.0.0.darwin_arm64.zip
alexanderzobnin-zabbix-app-5.0.0.linux_amd64.zip
alexanderzobnin-zabbix-app-5.0.0.linux_arm64.zip
alexanderzobnin-zabbix-app-5.0.0.linux_arm.zip
alexanderzobnin-zabbix-app-5.0.0.windows_amd64.zip
alexanderzobnin-zabbix-app-5.0.0.zip
```

**Example with a non-nested app:**
```
grafana-github-datasource-2.0.1.darwin_amd64.zip
grafana-github-datasource-2.0.1.darwin_arm64.zip
grafana-github-datasource-2.0.1.linux_amd64.zip
grafana-github-datasource-2.0.1.linux_arm64.zip
grafana-github-datasource-2.0.1.linux_arm.zip
grafana-github-datasource-2.0.1.windows_amd64.zip
grafana-github-datasource-2.0.1.zip
```

**Local testing instructions:**

1. Build a nested app locally, i.e.: zabbix
2. Run the `package.sh` script without the `-u` flag to produce os/arch zip files:

```bash
./actions/plugins/package/package.sh /home/giuseppe/grafana/grafana-zabbix/dist /home/giuseppe/grafana/grafana-zabbix/artifacts
```