### PR TITLE
CD: Upload ZIP files to a dedicated release folder

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -382,10 +382,11 @@ jobs:
     # TODO: change to "ops || prod" after testing
     # TODO: ensure it works with gcs-only = true (deploy is skipped, but we have "deploy" in needs)
     if: >-
-      ${{ contains(fromJSON(needs.define-variables.outputs.environments), 'dev') && (
-        (needs.deploy.result == 'success' && !inputs.gcs-only) ||
-        (needs.deploy.result == 'skipped' && inputs.gcs-only)
-      ) }}
+      ${{ !inputs.docs-only &&
+        contains(fromJSON(needs.define-variables.outputs.environments), 'dev') && (
+          (needs.deploy.result == 'success' && !inputs.gcs-only) ||
+          (needs.deploy.result == 'skipped' && inputs.gcs-only)
+        ) }}
 
     strategy:
       matrix:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -361,16 +361,23 @@ jobs:
           gcom-publish-token: ${{ env.GCOM_PUBLISH_TOKEN }}
           gcloud-auth-token: ${{ steps.gcloud.outputs.id_token }}
 
+  # Note: This job can be removed once provisioned plugins releases are moved to the
+  # tailored plugins catalog instead of using GCS.
   upload-to-gcs-release:
     name: Upload to GCS (release)
     runs-on: ubuntu-latest
 
     needs:
       - ci
+      - define-variables
       - deploy
 
     # TODO: change to "ops || prod" after testing
-    if: ${{ inputs.environment == 'dev' }}
+    if: >-
+      ${{ contains(fromJSON(needs.define-variables.outputs.environments), 'dev') && (
+        (needs.deploy.result == 'success' && !inputs.gcs-only) ||
+        (needs.deploy.result == 'skipped' && inputs.gcs-only)
+      ) }}
 
     strategy:
       matrix:
@@ -404,7 +411,7 @@ jobs:
           glob: "*${{ matrix.os }}*"
           destination: "${{ env.gcs_artifacts_release_path_tag }}/${{ matrix.os }}"
           parent: false
-          process_gcloudignore: falses
+          process_gcloudignore: false
 
       - name: Upload GCS release artifact (latest)
         uses: google-github-actions/upload-cloud-storage@v2.2.1
@@ -413,7 +420,7 @@ jobs:
           glob: "*${{ matrix.os }}*"
           destination: "${{ env.gcs_artifacts_release_path_latest }}/${{ matrix.os }}"
           parent: false
-          process_gcloudignore: falses
+          process_gcloudignore: false
 
   publish-docs:
     name: Publish docs
@@ -480,7 +487,7 @@ jobs:
       - deploy
     if: >-
       ${{
-        (needs.define-variables.outputs.prod == 'true')
+        contains(fromJSON(needs.define-variables.outputs.environments), 'prod')
         && !(failure() || cancelled())
       }}
     steps:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -413,13 +413,9 @@ jobs:
             echo "gcs_artifacts_release_path_latest=$gcs_artifacts_release_base/latest"
             echo "gcs_artifacts_release_path_tag=$gcs_artifacts_release_base/$plugin_version"
             if [ "${{ matrix.platform }}" == 'any' ]; then
-              # For "any" platform (universal zip), the platform name is not included in the file names.
-              # Get the url of the universal zip, get the file name from it, and add "*" at the end
-              # (so we also upload the hash files).
               echo "gcs_upload_glob=$(basename ${{ needs.ci.outputs.gcs-universal-zip-url-commit }})*"
             else
-              # For other platforms it's easier, because the platform is in the filename
-              echo "gcs_upload_glob=*${{ matrix.platform }}*"
+              echo "gcs_upload_glob=$(basename ${{ needs.ci.outputs.gcs-universal-zip-url-commit }}).${{ matrix.platform }}*"
             fi
           } >> "$GITHUB_ENV"
         shell: bash

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -376,8 +376,7 @@ jobs:
 
     strategy:
       matrix:
-        # TODO: any if frontend only, archs if has backend
-        os: [linux, darwin, windows, any]
+        os: ${{ fromJson(needs.ci.outputs.plugin).has-backend == 'true' && '["linux", "darwin", "windows", "any"]' || '["any"]' }}
 
     steps:
       - name: Download GitHub artifact

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -376,6 +376,7 @@ jobs:
 
     strategy:
       matrix:
+        # TODO: any if frontend only, archs if has backend
         os: [linux, darwin, windows, any]
 
     steps:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -378,13 +378,7 @@ jobs:
       - ci
       - define-variables
 
-    # TODO: change to "ops || prod" after testing
-    # TODO: ensure it works with gcs-only = true (deploy is skipped, but we have "deploy" in needs)
-    if: >-
-      ${{
-        !inputs.docs-only &&
-        (contains(fromJSON(needs.define-variables.outputs.environments), 'dev'))
-      }}
+    if: ${{ !inputs.docs-only }}
 
     strategy:
       matrix:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -417,7 +417,7 @@ jobs:
               # Get the url of the universal zip, get the file name from it,
               # strip the extension and replace it with ".*" (so we also upload the hash files)
               fn=$(basename ${{ needs.ci.outputs.gcs-universal-zip-url-commit }})
-              echo "gcs_upload_glob=${fn%.*}.*"
+              echo "gcs_upload_glob=${fn%.*}.{zip,md5,sha1}"
             else
               # For other platforms it's easier, because the platform is in the filename
               echo "gcs_upload_glob=*${{ matrix.platform }}*"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -240,7 +240,6 @@ jobs:
     outputs:
       environments: ${{ steps.vars.outputs.environments }}
       publish-docs: ${{ steps.vars.outputs.publish-docs }}
-      prod: ${{ steps.vars.outputs.prod }}
 
     steps:
       - name: Define variables
@@ -251,7 +250,6 @@ jobs:
             {
               echo 'environments=[]'
               echo 'publish-docs=true'
-              echo 'prod=false'
             } >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -262,20 +260,17 @@ jobs:
             {
               echo 'environments=["dev"]'
               echo 'publish-docs=false'
-              echo 'prod=false' 
             } >> "$GITHUB_OUTPUT"
           elif [ "${{ inputs.environment }}" == 'ops' ]; then
             {
               echo 'environments=["dev", "ops"]'
               echo 'publish-docs=false'
-              echo 'prod=false'
             } >> "$GITHUB_OUTPUT"
             
           elif [ "${{ inputs.environment }}" == 'prod' ]; then
             {
               echo 'environments=["dev", "ops", "prod"]'
               echo 'publish-docs=true'
-              echo 'prod=true'
             } >> "$GITHUB_OUTPUT"
             
           else

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -255,7 +255,7 @@ jobs:
           else
             platforms='["any"]'
           fi
-          echo 'platforms=$platforms' >> "$GITHUB_OUTPUT"
+          echo "platforms=$platforms" >> "$GITHUB_OUTPUT"
 
           # If we are publishing docs only, we don't need to deploy the plugin
           if [ "${{ inputs.docs-only }}" == 'true' ]; then

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -412,10 +412,12 @@ jobs:
           {
             echo "gcs_artifacts_release_path_latest=$gcs_artifacts_release_base/latest"
             echo "gcs_artifacts_release_path_tag=$gcs_artifacts_release_base/$plugin_version"
+            fn=$(basename ${{ needs.ci.outputs.gcs-universal-zip-url-commit }})
             if [ "${{ matrix.platform }}" == 'any' ]; then
-              echo "gcs_upload_glob=$(basename ${{ needs.ci.outputs.gcs-universal-zip-url-commit }})*"
+              echo "gcs_upload_glob=$fn*"
             else
-              echo "gcs_upload_glob=$(basename ${{ needs.ci.outputs.gcs-universal-zip-url-commit }}).${{ matrix.platform }}*"
+              # strip the extension (.zip) and append the platform instead
+              echo "gcs_upload_glob=${fn%.*}.${{ matrix.platform }}*"
             fi
           } >> "$GITHUB_ENV"
         shell: bash

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -255,7 +255,7 @@ jobs:
           else
             platforms='["any"]'
           fi
-          echo "platforms=$platforms" >> "$GITHUB_ENV"
+          echo 'platforms=$platforms' >> "$GITHUB_OUTPUT"
 
           # If we are publishing docs only, we don't need to deploy the plugin
           if [ "${{ inputs.docs-only }}" == 'true' ]; then

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -414,10 +414,9 @@ jobs:
             echo "gcs_artifacts_release_path_tag=$gcs_artifacts_release_base/$plugin_version"
             if [ "${{ matrix.platform }}" == 'any' ]; then
               # For "any" platform (universal zip), the platform name is not included in the file names.
-              # Get the url of the universal zip, get the file name from it,
-              # strip the extension and replace it with ".*" (so we also upload the hash files)
-              fn=$(basename ${{ needs.ci.outputs.gcs-universal-zip-url-commit }})
-              echo "gcs_upload_glob=${fn%.*}.{zip,md5,sha1}"
+              # Get the url of the universal zip, get the file name from it, and add "*" at the end
+              # (so we also upload the hash files).
+              echo "gcs_upload_glob=$(basename ${{ needs.ci.outputs.gcs-universal-zip-url-commit }})*"
             else
               # For other platforms it's easier, because the platform is in the filename
               echo "gcs_upload_glob=*${{ matrix.platform }}*"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -377,16 +377,14 @@ jobs:
     needs:
       - ci
       - define-variables
-      - deploy
 
     # TODO: change to "ops || prod" after testing
     # TODO: ensure it works with gcs-only = true (deploy is skipped, but we have "deploy" in needs)
     if: >-
-      ${{ !inputs.docs-only &&
-        contains(fromJSON(needs.define-variables.outputs.environments), 'dev') && (
-          (needs.deploy.result == 'success' && !inputs.gcs-only) ||
-          (needs.deploy.result == 'skipped' && inputs.gcs-only)
-        ) }}
+      ${{
+        !inputs.docs-only &&
+        (contains(fromJSON(needs.define-variables.outputs.environments), 'dev'))
+      }}
 
     strategy:
       matrix:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -394,13 +394,13 @@ jobs:
 
     steps:
       - name: Download GitHub artifact
-        uses: actions/download-artifact@v4.1.8
+        uses: actions/download-artifact@v4.1.9
         with:
           name: dist-artifacts
           path: /tmp/dist-artifacts
 
       - name: Login to Google Cloud
-        uses: google-github-actions/auth@v2.1.7
+        uses: google-github-actions/auth@v2.1.8
         with:
           workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
           service_account: github-plugin-ci-workflows@grafanalabs-workload-identity.iam.gserviceaccount.com
@@ -423,7 +423,7 @@ jobs:
         shell: bash
 
       - name: Upload GCS release artifact (tag)
-        uses: google-github-actions/upload-cloud-storage@v2.2.1
+        uses: google-github-actions/upload-cloud-storage@v2.2.2
         with:
           path: /tmp/dist-artifacts
           glob: ${{ env.gcs_upload_glob }}
@@ -432,7 +432,7 @@ jobs:
           process_gcloudignore: false
 
       - name: Upload GCS release artifact (latest)
-        uses: google-github-actions/upload-cloud-storage@v2.2.1
+        uses: google-github-actions/upload-cloud-storage@v2.2.2
         with:
           path: /tmp/dist-artifacts
           glob: ${{ env.gcs_upload_glob }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -183,8 +183,7 @@ jobs:
 
   ci:
     name: CI
-    # TODO: switch branch after testing
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@giuseppe/drone-release-artifacts
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main
     needs:
       - setup
     with:
@@ -362,8 +361,8 @@ jobs:
           gcom-publish-token: ${{ env.GCOM_PUBLISH_TOKEN }}
           gcloud-auth-token: ${{ steps.gcloud.outputs.id_token }}
 
-  upload-gcs-release:
-    name: Upload GCS artifacts (release)
+  upload-to-gcs-release:
+    name: Upload to GCS (release)
     runs-on: ubuntu-latest
 
     needs:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -144,6 +144,7 @@ permissions:
 
 env:
   VAULT_INSTANCE: ops
+  GCS_ARTIFACTS_BUCKET: integration-artifacts
 
 jobs:
   setup:
@@ -206,7 +207,6 @@ jobs:
           && needs.setup.outputs.commit-sha
           || ''
         }}
-      upload-to-gcs-release-folder: true
 
   build-attestation:
     name: Build attestation
@@ -361,6 +361,60 @@ jobs:
           scopes: ${{ inputs.scopes }}
           gcom-publish-token: ${{ env.GCOM_PUBLISH_TOKEN }}
           gcloud-auth-token: ${{ steps.gcloud.outputs.id_token }}
+
+  upload-gcs-release:
+    name: Upload GCS artifacts (release)
+    runs-on: ubuntu-latest
+
+    needs:
+      - ci
+      - deploy
+
+    # TODO: change to "ops || prod" after testing
+    if: ${{ inputs.environment == 'dev' }}
+
+    strategy:
+      matrix:
+        os: [linux, darwin, windows, any]
+
+    steps:
+      - name: Download GitHub artifact
+        uses: actions/download-artifact@v4.1.8
+        with:
+          name: dist-artifacts
+          path: /tmp/dist-artifacts
+
+      - name: Login to Google Cloud
+        uses: google-github-actions/auth@v2.1.7
+        with:
+          workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
+          service_account: github-plugin-ci-workflows@grafanalabs-workload-identity.iam.gserviceaccount.com
+
+      - name: Determine GCS artifacts paths
+        run: |
+          plugin_version='${{ fromJSON(needs.ci.outputs.plugin).version }}'
+          gcs_artifacts_release_base="${{ env.GCS_ARTIFACTS_BUCKET }}/${{ fromJSON(needs.ci.outputs.plugin).id }}/release"
+          echo "gcs_artifacts_release_path_latest=$gcs_artifacts_release_base/latest" >> "$GITHUB_ENV"
+          echo "gcs_artifacts_release_path_tag=$gcs_artifacts_release_base/$plugin_version" >> "$GITHUB_ENV"
+        shell: bash
+
+      - name: Upload GCS release artifact (tag)
+        uses: google-github-actions/upload-cloud-storage@v2.2.1
+        with:
+          path: /tmp/dist-artifacts
+          glob: "*${{ matrix.os }}*"
+          destination: "${{ env.gcs_artifacts_release_path_tag }}/${{ matrix.os }}"
+          parent: false
+          process_gcloudignore: falses
+
+      - name: Upload GCS release artifact (latest)
+        uses: google-github-actions/upload-cloud-storage@v2.2.1
+        with:
+          path: /tmp/dist-artifacts
+          glob: "*${{ matrix.os }}*"
+          destination: "${{ env.gcs_artifacts_release_path_latest }}/${{ matrix.os }}"
+          parent: false
+          process_gcloudignore: falses
 
   publish-docs:
     name: Publish docs

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -182,6 +182,7 @@ jobs:
 
   ci:
     name: CI
+    # TODO: switch branch after testing
     uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@giuseppe/drone-release-artifacts
     needs:
       - setup

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -389,6 +389,7 @@ jobs:
 
     strategy:
       matrix:
+        # TODO: 'any' doesn't upload anything?
         platform: ${{ fromJson(needs.define-variables.outputs.platforms) }}
 
     steps:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -205,6 +205,7 @@ jobs:
           && needs.setup.outputs.commit-sha
           || ''
         }}
+      upload-to-gcs-release-folder: true
 
   build-attestation:
     name: Build attestation

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -409,15 +409,27 @@ jobs:
         run: |
           plugin_version='${{ fromJSON(needs.ci.outputs.plugin).version }}'
           gcs_artifacts_release_base="${{ env.GCS_ARTIFACTS_BUCKET }}/${{ fromJSON(needs.ci.outputs.plugin).id }}/release"
-          echo "gcs_artifacts_release_path_latest=$gcs_artifacts_release_base/latest" >> "$GITHUB_ENV"
-          echo "gcs_artifacts_release_path_tag=$gcs_artifacts_release_base/$plugin_version" >> "$GITHUB_ENV"
+          {
+            echo "gcs_artifacts_release_path_latest=$gcs_artifacts_release_base/latest"
+            echo "gcs_artifacts_release_path_tag=$gcs_artifacts_release_base/$plugin_version"
+            if [ "${{ matrix.platform }}" == 'any' ]; then
+              # For "any" platform (universal zip), the platform name is not included in the file names.
+              # Get the url of the universal zip, get the file name from it,
+              # strip the extension and replace it with ".*" (so we also upload the hash files)
+              fn=$(basename ${{ needs.ci.outputs.gcs-universal-zip-url-commit }})
+              echo "gcs_upload_glob=${fn%.*}.*"
+            else
+              # For other platforms it's easier, because the platform is in the filename
+              echo "gcs_upload_glob=*${{ matrix.platform }}*"
+            fi
+          } >> "$GITHUB_ENV"
         shell: bash
 
       - name: Upload GCS release artifact (tag)
         uses: google-github-actions/upload-cloud-storage@v2.2.1
         with:
           path: /tmp/dist-artifacts
-          glob: "*${{ matrix.platform }}*"
+          glob: ${{ env.gcs_upload_glob }}
           destination: "${{ env.gcs_artifacts_release_path_tag }}/${{ matrix.platform }}"
           parent: false
           process_gcloudignore: false
@@ -426,7 +438,7 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@v2.2.1
         with:
           path: /tmp/dist-artifacts
-          glob: "*${{ matrix.platform }}*"
+          glob: ${{ env.gcs_upload_glob }}
           destination: "${{ env.gcs_artifacts_release_path_latest }}/${{ matrix.platform }}"
           parent: false
           process_gcloudignore: false

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -382,7 +382,6 @@ jobs:
 
     strategy:
       matrix:
-        # TODO: 'any' doesn't upload anything?
         platform: ${{ fromJson(needs.define-variables.outputs.platforms) }}
 
     steps:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -182,7 +182,7 @@ jobs:
 
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@giuseppe/drone-release-artifacts
     needs:
       - setup
     with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -380,6 +380,7 @@ jobs:
       - deploy
 
     # TODO: change to "ops || prod" after testing
+    # TODO: ensure it works with gcs-only = true (deploy is skipped, but we have "deploy" in needs)
     if: >-
       ${{ contains(fromJSON(needs.define-variables.outputs.environments), 'dev') && (
         (needs.deploy.result == 'success' && !inputs.gcs-only) ||

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -237,14 +237,26 @@ jobs:
     name: Define variables
     runs-on: ubuntu-latest
 
+    needs:
+      - ci
+
     outputs:
       environments: ${{ steps.vars.outputs.environments }}
       publish-docs: ${{ steps.vars.outputs.publish-docs }}
+      platforms: ${{ steps.vars.outputs.platforms }}
 
     steps:
       - name: Define variables
         id: vars
         run: |
+          # Platforms matrix
+          if [ "${{ fromJSON(needs.ci.outputs.plugin).has-backend }}" == 'true' ]; then
+            platforms='["linux", "darwin", "windows", "any"]'
+          else
+            platforms='["any"]'
+          fi
+          echo "platforms=$platforms" >> "$GITHUB_ENV"
+
           # If we are publishing docs only, we don't need to deploy the plugin
           if [ "${{ inputs.docs-only }}" == 'true' ]; then
             {
@@ -376,7 +388,7 @@ jobs:
 
     strategy:
       matrix:
-        os: ${{ fromJson(needs.ci.outputs.plugin).has-backend == 'true' && '["linux", "darwin", "windows", "any"]' || '["any"]' }}
+        platform: ${{ fromJson(needs.define-variables.outputs.platforms) }}
 
     steps:
       - name: Download GitHub artifact
@@ -403,8 +415,8 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@v2.2.1
         with:
           path: /tmp/dist-artifacts
-          glob: "*${{ matrix.os }}*"
-          destination: "${{ env.gcs_artifacts_release_path_tag }}/${{ matrix.os }}"
+          glob: "*${{ matrix.platform }}*"
+          destination: "${{ env.gcs_artifacts_release_path_tag }}/${{ matrix.platform }}"
           parent: false
           process_gcloudignore: false
 
@@ -412,8 +424,8 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@v2.2.1
         with:
           path: /tmp/dist-artifacts
-          glob: "*${{ matrix.os }}*"
-          destination: "${{ env.gcs_artifacts_release_path_latest }}/${{ matrix.os }}"
+          glob: "*${{ matrix.platform }}*"
+          destination: "${{ env.gcs_artifacts_release_path_latest }}/${{ matrix.platform }}"
           parent: false
           process_gcloudignore: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,6 +459,7 @@ jobs:
     runs-on: ubuntu-latest
 
     needs:
+      - test-and-build
       - upload-to-gcs
 
     if: ${{ needs.upload-to-gcs.result == 'success' && inputs.upload-to-gcs-release-folder == true }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,17 @@ on:
         type: string
         required: false
 
+      # GCS/provisioned plugins options
+      upload-to-gcs-release-folder:
+        description: |
+          If true, the plugin will be uploaded to the release folder in GCS.
+          (`integration-artifacts/${PLUGIN_NAME}/release/${VERSION}`).
+          Default is false.
+          This should be true only when calling CI for deployments.
+        required: false
+        type: boolean
+        default: false
+
       # Options for building PRs. Those values should come from the PR event and should not be set manually.
       plugin-version-suffix:
         description: |
@@ -337,7 +348,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # Skip the GCS upload for PRs from forks (no access to the GCS bucket)
-    # This is equivalent to !env.IS_FORK equivalent (we don't have access to the env context at this level)
+    # This is equivalent to !env.IS_FORK (we don't have access to the env context at this level)
     if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
 
     permissions:
@@ -368,13 +379,16 @@ jobs:
           service_account: github-plugin-ci-workflows@grafanalabs-workload-identity.iam.gserviceaccount.com
 
       - name: Determine GCS artifacts paths
+        # TODO: for release artifacts: windows, darwin, linux, any
+        #   (https://github.com/grafana/grafana-drone-extension/blob/411172f4e3681acb2e78d2ed0d42ba8e1fc093c7/pluginjson/pipeline-deploy.go#L142-L153)
         run: |
           plugin_version='${{ fromJSON(needs.test-and-build.outputs.plugin).version }}'
           # Strip the SHA suffix from the version, if present.
           plugin_version="${plugin_version%%+*}"
-          gcs_artifacts_base="${{ env.GCS_ARTIFACTS_BUCKET }}/${{ fromJSON(needs.test-and-build.outputs.plugin).id }}/$plugin_version"
-          echo "gcs_artifacts_path_latest=$gcs_artifacts_base/main/latest" >> "$GITHUB_ENV"
-          echo "gcs_artifacts_path_commit=$gcs_artifacts_base/${{ github.event.pull_request.base.ref || 'main' }}/${{ github.event.pull_request.head.sha || github.sha }}" >> "$GITHUB_ENV"
+          gcs_artifacts_base="${{ env.GCS_ARTIFACTS_BUCKET }}/${{ fromJSON(needs.test-and-build.outputs.plugin).id }}"
+          echo "gcs_artifacts_path_latest=$gcs_artifacts_base/$plugin_version/main/latest" >> "$GITHUB_ENV"
+          echo "gcs_artifacts_path_commit=$gcs_artifacts_base/$plugin_version/${{ github.event.pull_request.base.ref || 'main' }}/${{ github.event.pull_request.head.sha || github.sha }}" >> "$GITHUB_ENV"
+          echo "gcs_artifacts_path_release=$gcs_artifacts_base/release/$plugin_version" >> "$GITHUB_ENV"
         shell: bash
 
       - name: Upload GCS artifacts (latest)
@@ -393,6 +407,16 @@ jobs:
         with:
           path: /tmp/dist-artifacts
           destination: ${{ env.gcs_artifacts_path_commit }}
+          parent: false
+          process_gcloudignore: false
+
+      - name: Upload GCS artifacts (release)
+        id: gcs-upload-release
+        if: ${{ inputs.upload-to-gcs-release-folder == true }}
+        uses: google-github-actions/upload-cloud-storage@v2.2.1
+        with:
+          path: /tmp/dist-artifacts
+          destination: ${{ env.gcs_artifacts_path_release }}
           parent: false
           process_gcloudignore: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,17 +89,6 @@ on:
         type: string
         required: false
 
-      # GCS/provisioned plugins options
-      upload-to-gcs-release-folder:
-        description: |
-          If true, the plugin will be uploaded to the release folder in GCS.
-          (`${GCS_ARTIFACTS_BUCKET}/${PLUGIN_NAME}/release/${VERSION}`).
-          Default is false.
-          This should be true only when calling CI for deployments.
-        required: false
-        type: boolean
-        default: false
-
       # Options for building PRs. Those values should come from the PR event and should not be set manually.
       plugin-version-suffix:
         description: |
@@ -166,7 +155,7 @@ env:
   DEFAULT_GOLANGCI_LINT_VERSION: "1.61.0"
   DEFAULT_TRUFFLEHOG_VERSION: "3.88.1"
 
-  GCS_ARTIFACTS_BUCKET: "integration-artifacts"
+  GCS_ARTIFACTS_BUCKET: integration-artifacts
   VAULT_INSTANCE: ops
 
   IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
@@ -451,59 +440,3 @@ jobs:
           # TODO: remove
           cat "$GITHUB_OUTPUT"
         shell: bash
-
-  # Optional step to upload the plugin to the release folder in GCS.
-  # We need this in a separate job because we use a different folder structure and we need to use a matrix.
-  upload-to-gcs-release:
-    name: Upload GCS artifacts (release)
-    runs-on: ubuntu-latest
-
-    needs:
-      - test-and-build
-      # Depend on "upload-to-gcs" to avoid repeating the if condition for GCS uploads here as well (fork check).
-      - upload-to-gcs
-
-    if: ${{ needs.upload-to-gcs.result == 'success' && inputs.upload-to-gcs-release-folder == true }}
-
-    strategy:
-      matrix:
-        os: [linux, darwin, windows, any]
-
-    steps:
-      - name: Download GitHub artifact
-        uses: actions/download-artifact@v4.1.8
-        with:
-          name: dist-artifacts
-          path: /tmp/dist-artifacts
-
-      - name: Login to Google Cloud
-        uses: google-github-actions/auth@v2.1.7
-        with:
-          workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
-          service_account: github-plugin-ci-workflows@grafanalabs-workload-identity.iam.gserviceaccount.com
-
-      - name: Determine GCS artifacts paths
-        run: |
-          plugin_version='${{ fromJSON(needs.test-and-build.outputs.plugin).version }}'
-          gcs_artifacts_release_base="${{ env.GCS_ARTIFACTS_BUCKET }}/${{ fromJSON(needs.test-and-build.outputs.plugin).id }}/release"
-          echo "gcs_artifacts_release_path_latest=$gcs_artifacts_release_base/latest" >> "$GITHUB_ENV"
-          echo "gcs_artifacts_release_path_tag=$gcs_artifacts_release_base/$plugin_version" >> "$GITHUB_ENV"
-        shell: bash
-
-      - name: Upload GCS release artifact (tag)
-        uses: google-github-actions/upload-cloud-storage@v2.2.1
-        with:
-          path: /tmp/dist-artifacts
-          glob: "*${{ matrix.os }}*"
-          destination: "${{ env.gcs_artifacts_release_path_tag }}/${{ matrix.os }}"
-          parent: false
-          process_gcloudignore: falses
-
-      - name: Upload GCS release artifact (latest)
-        uses: google-github-actions/upload-cloud-storage@v2.2.1
-        with:
-          path: /tmp/dist-artifacts
-          glob: "*${{ matrix.os }}*"
-          destination: "${{ env.gcs_artifacts_release_path_latest }}/${{ matrix.os }}"
-          parent: false
-          process_gcloudignore: falses

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -460,6 +460,7 @@ jobs:
 
     needs:
       - test-and-build
+      # Depend on "upload-to-gcs" to avoid repeating the if condition for GCS uploads here as well (fork check).
       - upload-to-gcs
 
     if: ${{ needs.upload-to-gcs.result == 'success' && inputs.upload-to-gcs-release-folder == true }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,9 +386,11 @@ jobs:
           # Strip the SHA suffix from the version, if present.
           plugin_version="${plugin_version%%+*}"
           gcs_artifacts_base="${{ env.GCS_ARTIFACTS_BUCKET }}/${{ fromJSON(needs.test-and-build.outputs.plugin).id }}"
-          echo "gcs_artifacts_path_latest=$gcs_artifacts_base/$plugin_version/main/latest" >> "$GITHUB_ENV"
-          echo "gcs_artifacts_path_commit=$gcs_artifacts_base/$plugin_version/${{ github.event.pull_request.base.ref || 'main' }}/${{ github.event.pull_request.head.sha || github.sha }}" >> "$GITHUB_ENV"
-          echo "gcs_artifacts_path_release=$gcs_artifacts_base/release/$plugin_version" >> "$GITHUB_ENV"
+          {
+            echo "gcs_artifacts_path_latest=$gcs_artifacts_base/$plugin_version/main/latest"
+            echo "gcs_artifacts_path_commit=$gcs_artifacts_base/$plugin_version/${{ github.event.pull_request.base.ref || 'main' }}/${{ github.event.pull_request.head.sha || github.sha }}"
+            echo "gcs_artifacts_path_release=$gcs_artifacts_base/release/$plugin_version"
+          } >> "$GITHUB_ENV"
         shell: bash
 
       - name: Upload GCS artifacts (latest)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,8 +379,6 @@ jobs:
           service_account: github-plugin-ci-workflows@grafanalabs-workload-identity.iam.gserviceaccount.com
 
       - name: Determine GCS artifacts paths
-        # TODO: for release artifacts: windows, darwin, linux, any
-        #   (https://github.com/grafana/grafana-drone-extension/blob/411172f4e3681acb2e78d2ed0d42ba8e1fc093c7/pluginjson/pipeline-deploy.go#L142-L153)
         run: |
           plugin_version='${{ fromJSON(needs.test-and-build.outputs.plugin).version }}'
           # Strip the SHA suffix from the version, if present.
@@ -389,7 +387,6 @@ jobs:
           {
             echo "gcs_artifacts_path_latest=$gcs_artifacts_base/$plugin_version/main/latest"
             echo "gcs_artifacts_path_commit=$gcs_artifacts_base/$plugin_version/${{ github.event.pull_request.base.ref || 'main' }}/${{ github.event.pull_request.head.sha || github.sha }}"
-            echo "gcs_artifacts_path_release=$gcs_artifacts_base/release/$plugin_version"
           } >> "$GITHUB_ENV"
         shell: bash
 
@@ -409,16 +406,6 @@ jobs:
         with:
           path: /tmp/dist-artifacts
           destination: ${{ env.gcs_artifacts_path_commit }}
-          parent: false
-          process_gcloudignore: false
-
-      - name: Upload GCS artifacts (release)
-        id: gcs-upload-release
-        if: ${{ inputs.upload-to-gcs-release-folder == true }}
-        uses: google-github-actions/upload-cloud-storage@v2.2.1
-        with:
-          path: /tmp/dist-artifacts
-          destination: ${{ env.gcs_artifacts_path_release }}
           parent: false
           process_gcloudignore: false
 
@@ -463,5 +450,44 @@ jobs:
             echo universal_zip_url_latest="$gcs_artifacts_path_latest/$universal_zip_file_name" >> "$GITHUB_OUTPUT"
             echo universal_zip_url_commit="$gcs_artifacts_path_commit/$universal_zip_file_name" >> "$GITHUB_OUTPUT"
           fi
+          # TODO: remove
           cat "$GITHUB_OUTPUT"
         shell: bash
+
+  # Optional step to upload the plugin to the release folder in GCS.
+  # We need this in a separate job because we use a different folder structure and we need to use a matrix.
+  upload-to-gcs-release:
+    name: Upload GCS artifacts (release)
+    runs-on: ubuntu-latest
+
+    needs:
+      - upload-to-gcs
+
+    if: ${{ needs.upload-to-gcs.result == 'success' && inputs.upload-to-gcs-release-folder == true }}
+
+    strategy:
+      matrix:
+        os: [linux, darwin, windows, any]
+
+    steps:
+      - name: Download GitHub artifact
+        uses: actions/download-artifact@v4.1.8
+        with:
+          name: dist-artifacts
+          path: /tmp/dist-artifacts
+
+      - name: Login to Google Cloud
+        uses: google-github-actions/auth@v2.1.7
+        with:
+          workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
+          service_account: github-plugin-ci-workflows@grafanalabs-workload-identity.iam.gserviceaccount.com
+
+      - name: Upload GCS release artifact
+        id: gcs-upload-release
+        uses: google-github-actions/upload-cloud-storage@v2.2.1
+        with:
+          path: /tmp/dist-artifacts
+          glob: "*${{ matrix.os }}*"
+          destination: "${{ env.GCS_ARTIFACTS_BUCKET }}/${{ fromJSON(needs.test-and-build.outputs.plugin).id }}/release/${{ fromJSON(needs.test-and-build.outputs.plugin).version }}"
+          parent: false
+          process_gcloudignore: falses

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,11 +383,9 @@ jobs:
           plugin_version='${{ fromJSON(needs.test-and-build.outputs.plugin).version }}'
           # Strip the SHA suffix from the version, if present.
           plugin_version="${plugin_version%%+*}"
-          gcs_artifacts_base="${{ env.GCS_ARTIFACTS_BUCKET }}/${{ fromJSON(needs.test-and-build.outputs.plugin).id }}"
-          {
-            echo "gcs_artifacts_path_latest=$gcs_artifacts_base/$plugin_version/main/latest"
-            echo "gcs_artifacts_path_commit=$gcs_artifacts_base/$plugin_version/${{ github.event.pull_request.base.ref || 'main' }}/${{ github.event.pull_request.head.sha || github.sha }}"
-          } >> "$GITHUB_ENV"
+          gcs_artifacts_base="${{ env.GCS_ARTIFACTS_BUCKET }}/${{ fromJSON(needs.test-and-build.outputs.plugin).id }}/$plugin_version"
+          echo "gcs_artifacts_path_latest=$gcs_artifacts_base/main/latest" >> "$GITHUB_ENV"
+          echo "gcs_artifacts_path_commit=$gcs_artifacts_base/${{ github.event.pull_request.base.ref || 'main' }}/${{ github.event.pull_request.head.sha || github.sha }}" >> "$GITHUB_ENV"
         shell: bash
 
       - name: Upload GCS artifacts (latest)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -482,12 +482,28 @@ jobs:
           workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
           service_account: github-plugin-ci-workflows@grafanalabs-workload-identity.iam.gserviceaccount.com
 
-      - name: Upload GCS release artifact
-        id: gcs-upload-release
+      - name: Determine GCS artifacts paths
+        run: |
+          plugin_version='${{ fromJSON(needs.test-and-build.outputs.plugin).version }}'
+          gcs_artifacts_release_base="${{ env.GCS_ARTIFACTS_BUCKET }}/${{ fromJSON(needs.test-and-build.outputs.plugin).id }}/release"
+          echo "gcs_artifacts_release_path_latest=$gcs_artifacts_release_base/latest" >> "$GITHUB_ENV"
+          echo "gcs_artifacts_release_path_tag=$gcs_artifacts_release_base/$plugin_version" >> "$GITHUB_ENV"
+        shell: bash
+
+      - name: Upload GCS release artifact (tag)
         uses: google-github-actions/upload-cloud-storage@v2.2.1
         with:
           path: /tmp/dist-artifacts
           glob: "*${{ matrix.os }}*"
-          destination: "${{ env.GCS_ARTIFACTS_BUCKET }}/${{ fromJSON(needs.test-and-build.outputs.plugin).id }}/release/${{ fromJSON(needs.test-and-build.outputs.plugin).version }}"
+          destination: "${{ env.gcs_artifacts_release_path_tag }}/${{ matrix.os }}"
+          parent: false
+          process_gcloudignore: falses
+
+      - name: Upload GCS release artifact (latest)
+        uses: google-github-actions/upload-cloud-storage@v2.2.1
+        with:
+          path: /tmp/dist-artifacts
+          glob: "*${{ matrix.os }}*"
+          destination: "${{ env.gcs_artifacts_release_path_latest }}/${{ matrix.os }}"
           parent: false
           process_gcloudignore: falses

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ on:
       upload-to-gcs-release-folder:
         description: |
           If true, the plugin will be uploaded to the release folder in GCS.
-          (`integration-artifacts/${PLUGIN_NAME}/release/${VERSION}`).
+          (`${GCS_ARTIFACTS_BUCKET}/${PLUGIN_NAME}/release/${VERSION}`).
           Default is false.
           This should be true only when calling CI for deployments.
         required: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -437,6 +437,4 @@ jobs:
             echo universal_zip_url_latest="$gcs_artifacts_path_latest/$universal_zip_file_name" >> "$GITHUB_OUTPUT"
             echo universal_zip_url_commit="$gcs_artifacts_path_commit/$universal_zip_file_name" >> "$GITHUB_OUTPUT"
           fi
-          # TODO: remove
-          cat "$GITHUB_OUTPUT"
         shell: bash


### PR DESCRIPTION
Restores the same behaviour as Drone by uploading files to this folder in GCS, only when deploying:

`gs://integration-artifacts/$${PLUGIN_NAME}/release/$${VERSION}/*`

Drone code: https://github.com/grafana/grafana-drone-extension/blob/411172f4e3681acb2e78d2ed0d42ba8e1fc093c7/pluginjson/pipeline-deploy.go#L142-L153

Example run: https://github.com/grafana/plugins-drone-to-gha/actions/runs/13786876201

Example artifacts folder: https://console.cloud.google.com/storage/browser/integration-artifacts/grafana-datasourcehttpbackendghateststub-datasource/release?inv=1&invt=Abrvaw&project=grafanalabs-global&pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))

Fix #45