### PR TITLE
Add support for go dependencies on private repositories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,16 @@ jobs:
           vault_instance: ${{ env.VAULT_INSTANCE }}
           common_secrets: |
             SIGN_PLUGIN_ACCESS_POLICY_TOKEN=plugins/sign-plugin-access-policy-token:token
+            GITHUB_APP_ID=plugins-platform-bot-app:app-id
+            GITHUB_APP_PRIVATE_KEY=plugins-platform-bot-app:private-key
+
+      - name: Generate GitHub token
+        id: generate-github-token
+        uses: actions/create-github-app-token@v1.11.5
+        with:
+          app-id: ${{ env.GITHUB_APP_ID }}
+          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Spellcheck
         run: |
@@ -227,6 +237,8 @@ jobs:
       - name: Test and build backend
         if: ${{ steps.check-for-backend.outputs.has-backend == 'true' }}
         uses: grafana/plugin-ci-workflows/actions/plugins/backend@main
+        with:
+          github-token: ${{ steps.generate-github-token.outputs.token }}
 
       - name: Package universal ZIP
         id: universal-zip

--- a/actions/plugins/backend/action.yml
+++ b/actions/plugins/backend/action.yml
@@ -1,9 +1,18 @@
 name: Plugins - Backend - Test and build
 description: Tests, lints and builds the backend.
 
+inputs:
+  github-token:
+    description: GitHub token for downloading dependencies from private repos, if necessary
+    required: true
+
 runs:
   using: composite
   steps:
+    - name: Config git to use GitHub token
+      run: git config --global url."https://oauth2:${{ inputs.github-token }}@github.com/".insteadOf "https://github.com/"
+      shell: bash
+
     - name: Install dependencies
       run: go mod download
       shell: bash


### PR DESCRIPTION
This PR adds support for Go plugins that have dependencies on private GitHub repositories. It enables the CI workflow to access and download Go modules from private repositories during the build process.
