### PR TITLE
Fix vault secrets step skipped for non-fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,8 @@ env:
   GCS_ARTIFACTS_BUCKET: "integration-artifacts"
   VAULT_INSTANCE: ops
 
+  IS_FORK: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+
 jobs:
   test-and-build:
     name: Test and build plugin
@@ -233,7 +235,8 @@ jobs:
           universal: "true"
           dist-folder: dist
           output-folder: dist-artifacts
-          access-policy-token: ${{ env.SIGN_PLUGIN_ACCESS_POLICY_TOKEN }}
+          access-policy-token: ${{ env.SIGN_PLUGIN_ACCESS_POLICY_TOKEN || '' }}
+          allow-unsigned: ${{ env.IS_FORK }}
 
       - name: Package os/arch ZIPs
         id: os-arch-zips
@@ -242,7 +245,8 @@ jobs:
           universal: "false"
           dist-folder: dist
           output-folder: dist-artifacts
-          access-policy-token: ${{ env.SIGN_PLUGIN_ACCESS_POLICY_TOKEN }}
+          access-policy-token: ${{ env.SIGN_PLUGIN_ACCESS_POLICY_TOKEN || '' }}
+          allow-unsigned: ${{ env.IS_FORK }}
 
       - name: Trufflehog secrets scanning
         if: ${{ inputs.run-trufflehog == true }}
@@ -331,6 +335,9 @@ jobs:
   upload-to-gcs:
     name: Upload to GCS
     runs-on: ubuntu-latest
+
+    # Do not run upload to GCS for PRs from forks (no access)
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
 
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,7 @@ jobs:
           dist-folder: dist
           output-folder: dist-artifacts
           access-policy-token: ${{ env.SIGN_PLUGIN_ACCESS_POLICY_TOKEN || '' }}
-          allow-unsigned: ${{ env.IS_FORK }}
+          allow-unsigned: ${{ env.IS_FORK == 'true' }}
 
       - name: Trufflehog secrets scanning
         if: ${{ inputs.run-trufflehog == true }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
 
       - name: Get secrets from Vault
         id: get-secrets
-        if: ${{ !env.IS_FORK }}
+        if: ${{ env.IS_FORK == 'true' }}
         uses: grafana/shared-workflows/actions/get-vault-secrets@main
         with:
           vault_instance: ${{ env.VAULT_INSTANCE }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
 
       - name: Get secrets from Vault
         id: get-secrets
-        if: ${{ env.IS_FORK == 'true' }}
+        if: ${{ env.IS_FORK != 'true' }}
         uses: grafana/shared-workflows/actions/get-vault-secrets@main
         with:
           vault_instance: ${{ env.VAULT_INSTANCE }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
 
       - name: Get secrets from Vault
         id: get-secrets
-        if: ${{ env.IS_FORK != 'true' }}
+        if: ${{ env.IS_FORK == 'false' }}
         uses: grafana/shared-workflows/actions/get-vault-secrets@main
         with:
           vault_instance: ${{ env.VAULT_INSTANCE }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,7 +236,7 @@ jobs:
           dist-folder: dist
           output-folder: dist-artifacts
           access-policy-token: ${{ env.SIGN_PLUGIN_ACCESS_POLICY_TOKEN || '' }}
-          allow-unsigned: ${{ env.IS_FORK }}
+          allow-unsigned: ${{ env.IS_FORK == 'true' }}
 
       - name: Package os/arch ZIPs
         id: os-arch-zips


### PR DESCRIPTION
Same as #40 (which was reverted in #41), but includes a bugfix for internal PRs.

For internal PRs, the "Get secrets from vault" step was skipped (treated as if it was a fork PR), causing the package step to fail.

The PR has the same changes as #40, plus a bugfix. The diff for the bugfix is: https://github.com/grafana/plugin-ci-workflows/compare/95103bb803c14175a71132455ad6b61d3bc713e8...51f82be

Example failing run: https://github.com/grafana/metrics-drilldown/actions/runs/13411387311/job/37525765368

Example run with this GHA branch for an internal PR: https://github.com/grafana/plugins-drone-to-gha/actions/runs/13434629597?pr=15

Example run with this GHA branch for a fork PR: https://github.com/grafana/clock-panel/actions/runs/13434699105?pr=249