### PR TITLE
Custom docker / playwright paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,14 +73,6 @@ on:
         type: string
         default: playwright.config.ts
         description: Path to the Playwright config file to use for testing
-      playwright-docker-prepare-command:
-        required: false
-        type: string
-        description: Custom npm command to prepare Playwright environment in a container. If provided, run-playwright-with-command must also be provided.
-      playwright-docker-run-command:
-        required: false
-        type: string
-        description: Custom command to run Playwright tests in a container. Must be provided if run-playwright-with-prepare is used.
 
       # Trufflehog
       run-trufflehog:
@@ -362,8 +354,6 @@ jobs:
       upload-artifacts: ${{ inputs.upload-playwright-artifacts }}
       docker-compose-file: ${{ inputs.playwright-docker-compose-file }}
       playwright-config: ${{ inputs.playwright-config }}
-      dockerized-playwright-prepare: ${{ inputs.playwright-docker-prepare-command }}
-      dockerized-playwright-command: ${{ inputs.playwright-docker-run-command }}
 
   upload-to-gcs:
     name: Upload to GCS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,16 @@ jobs:
           vault_instance: ${{ env.VAULT_INSTANCE }}
           common_secrets: |
             SIGN_PLUGIN_ACCESS_POLICY_TOKEN=plugins/sign-plugin-access-policy-token:token
+            GITHUB_APP_ID=plugins-platform-bot-app:app-id
+            GITHUB_APP_PRIVATE_KEY=plugins-platform-bot-app:private-key
+
+      - name: Generate GitHub token
+        id: generate-github-token
+        uses: actions/create-github-app-token@v1.11.5
+        with:
+          app-id: ${{ env.GITHUB_APP_ID }}
+          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Spellcheck
         run: |
@@ -244,6 +254,8 @@ jobs:
       - name: Test and build backend
         if: ${{ steps.check-for-backend.outputs.has-backend == 'true' }}
         uses: grafana/plugin-ci-workflows/actions/plugins/backend@main
+        with:
+          github-token: ${{ steps.generate-github-token.outputs.token }}
 
       - name: Package universal ZIP
         id: universal-zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,6 @@ on:
       playwright-docker-compose-file:
         required: false
         type: string
-        default: docker-compose.yml
         description: Path to the docker-compose file to use for testing
       playwright-config:
         required: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,14 @@ on:
         type: string
         default: playwright.config.ts
         description: Path to the Playwright config file to use for testing
+      playwright-docker-prepare-command:
+        required: false
+        type: string
+        description: Custom npm command to prepare Playwright environment in a container. If provided, run-playwright-with-command must also be provided.
+      playwright-docker-run-command:
+        required: false
+        type: string
+        description: Custom command to run Playwright tests in a container. Must be provided if run-playwright-with-prepare is used.
 
       # Trufflehog
       run-trufflehog:
@@ -342,6 +350,8 @@ jobs:
       upload-artifacts: ${{ inputs.upload-playwright-artifacts }}
       docker-compose-file: ${{ inputs.playwright-docker-compose-file }}
       playwright-config: ${{ inputs.playwright-config }}
+      dockerized-playwright-prepare: ${{ inputs.playwright-docker-prepare-command }}
+      dockerized-playwright-command: ${{ inputs.playwright-docker-run-command }}
 
   upload-to-gcs:
     name: Upload to GCS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,16 @@ on:
         required: false
         type: boolean
         default: false
+      playwright-docker-compose-file:
+        required: false
+        type: string
+        default: docker-compose.yml
+        description: Path to the docker-compose file to use for testing
+      playwright-config:
+        required: false
+        type: string
+        default: playwright.config.ts
+        description: Path to the Playwright config file to use for testing
 
       # Trufflehog
       run-trufflehog:
@@ -331,6 +341,8 @@ jobs:
       skip-grafana-dev-image: ${{ inputs.run-playwright-with-skip-grafana-dev-image }}
       version-resolver-type: ${{ inputs.run-playwright-with-version-resolver-type }}
       upload-artifacts: ${{ inputs.upload-playwright-artifacts }}
+      docker-compose-file: ${{ inputs.playwright-docker-compose-file }}
+      playwright-config: ${{ inputs.playwright-config }}
 
   upload-to-gcs:
     name: Upload to GCS

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -34,7 +34,6 @@ on:
       docker-compose-file:
         required: false
         type: string
-        default: docker-compose.yml
         description: Path to the docker-compose file to use for testing
       playwright-config:
         required: false

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -154,14 +154,15 @@ jobs:
       - name: Wait for Grafana to start
         uses: grafana/plugin-actions/wait-for-grafana@main
 
+      - name: Run Dockerized Playwright tests
+        if: ${{ inputs.dockerized-playwright-command }}
+        id: run-tests-in-container
+        run: ${{ inputs.dockerized-playwright-command }}
+
       - name: Run Playwright tests
+        if: ${{ !inputs.dockerized-playwright-command }}
         id: run-tests
-        run: |
-          if [ -n "${{ inputs.dockerized-playwright-command }}" ]; then
-            ${{ inputs.dockerized-playwright-command }}
-          else
-            npx playwright test --config ${{ inputs.playwright-config }}
-          fi
+        run: npx playwright test --config ${{ inputs.playwright-config }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4.6.1

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -116,10 +116,8 @@ jobs:
       - name: Start Grafana
         # add the -f argument only if "inputs.docker-compose-file" is defined
         run: |
-          dcf="${{ inputs.docker-compose-file }}"
-          dc="docker compose ${dcf:+-f "$dcf"}"
-          dc pull
-          GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} $dc up -d
+         dcf="${{ inputs.docker-compose-file }}"
+         GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose ${dcf:+-f "$dcf"} up -d
 
       - name: Wait for Grafana to start
         uses: grafana/plugin-actions/wait-for-grafana@main

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -141,15 +141,17 @@ jobs:
           cd "$(ls -1)"
           mv ./* "$src/dist/"
 
-      - name: Start Grafana
+      - name: Start Grafana Custom Location
+        if: ${{ inputs.docker-compose-file }}
         run: |
-          if [ -n "${{ inputs.docker-compose-file }}" ]; then
-            docker compose -f ${{ inputs.docker-compose-file }} pull
-            GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose -f ${{ inputs.docker-compose-file }} up -d
-          else
-            docker compose pull
-            GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose up -d
-          fi
+          docker compose -f ${{ inputs.docker-compose-file }} pull
+          GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose -f ${{ inputs.docker-compose-file }} up -d
+
+      - name: Start Grafana
+        if: ${{ !inputs.docker-compose-file }}
+        run: |
+          docker compose pull
+          GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose up -d
 
       - name: Wait for Grafana to start
         uses: grafana/plugin-actions/wait-for-grafana@main

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -141,17 +141,13 @@ jobs:
           cd "$(ls -1)"
           mv ./* "$src/dist/"
 
-      - name: Start Grafana Custom Location
-        if: ${{ inputs.docker-compose-file }}
-        run: |
-          docker compose -f ${{ inputs.docker-compose-file }} pull
-          GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose -f ${{ inputs.docker-compose-file }} up -d
-
       - name: Start Grafana
-        if: ${{ !inputs.docker-compose-file }}
+        # add the -f argument only if "inputs.docker-compose-file" is defined
         run: |
-          docker compose pull
-          GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose up -d
+          $dcf="${{ inputs.docker-compose-file }}"
+          $dc="docker compose ${dcf:+-f "$dcf"}"
+          $dc pull
+          GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} $dc up -d
 
       - name: Wait for Grafana to start
         uses: grafana/plugin-actions/wait-for-grafana@main

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -40,7 +40,7 @@ on:
         required: false
         type: string
         default: playwright.config.ts
-        description: Path to the docker-compose file(s) to use for testing. Can be a single file or comma-separated list of files.
+        description: Path to the Playwright config file to use for testing
       dockerized-playwright-prepare:
         required: false
         type: string

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -40,14 +40,6 @@ on:
         type: string
         default: playwright.config.ts
         description: Path to the Playwright config file to use for testing
-      dockerized-playwright-prepare:
-        required: false
-        type: string
-        description: Custom npm command to prepare Playwright environment in a container. If provided, dockerized-playwright-command must also be provided.
-      dockerized-playwright-command:
-        required: false
-        type: string
-        description: Custom command to run Playwright tests in a container. Must be provided if dockerized-playwright-prepare is used.
 
 permissions:
   contents: read
@@ -84,26 +76,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
 
-      - name: Validate dockerized inputs
-        if: ${{ inputs.dockerized-playwright-prepare || inputs.dockerized-playwright-command }}
-        run: |
-          if [ -n "${{ inputs.dockerized-playwright-prepare }}" ] && [ -z "${{ inputs.dockerized-playwright-command }}" ]; then
-            echo "Error: dockerized-playwright-command must be provided when using dockerized-playwright-prepare"
-            exit 1
-          fi
-          if [ -z "${{ inputs.dockerized-playwright-prepare }}" ] && [ -n "${{ inputs.dockerized-playwright-command }}" ]; then
-            echo "Error: dockerized-playwright-prepare must be provided when using dockerized-playwright-command"
-            exit 1
-          fi
-
       - name: Setup Node.js environment
-        if: ${{ !inputs.dockerized-playwright-prepare }}
         uses: actions/setup-node@v4.2.0
         with:
           node-version-file: .nvmrc
 
       - name: Install npm dependencies
-        if: ${{ !inputs.dockerized-playwright-prepare }}
         # TODO: find a better way
         run: |
           if [ -f yarn.lock ]; then
@@ -114,12 +92,7 @@ jobs:
         shell: bash
 
       - name: Install Playwright Browsers
-        if: ${{ !inputs.dockerized-playwright-prepare }}
         run: npx playwright install --with-deps chromium
-
-      - name: Prepare Playwright environment in container
-        if: ${{ inputs.dockerized-playwright-prepare }}
-        run: ${{ inputs.dockerized-playwright-prepare }}
 
       - name: Download GitHub artifact
         uses: actions/download-artifact@v4.1.9
@@ -151,13 +124,7 @@ jobs:
       - name: Wait for Grafana to start
         uses: grafana/plugin-actions/wait-for-grafana@main
 
-      - name: Run Dockerized Playwright tests
-        if: ${{ inputs.dockerized-playwright-command }}
-        id: run-tests-in-container
-        run: ${{ inputs.dockerized-playwright-command }}
-
       - name: Run Playwright tests
-        if: ${{ !inputs.dockerized-playwright-command }}
         id: run-tests
         run: npx playwright test --config ${{ inputs.playwright-config }}
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -116,9 +116,9 @@ jobs:
       - name: Start Grafana
         # add the -f argument only if "inputs.docker-compose-file" is defined
         run: |
-          $dcf="${{ inputs.docker-compose-file }}"
-          $dc="docker compose ${dcf:+-f "$dcf"}"
-          $dc pull
+          dcf="${{ inputs.docker-compose-file }}"
+          dc="docker compose ${dcf:+-f "$dcf"}"
+          dc pull
           GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} $dc up -d
 
       - name: Wait for Grafana to start

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -40,7 +40,7 @@ on:
         required: false
         type: string
         default: playwright.config.ts
-        description: Path to the Playwright config file to use for testing
+        description: Path to the docker-compose file(s) to use for testing. Can be a single file or comma-separated list of files.
 
 permissions:
   contents: read

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -44,7 +44,11 @@ on:
       dockerized-playwright-prepare:
         required: false
         type: string
-        description: Custom npm command to prepare Playwright environment in a container. If provided, skips Node.js setup steps.
+        description: Custom npm command to prepare Playwright environment in a container. If provided, dockerized-playwright-command must also be provided.
+      dockerized-playwright-command:
+        required: false
+        type: string
+        description: Custom command to run Playwright tests in a container. Must be provided if dockerized-playwright-prepare is used.
 
 permissions:
   contents: read
@@ -80,6 +84,18 @@ jobs:
     runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@v4.2.2
+
+      - name: Validate dockerized inputs
+        if: ${{ inputs.dockerized-playwright-prepare || inputs.dockerized-playwright-command }}
+        run: |
+          if [ -n "${{ inputs.dockerized-playwright-prepare }}" ] && [ -z "${{ inputs.dockerized-playwright-command }}" ]; then
+            echo "Error: dockerized-playwright-command must be provided when using dockerized-playwright-prepare"
+            exit 1
+          fi
+          if [ -z "${{ inputs.dockerized-playwright-prepare }}" ] && [ -n "${{ inputs.dockerized-playwright-command }}" ]; then
+            echo "Error: dockerized-playwright-prepare must be provided when using dockerized-playwright-command"
+            exit 1
+          fi
 
       - name: Setup Node.js environment
         if: ${{ !inputs.dockerized-playwright-prepare }}
@@ -140,7 +156,12 @@ jobs:
 
       - name: Run Playwright tests
         id: run-tests
-        run: npx playwright test --config ${{ inputs.playwright-config }}
+        run: |
+          if [ -n "${{ inputs.dockerized-playwright-command }}" ]; then
+            ${{ inputs.dockerized-playwright-command }}
+          else
+            npx playwright test --config ${{ inputs.playwright-config }}
+          fi
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4.6.1

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -31,6 +31,16 @@ on:
         required: false
         type: boolean
         default: false
+      docker-compose-file:
+        required: false
+        type: string
+        default: docker-compose.yml
+        description: Path to the docker-compose file to use for testing
+      playwright-config:
+        required: false
+        type: string
+        default: playwright.config.ts
+        description: Path to the Playwright config file to use for testing
 
 permissions:
   contents: read
@@ -106,15 +116,15 @@ jobs:
 
       - name: Start Grafana
         run: |
-          docker compose pull
-          GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose up -d
+          docker compose -f ${{ inputs.docker-compose-file }} pull
+          GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose -f ${{ inputs.docker-compose-file }} up -d
 
       - name: Wait for Grafana to start
         uses: grafana/plugin-actions/wait-for-grafana@main
 
       - name: Run Playwright tests
         id: run-tests
-        run: npx playwright test
+        run: npx playwright test --config ${{ inputs.playwright-config }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4.6.1

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -41,6 +41,10 @@ on:
         type: string
         default: playwright.config.ts
         description: Path to the docker-compose file(s) to use for testing. Can be a single file or comma-separated list of files.
+      dockerized-playwright-prepare:
+        required: false
+        type: string
+        description: Custom npm command to prepare Playwright environment in a container. If provided, skips Node.js setup steps.
 
 permissions:
   contents: read
@@ -78,11 +82,13 @@ jobs:
       - uses: actions/checkout@v4.2.2
 
       - name: Setup Node.js environment
+        if: ${{ !inputs.dockerized-playwright-prepare }}
         uses: actions/setup-node@v4.2.0
         with:
           node-version-file: .nvmrc
 
       - name: Install npm dependencies
+        if: ${{ !inputs.dockerized-playwright-prepare }}
         # TODO: find a better way
         run: |
           if [ -f yarn.lock ]; then
@@ -93,7 +99,12 @@ jobs:
         shell: bash
 
       - name: Install Playwright Browsers
+        if: ${{ !inputs.dockerized-playwright-prepare }}
         run: npx playwright install --with-deps chromium
+
+      - name: Prepare Playwright environment in container
+        if: ${{ inputs.dockerized-playwright-prepare }}
+        run: ${{ inputs.dockerized-playwright-prepare }}
 
       - name: Download GitHub artifact
         uses: actions/download-artifact@v4.1.9

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -116,8 +116,13 @@ jobs:
 
       - name: Start Grafana
         run: |
-          docker compose -f ${{ inputs.docker-compose-file }} pull
-          GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose -f ${{ inputs.docker-compose-file }} up -d
+          if [ -n "${{ inputs.docker-compose-file }}" ]; then
+            docker compose -f ${{ inputs.docker-compose-file }} pull
+            GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose -f ${{ inputs.docker-compose-file }} up -d
+          else
+            docker compose pull
+            GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose up -d
+          fi
 
       - name: Wait for Grafana to start
         uses: grafana/plugin-actions/wait-for-grafana@main

--- a/actions/plugins/backend/action.yml
+++ b/actions/plugins/backend/action.yml
@@ -1,9 +1,18 @@
 name: Plugins - Backend - Test and build
 description: Tests, lints and builds the backend.
 
+inputs:
+  github-token:
+    description: GitHub token for downloading dependencies from private repos, if necessary
+    required: true
+
 runs:
   using: composite
   steps:
+    - name: Config git to use GitHub token
+      run: git config --global url."https://oauth2:${{ inputs.github-token }}@github.com/".insteadOf "https://github.com/"
+      shell: bash
+
     - name: Install dependencies
       run: go mod download
       shell: bash


### PR DESCRIPTION
- Backwards compatible.
- Adds `playwright-docker-compose-file` and `playwright-config` options to the `ci.yml` workflow
- Adds `playwright-config` and `docker-compose-file` options to the `playwright.yml` workflow
- Allows for provided docker compose path and playwright config path to the runner

This allows a bit more customization for the e2e flows for the metrics drilldown squad as described in this living document:

https://docs.google.com/document/d/1f7_VRmp2PXWLgYnLorQD6tRfeEH74_U588NnKfTrHvs/edit?pli=1&tab=t.0

Unblocks: https://github.com/grafana/metrics-drilldown/pull/171