### PR TITLE
CI: Fix GCS upload skipped for push events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # Do not run upload to GCS for PRs from forks (no access)
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
 
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,7 +336,10 @@ jobs:
     name: Upload to GCS
     runs-on: ubuntu-latest
 
-    # Always upload to GCS for pushes, but skip the upload for PRs from forks (no access to the GCS bucket)
+    # Upload to GCS:
+    # - For push event (commits and tags)
+    # - For internal PRs
+    # But skip the GCS upload for PRs from forks (no access to the GCS bucket)
     if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
 
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,7 +336,7 @@ jobs:
     name: Upload to GCS
     runs-on: ubuntu-latest
 
-    # Do not run upload to GCS for PRs from forks (no access)
+    # Always upload to GCS for pushes, but skip the upload for PRs from forks (no access to the GCS bucket)
     if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
 
     permissions:


### PR DESCRIPTION
Fixes a bug introduced in #42 where GCS upload was not being executed for pushes to the "main" branch.