### PR TITLE
Chore: Bump setup-node and setup-go in setup action, pin their versions

### DIFF
--- a/actions/plugins/setup/action.yml
+++ b/actions/plugins/setup/action.yml
@@ -16,12 +16,12 @@ runs:
   using: composite
   steps:
     - name: Node
-      uses: actions/setup-node@v4.1.0
+      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
       with:
         node-version: "${{ inputs.node-version }}"
 
     - name: Go
-      uses: actions/setup-go@v5.1.0
+      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
       with:
         go-version: "${{ inputs.go-version }}"
 


### PR DESCRIPTION
Follow-up to https://github.com/grafana/plugin-ci-workflows/pull/60 for the re-usable "setup" action.

It also bumps the `setup-node` and `setup-go` actions used in the re-usable action because they were not scanned by dependabot.