### PR TITLE
CD: Fix path for 'latest' artifacts

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -396,8 +396,6 @@ jobs:
           cp -r /tmp/dist-artifacts /tmp/dist-artifacts-latest
           # Replace the version with "latest" in the zip file name
           find /tmp/dist-artifacts-latest -type f -exec bash -c 'mv "$1" "${1//${{ fromJSON(needs.ci.outputs.plugin).version }}/latest}"' _ {} \;
-          # TODO: remove, debug
-          ls -1 /tmp/dist-artifacts-latest
         shell: bash
 
       - name: Login to Google Cloud

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -391,6 +391,15 @@ jobs:
           name: dist-artifacts
           path: /tmp/dist-artifacts
 
+      - name: Prepare "latest" artifacts
+        run: |
+          cp -r /tmp/dist-artifacts /tmp/dist-artifacts-latest
+          # Replace the version with "latest" in the zip file name
+          find /tmp/dist-artifacts-latest -type f -name "*.zip" -exec bash -c 'mv "$1" "${1//${{ fromJSON(needs.ci.outputs.plugin).version }}/latest}"' _ {} \;
+          # TODO: remove, debug
+          ls -1 /tmp/dist-artifacts-latest
+        shell: bash
+
       - name: Login to Google Cloud
         uses: google-github-actions/auth@v2.1.8
         with:
@@ -405,11 +414,14 @@ jobs:
             echo "gcs_artifacts_release_path_latest=$gcs_artifacts_release_base/latest"
             echo "gcs_artifacts_release_path_tag=$gcs_artifacts_release_base/$plugin_version"
             fn=$(basename ${{ needs.ci.outputs.gcs-universal-zip-url-commit }})
+            latest_fn=${fn//${{ fromJSON(needs.ci.outputs.plugin).version }}/latest}
             if [ "${{ matrix.platform }}" == 'any' ]; then
               echo "gcs_upload_glob=$fn*"
+              echo "gcs_upload_glob_latest=$latest_fn*"
             else
               # strip the extension (.zip) and append the platform instead
               echo "gcs_upload_glob=${fn%.*}.${{ matrix.platform }}*"
+              echo "gcs_upload_glob_latest=${latest_fn%.*}.${{ matrix.platform }}*"
             fi
           } >> "$GITHUB_ENV"
         shell: bash
@@ -426,8 +438,8 @@ jobs:
       - name: Upload GCS release artifact (latest)
         uses: google-github-actions/upload-cloud-storage@v2.2.2
         with:
-          path: /tmp/dist-artifacts
-          glob: ${{ env.gcs_upload_glob }}
+          path: /tmp/dist-artifacts-latest
+          glob: ${{ env.gcs_upload_glob_latest }}
           destination: "${{ env.gcs_artifacts_release_path_latest }}/${{ matrix.platform }}"
           parent: false
           process_gcloudignore: false

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -449,7 +449,7 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@v2.2.2
         with:
           path: /tmp/dist-artifacts-latest/${{ fromJSON(needs.ci.outputs.plugin).id }}-latest.zip
-          destination: "${{ steps.paths.outputs.gcs_artifacts_release_base }}"
+          destination: "${{ steps.paths.outputs.gcs_artifacts_release_path_latest }}"
           parent: false
           process_gcloudignore: false
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -395,7 +395,7 @@ jobs:
         run: |
           cp -r /tmp/dist-artifacts /tmp/dist-artifacts-latest
           # Replace the version with "latest" in the zip file name
-          find /tmp/dist-artifacts-latest -type f -name "*.zip" -exec bash -c 'mv "$1" "${1//${{ fromJSON(needs.ci.outputs.plugin).version }}/latest}"' _ {} \;
+          find /tmp/dist-artifacts-latest -type f -exec bash -c 'mv "$1" "${1//${{ fromJSON(needs.ci.outputs.plugin).version }}/latest}"' _ {} \;
           # TODO: remove, debug
           ls -1 /tmp/dist-artifacts-latest
         shell: bash

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -450,8 +450,8 @@ jobs:
         if: ${{ matrix.platform == 'any' }}
         uses: google-github-actions/upload-cloud-storage@v2.2.2
         with:
-          path: /tmp/dist-artifacts-latest/${{ steps.paths.outputs.gcs_upload_glob_latest }}
-          destination: "${{ steps.paths.outputs.gcs_artifacts_release_base }}/${{ fromJSON(needs.ci.outputs.plugin).id }}-latest.zip"
+          path: /tmp/dist-artifacts-latest/${{ fromJSON(needs.ci.outputs.plugin).id }}-latest.zip
+          destination: "${{ steps.paths.outputs.gcs_artifacts_release_base }}"
           parent: false
           process_gcloudignore: false
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -407,31 +407,33 @@ jobs:
           service_account: github-plugin-ci-workflows@grafanalabs-workload-identity.iam.gserviceaccount.com
 
       - name: Determine GCS artifacts paths
+        id: paths
         run: |
           plugin_version='${{ fromJSON(needs.ci.outputs.plugin).version }}'
           gcs_artifacts_release_base="${{ env.GCS_ARTIFACTS_BUCKET }}/${{ fromJSON(needs.ci.outputs.plugin).id }}/release"
           {
+            echo "gcs_artifacts_release_base=$gcs_artifacts_release_base"
             echo "gcs_artifacts_release_path_latest=$gcs_artifacts_release_base/latest"
             echo "gcs_artifacts_release_path_tag=$gcs_artifacts_release_base/$plugin_version"
             fn=$(basename ${{ needs.ci.outputs.gcs-universal-zip-url-commit }})
             latest_fn=${fn//${{ fromJSON(needs.ci.outputs.plugin).version }}/latest}
             if [ "${{ matrix.platform }}" == 'any' ]; then
               echo "gcs_upload_glob=$fn*"
-              echo "gcs_upload_glob_latest=$latest_fn*"
+              echo "gcs_upload_glob_latest=$latest_fn"
             else
               # strip the extension (.zip) and append the platform instead
               echo "gcs_upload_glob=${fn%.*}.${{ matrix.platform }}*"
               echo "gcs_upload_glob_latest=${latest_fn%.*}.${{ matrix.platform }}*"
             fi
-          } >> "$GITHUB_ENV"
+          } >> "$GITHUB_OUTPUT"
         shell: bash
 
       - name: Upload GCS release artifact (tag)
         uses: google-github-actions/upload-cloud-storage@v2.2.2
         with:
           path: /tmp/dist-artifacts
-          glob: ${{ env.gcs_upload_glob }}
-          destination: "${{ env.gcs_artifacts_release_path_tag }}/${{ matrix.platform }}"
+          glob: ${{ steps.paths.outputs.gcs_upload_glob }}
+          destination: "${{ steps.paths.outputs.gcs_artifacts_release_path_tag }}/${{ matrix.platform }}"
           parent: false
           process_gcloudignore: false
 
@@ -439,8 +441,17 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@v2.2.2
         with:
           path: /tmp/dist-artifacts-latest
-          glob: ${{ env.gcs_upload_glob_latest }}
-          destination: "${{ env.gcs_artifacts_release_path_latest }}/${{ matrix.platform }}"
+          glob: ${{ steps.paths.outputs.gcs_upload_glob_latest }}
+          destination: "${{ steps.paths.outputs.gcs_artifacts_release_path_latest }}/${{ matrix.platform }}"
+          parent: false
+          process_gcloudignore: false
+
+      - name: Upload GCS release artifacst (latest, any)
+        if: ${{ matrix.platform == 'any' }}
+        uses: google-github-actions/upload-cloud-storage@v2.2.2
+        with:
+          path: /tmp/dist-artifacts-latest/${{ steps.paths.outputs.gcs_upload_glob_latest }}
+          destination: "${{ steps.paths.outputs.gcs_artifacts_release_base }}/${{ fromJSON(needs.ci.outputs.plugin).id }}-latest.zip"
           parent: false
           process_gcloudignore: false
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -419,7 +419,7 @@ jobs:
             latest_fn=${fn//${{ fromJSON(needs.ci.outputs.plugin).version }}/latest}
             if [ "${{ matrix.platform }}" == 'any' ]; then
               echo "gcs_upload_glob=$fn*"
-              echo "gcs_upload_glob_latest=$latest_fn"
+              echo "gcs_upload_glob_latest=$latest_fn*"
             else
               # strip the extension (.zip) and append the platform instead
               echo "gcs_upload_glob=${fn%.*}.${{ matrix.platform }}*"


### PR DESCRIPTION
Fixes some issues with the "latest" artifacts introduced in #45.

Before, the "latest" artifacts contained the version number in them instead of "latest", this PR fixes it.

Also, it uploads the "any" artifact to the `release/latest`, folder e.g.:

https://storage.googleapis.com/integration-artifacts/grafana-datasourcehttpbackendghateststub-datasource/release/latest/grafana-datasourcehttpbackendghateststub-datasource-latest.zip

Rather than just in `release/latest/any`.

These changes are needed for consistency with the old Drone behaviour.