### PR TITLE
feat: overridable playwright config path and docker-compose path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,6 @@ on:
       playwright-docker-compose-file:
         required: false
         type: string
-        default: docker-compose.yml
         description: Path to the docker-compose file to use for testing
       playwright-config:
         required: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,16 @@ on:
         required: false
         type: boolean
         default: false
+      playwright-docker-compose-file:
+        required: false
+        type: string
+        default: docker-compose.yml
+        description: Path to the docker-compose file to use for testing
+      playwright-config:
+        required: false
+        type: string
+        default: playwright.config.ts
+        description: Path to the Playwright config file to use for testing
 
       # Trufflehog
       run-trufflehog:
@@ -331,6 +341,8 @@ jobs:
       skip-grafana-dev-image: ${{ inputs.run-playwright-with-skip-grafana-dev-image }}
       version-resolver-type: ${{ inputs.run-playwright-with-version-resolver-type }}
       upload-artifacts: ${{ inputs.upload-playwright-artifacts }}
+      docker-compose-file: ${{ inputs.playwright-docker-compose-file }}
+      playwright-config: ${{ inputs.playwright-config }}
 
   upload-to-gcs:
     name: Upload to GCS

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -40,7 +40,7 @@ on:
         required: false
         type: string
         default: playwright.config.ts
-        description: Path to the Playwright config file to use for testing
+        description: Path to the docker-compose file(s) to use for testing. Can be a single file or comma-separated list of files.
 
 permissions:
   contents: read

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -31,6 +31,16 @@ on:
         required: false
         type: boolean
         default: false
+      docker-compose-file:
+        required: false
+        type: string
+        default: docker-compose.yml
+        description: Path to the docker-compose file to use for testing
+      playwright-config:
+        required: false
+        type: string
+        default: playwright.config.ts
+        description: Path to the Playwright config file to use for testing
 
 permissions:
   contents: read
@@ -106,15 +116,15 @@ jobs:
 
       - name: Start Grafana
         run: |
-          docker compose pull
-          GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose up -d
+          docker compose -f ${{ inputs.docker-compose-file }} pull
+          GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose -f ${{ inputs.docker-compose-file }} up -d
 
       - name: Wait for Grafana to start
         uses: grafana/plugin-actions/wait-for-grafana@main
 
       - name: Run Playwright tests
         id: run-tests
-        run: npx playwright test
+        run: npx playwright test --config ${{ inputs.playwright-config }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4.6.1

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -116,8 +116,13 @@ jobs:
 
       - name: Start Grafana
         run: |
-          docker compose -f ${{ inputs.docker-compose-file }} pull
-          GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose -f ${{ inputs.docker-compose-file }} up -d
+          if [ -n "${{ inputs.docker-compose-file }}" ]; then
+            docker compose -f ${{ inputs.docker-compose-file }} pull
+            GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose -f ${{ inputs.docker-compose-file }} up -d
+          else
+            docker compose pull
+            GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose up -d
+          fi
 
       - name: Wait for Grafana to start
         uses: grafana/plugin-actions/wait-for-grafana@main


### PR DESCRIPTION
## Summary

- Backwards compatible.
- Adds `playwright-docker-compose-file` and `playwright-config` options to the `ci.yml` workflow
- Adds `playwright-config` and `docker-compose-file` options to the `playwright.yml` workflow
- Allows for provided docker compose path and playwright config path to the runner

This allows a bit more customization for the e2e flows for the metrics drilldown squad as described in this living document:

https://docs.google.com/document/d/1f7_VRmp2PXWLgYnLorQD6tRfeEH74_U588NnKfTrHvs/edit?pli=1&tab=t.0

Unblocks: https://github.com/grafana/metrics-drilldown/pull/171