### PR TITLE
CI: Fix IS_FORK value for non-pull_request events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ env:
   GCS_ARTIFACTS_BUCKET: "integration-artifacts"
   VAULT_INSTANCE: ops
 
-  IS_FORK: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+  IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
 
 jobs:
   test-and-build:


### PR DESCRIPTION
Follow up to #43 as I forgot to update a similar logic for the IS_FORK variable