### PR TITLE
Support running CI workflows on external forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # Do not run upload to GCS for PRs from forks (no access)
-    if: ${{ !github.env.IS_FORK }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
 
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,9 @@ env:
   GCS_ARTIFACTS_BUCKET: "integration-artifacts"
   VAULT_INSTANCE: ops
 
+  # TODO: testing
+  IS_FORK: ${{ github.event.pull_request.head.repo.full_name != github.repository || true }}
+
 jobs:
   test-and-build:
     name: Test and build plugin
@@ -185,6 +188,7 @@ jobs:
 
       - name: Get secrets from Vault
         id: get-secrets
+        if: ${{ !env.IS_FORK }}
         uses: grafana/shared-workflows/actions/get-vault-secrets@main
         with:
           vault_instance: ${{ env.VAULT_INSTANCE }}
@@ -232,7 +236,8 @@ jobs:
           universal: "true"
           dist-folder: dist
           output-folder: dist-artifacts
-          access-policy-token: ${{ env.SIGN_PLUGIN_ACCESS_POLICY_TOKEN }}
+          access-policy-token: ${{ env.SIGN_PLUGIN_ACCESS_POLICY_TOKEN || '' }}
+          allow-unsigned: ${{ env.IS_FORK }}
 
       - name: Package os/arch ZIPs
         id: os-arch-zips
@@ -241,7 +246,8 @@ jobs:
           universal: "false"
           dist-folder: dist
           output-folder: dist-artifacts
-          access-policy-token: ${{ env.SIGN_PLUGIN_ACCESS_POLICY_TOKEN }}
+          access-policy-token: ${{ env.SIGN_PLUGIN_ACCESS_POLICY_TOKEN || '' }}
+          allow-unsigned: ${{ env.IS_FORK }}
 
       - name: Trufflehog secrets scanning
         if: ${{ inputs.run-trufflehog == true }}
@@ -330,6 +336,10 @@ jobs:
   upload-to-gcs:
     name: Upload to GCS
     runs-on: ubuntu-latest
+
+    # Do not run upload to GCS for PRs from forks (no access)
+    # TODO: testing
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && false }}
 
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,8 +158,7 @@ env:
   GCS_ARTIFACTS_BUCKET: "integration-artifacts"
   VAULT_INSTANCE: ops
 
-  # TODO: testing
-  IS_FORK: ${{ github.event.pull_request.head.repo.full_name != github.repository || true }}
+  IS_FORK: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
 
 jobs:
   test-and-build:
@@ -338,8 +337,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # Do not run upload to GCS for PRs from forks (no access)
-    # TODO: testing
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && false }}
+    if: ${{ !github.env.IS_FORK }}
 
     permissions:
       contents: read


### PR DESCRIPTION
Fixes https://github.com/grafana/plugin-ci-workflows/issues/31

Allows CI to run on external forks by making those changes:
- Disables GCS upload, otherwise the step fails because forks don't have access to the service account
- Disables plugins signing, the GitHub actions artifacts will contain unsigned plugins

Example PR: https://github.com/grafana/clock-panel/pull/247

Example run: https://github.com/grafana/clock-panel/actions/runs/13375181080?pr=247