### PR TITLE
feat: dockerized playwright tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ on:
         description: The URL where Grafana is available at when running Playwright tests
         type: string
         required: false
-        default: "http://localhost:3000/"
+        default: http://localhost:3000/
 
       # Trufflehog
       run-trufflehog:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,11 @@ on:
         required: false
         type: boolean
         default: false
+      playwright-report-path:
+        required: false
+        type: string
+        description: Path to the folder to use to upload the artifacts
+        default: playwright-report/
       playwright-docker-compose-file:
         required: false
         type: string
@@ -82,11 +87,6 @@ on:
         required: false
         type: string
         description: Path to the playwright docker-compose file
-      playwright-report-path:
-        required: false
-        type: string
-        description: Path to the folder to use to upload the artifacts
-        default: playwright-report/
       grafana-url:
         description: The URL where Grafana is available at when running Playwright tests
         type: string
@@ -363,7 +363,6 @@ jobs:
     if: ${{ inputs.run-playwright == true }}
     needs:
       - test-and-build
-
     with:
       id: ${{ fromJSON(needs.test-and-build.outputs.plugin).id}}
       version: ${{ fromJSON(needs.test-and-build.outputs.plugin).version}}
@@ -373,6 +372,8 @@ jobs:
       upload-artifacts: ${{ inputs.upload-playwright-artifacts }}
       docker-compose-file: ${{ inputs.playwright-docker-compose-file }}
       playwright-config: ${{ inputs.playwright-config }}
+      report-path: ${{ inputs.playwright-report-path }}
+      grafana-url: ${{ inputs.grafana-url }}
 
   playwright-docker:
     name: Plugins - Dockerized Playwright E2E tests
@@ -380,7 +381,6 @@ jobs:
     if: ${{ inputs.run-playwright-docker == true }}
     needs:
       - test-and-build
-
     with:
       id: ${{ fromJSON(needs.test-and-build.outputs.plugin).id}}
       version: ${{ fromJSON(needs.test-and-build.outputs.plugin).version}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,11 @@ on:
         type: boolean
         required: false
         default: true
+      run-playwright-docker:
+        description: Whether to run dockerized Playwright E2E tests.
+        type: boolean
+        required: false
+        default: false
       # https://github.com/grafana/plugin-actions/blob/main/e2e-version/action.yml
       run-playwright-with-grafana-dependency:
         description: "Optionally, use this input to pass a semver range of supported Grafana versions to test against. This is only used when version-resolver-type is plugin-grafana-dependency. If not provided, the action will try to read grafanaDependency from the plugin.json file."
@@ -73,6 +78,10 @@ on:
         type: string
         default: playwright.config.ts
         description: Path to the Playwright config file to use for testing
+      e2e-compose-file:
+        required: false
+        type: string
+        description: Path to the playwright docker-compose file
 
       # Trufflehog
       run-trufflehog:
@@ -354,6 +363,23 @@ jobs:
       upload-artifacts: ${{ inputs.upload-playwright-artifacts }}
       docker-compose-file: ${{ inputs.playwright-docker-compose-file }}
       playwright-config: ${{ inputs.playwright-config }}
+
+  playwright-docker:
+    name: Plugins - Dockerized Playwright E2E tests
+    uses: grafana/plugin-ci-workflows/.github/workflows/playwright-docker.yml@main
+    if: ${{ inputs.run-playwright-docker == true }}
+    needs:
+      - test-and-build
+
+    with:
+      id: ${{ fromJSON(needs.test-and-build.outputs.plugin).id}}
+      version: ${{ fromJSON(needs.test-and-build.outputs.plugin).version}}
+      grafana-dependency: ${{ inputs.run-playwright-with-grafana-dependency }}
+      skip-grafana-dev-image: ${{ inputs.run-playwright-with-skip-grafana-dev-image }}
+      version-resolver-type: ${{ inputs.run-playwright-with-version-resolver-type }}
+      upload-artifacts: ${{ inputs.upload-playwright-artifacts }}
+      grafana-compose-file: ${{ inputs.playwright-docker-compose-file }}
+      playwright-compose-file: ${{ inputs.e2e-compose-file }}
 
   upload-to-gcs:
     name: Upload to GCS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ on:
         required: false
         type: string
         description: Path to the playwright docker-compose file
-      grafana-url:
+      playwright-grafana-url:
         description: The URL where Grafana is available at when running Playwright tests
         type: string
         required: false
@@ -373,7 +373,7 @@ jobs:
       docker-compose-file: ${{ inputs.playwright-docker-compose-file }}
       playwright-config: ${{ inputs.playwright-config }}
       report-path: ${{ inputs.playwright-report-path }}
-      grafana-url: ${{ inputs.grafana-url }}
+      grafana-url: ${{ inputs.playwright-grafana-url }}
 
   playwright-docker:
     name: Plugins - Dockerized Playwright E2E tests
@@ -391,7 +391,7 @@ jobs:
       grafana-compose-file: ${{ inputs.playwright-docker-compose-file }}
       playwright-compose-file: ${{ inputs.e2e-compose-file }}
       report-path: ${{ inputs.playwright-report-path }}
-      grafana-url: ${{ inputs.grafana-url }}
+      grafana-url: ${{ inputs.playwright-grafana-url }}
 
   upload-to-gcs:
     name: Upload to GCS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ on:
         type: string
         default: playwright.config.ts
         description: Path to the Playwright config file to use for testing
-      e2e-compose-file:
+      playwright-e2e-docker-compose-file:
         required: false
         type: string
         description: Path to the playwright docker-compose file
@@ -389,7 +389,7 @@ jobs:
       version-resolver-type: ${{ inputs.run-playwright-with-version-resolver-type }}
       upload-artifacts: ${{ inputs.upload-playwright-artifacts }}
       grafana-compose-file: ${{ inputs.playwright-docker-compose-file }}
-      playwright-compose-file: ${{ inputs.e2e-compose-file }}
+      playwright-compose-file: ${{ inputs.playwright-e2e-docker-compose-file }}
       report-path: ${{ inputs.playwright-report-path }}
       grafana-url: ${{ inputs.playwright-grafana-url }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,11 @@ on:
         required: false
         type: string
         description: Path to the playwright docker-compose file
+      playwright-report-path:
+        required: false
+        type: string
+        description: Path to the folder to use to upload the artifacts
+        default: playwright-report/
 
       # Trufflehog
       run-trufflehog:
@@ -380,6 +385,7 @@ jobs:
       upload-artifacts: ${{ inputs.upload-playwright-artifacts }}
       grafana-compose-file: ${{ inputs.playwright-docker-compose-file }}
       playwright-compose-file: ${{ inputs.e2e-compose-file }}
+      report-path: ${{ inputs.playwright-report-path }}
 
   upload-to-gcs:
     name: Upload to GCS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,11 @@ on:
         type: string
         description: Path to the folder to use to upload the artifacts
         default: playwright-report/
+      grafana-url:
+        description: "The URL to check"
+        type: string
+        required: false
+        default: "http://localhost:3000/"
 
       # Trufflehog
       run-trufflehog:
@@ -386,6 +391,7 @@ jobs:
       grafana-compose-file: ${{ inputs.playwright-docker-compose-file }}
       playwright-compose-file: ${{ inputs.e2e-compose-file }}
       report-path: ${{ inputs.playwright-report-path }}
+      grafana-url: ${{ inputs.grafana-url }}
 
   upload-to-gcs:
     name: Upload to GCS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,14 @@ on:
         default: false
       # https://github.com/grafana/plugin-actions/blob/main/e2e-version/action.yml
       run-playwright-with-grafana-dependency:
-        description: "Optionally, use this input to pass a semver range of supported Grafana versions to test against. This is only used when version-resolver-type is plugin-grafana-dependency. If not provided, the action will try to read grafanaDependency from the plugin.json file."
+        description: |
+          Optionally, use this input to pass a semver range of supported Grafana versions to test against.
+          This is only used when version-resolver-type is plugin-grafana-dependency.
+          If not provided, the action will try to read grafanaDependency from the plugin.json file.
         type: string
         required: false
       run-playwright-with-skip-grafana-dev-image:
-        description: "Optionally, you can skip the Grafana dev image"
+        description: Optionally, you can skip the Grafana dev image
         type: boolean
         required: false
         default: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ on:
         description: Path to the folder to use to upload the artifacts
         default: playwright-report/
       grafana-url:
-        description: "The URL to check"
+        description: The URL where Grafana is available at when running Playwright tests
         type: string
         required: false
         default: "http://localhost:3000/"

--- a/.github/workflows/playwright-docker.yml
+++ b/.github/workflows/playwright-docker.yml
@@ -49,7 +49,7 @@ on:
       grafana-url:
         description: "The URL to check"
         type: string
-        required: true
+        required: false
         default: "http://localhost:3000/"
 
 permissions:

--- a/.github/workflows/playwright-docker.yml
+++ b/.github/workflows/playwright-docker.yml
@@ -119,7 +119,7 @@ jobs:
 
       - name: Run Playwright tests
         id: run-tests
-        run: docker compose -f ${{ inputs.playwright-compose-file }} up
+        run: docker compose -f ${{ inputs.playwright-compose-file }} up --exit-code-from playwright
 
       - name: Upload artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/playwright-docker.yml
+++ b/.github/workflows/playwright-docker.yml
@@ -1,7 +1,8 @@
 # Description:
 # Run Dockerized Playwright E2E tests for the plugin.
 # The plugin must be built via the "ci" workflow and available as a GitHub artifact before running this workflow.
-# make sure your docker
+# make sure your docker volume maps to the `report-path` for your artifacts to be uploaded.
+# eg e2e:/app/e2e
 
 name: Plugins - Dockerized Playwright E2E tests
 

--- a/.github/workflows/playwright-docker.yml
+++ b/.github/workflows/playwright-docker.yml
@@ -83,7 +83,7 @@ jobs:
       fail-fast: false
       matrix:
         GRAFANA_IMAGE: ${{fromJson(needs.resolve-versions.outputs.matrix)}}
-    name: e2e ${r{ matrix.GRAFANA_IMAGE.name }}@${{ matrix.GRAFANA_IMAGE.VERSION }}
+    name: e2e ${{ matrix.GRAFANA_IMAGE.name }}@${{ matrix.GRAFANA_IMAGE.VERSION }}
     runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/playwright-docker.yml
+++ b/.github/workflows/playwright-docker.yml
@@ -48,10 +48,10 @@ on:
         description: Path to the folder to use to upload the artifacts
         default: playwright-report/
       grafana-url:
-        description: "The URL to check"
+        description: The URL to check
         type: string
         required: false
-        default: "http://localhost:3000/"
+        default: http://localhost:3000/
 
 permissions:
   contents: read

--- a/.github/workflows/playwright-docker.yml
+++ b/.github/workflows/playwright-docker.yml
@@ -1,6 +1,7 @@
 # Description:
 # Run Dockerized Playwright E2E tests for the plugin.
 # The plugin must be built via the "ci" workflow and available as a GitHub artifact before running this workflow.
+# make sure your docker
 
 name: Plugins - Dockerized Playwright E2E tests
 
@@ -40,6 +41,11 @@ on:
         type: string
         description: Path to the docker-compose file to use for testing
         default: docker-compose.playwright.yaml
+      report-path:
+        required: false
+        type: string
+        description: Path to the folder to use to upload the artifacts
+        default: playwright-report/
 
 permissions:
   contents: read
@@ -71,7 +77,7 @@ jobs:
       fail-fast: false
       matrix:
         GRAFANA_IMAGE: ${{fromJson(needs.resolve-versions.outputs.matrix)}}
-    name: e2e ${{ matrix.GRAFANA_IMAGE.name }}@${{ matrix.GRAFANA_IMAGE.VERSION }}
+    name: e2e ${r{ matrix.GRAFANA_IMAGE.name }}@${{ matrix.GRAFANA_IMAGE.VERSION }}
     runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -118,5 +124,5 @@ jobs:
         if: ${{ (inputs.upload-artifacts == true) && ((always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure')) }}
         with:
           name: playwright-report-${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}
-          path: playwright-report/
+          path: ${{ inputs.report-path }}
           retention-days: 30

--- a/.github/workflows/playwright-docker.yml
+++ b/.github/workflows/playwright-docker.yml
@@ -82,11 +82,6 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Setup Node.js environment
-        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
-        with:
-          node-version-file: .nvmrc
-
       - name: Download GitHub artifact
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:

--- a/.github/workflows/playwright-docker.yml
+++ b/.github/workflows/playwright-docker.yml
@@ -1,0 +1,122 @@
+# Description:
+# Run Dockerized Playwright E2E tests for the plugin.
+# The plugin must be built via the "ci" workflow and available as a GitHub artifact before running this workflow.
+
+name: Plugins - Dockerized Playwright E2E tests
+
+on:
+  workflow_call:
+    inputs:
+      id:
+        description: Plugin ID
+        type: string
+        required: true
+      version:
+        description: Plugin version
+        type: string
+        required: true
+      # https://github.com/grafana/plugin-actions/blob/main/e2e-version/action.yml
+      skip-grafana-dev-image:
+        default: false
+        required: false
+        type: boolean
+      version-resolver-type:
+        required: false
+        type: string
+        default: plugin-grafana-dependency
+      grafana-dependency:
+        required: false
+        type: string
+      upload-artifacts:
+        required: false
+        type: boolean
+        default: false
+      grafana-compose-file:
+        required: false
+        type: string
+        description: Path to the docker-compose file to use for testing
+      playwright-compose-file:
+        required: false
+        type: string
+        description: Path to the docker-compose file to use for testing
+        default: docker-compose.playwright.yaml
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  resolve-versions:
+    name: Resolve Grafana images
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      matrix: ${{ steps.resolve-versions.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Resolve Grafana E2E versions
+        id: resolve-versions
+        uses: grafana/plugin-actions/e2e-version@main
+        with:
+          skip-grafana-dev-image: ${{ inputs.skip-grafana-dev-image }}
+          version-resolver-type: ${{ inputs.version-resolver-type }}
+          grafana-dependency: ${{ inputs.grafana-dependency }}
+
+  playwright-tests:
+    needs: resolve-versions
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        GRAFANA_IMAGE: ${{fromJson(needs.resolve-versions.outputs.matrix)}}
+    name: e2e ${{ matrix.GRAFANA_IMAGE.name }}@${{ matrix.GRAFANA_IMAGE.VERSION }}
+    runs-on: ubuntu-latest-8-cores
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+        with:
+          node-version-file: .nvmrc
+
+      - name: Download GitHub artifact
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          name: dist-artifacts
+          path: /tmp/dist-artifacts
+
+      - name: Move dist artifacts
+        run: |
+          mkdir -p dist
+          src=$(pwd)
+
+          cd /tmp/dist-artifacts
+          # unzip the universal zip
+          unzip ${{ inputs.id }}-${{ inputs.version }}.zip -d out
+          # Folder structure: /tmp/dist-artifacts/out/$PLUGIN_ID/plugin.json
+          cd out
+          cd "$(ls -1)"
+          mv ./* "$src/dist/"
+
+      - name: Start Grafana
+        # add the -f argument only if "inputs.grafana-compose-file" is defined
+        run: |
+          dcf="${{ inputs.grafana-compose-file }}"
+          GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose ${dcf:+-f "$dcf"} up -d
+
+      - name: Wait for Grafana to start
+        uses: grafana/plugin-actions/wait-for-grafana@main
+
+      - name: Run Playwright tests
+        id: run-tests
+        run: docker compose -f ${{ inputs.playwright-compose-file }} up
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ (inputs.upload-artifacts == true) && ((always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure')) }}
+        with:
+          name: playwright-report-${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}
+          path: playwright-report/
+          retention-days: 30

--- a/.github/workflows/playwright-docker.yml
+++ b/.github/workflows/playwright-docker.yml
@@ -46,6 +46,11 @@ on:
         type: string
         description: Path to the folder to use to upload the artifacts
         default: playwright-report/
+      grafana-url:
+        description: "The URL to check"
+        type: string
+        required: true
+        default: "http://localhost:3000/"
 
 permissions:
   contents: read
@@ -109,6 +114,8 @@ jobs:
 
       - name: Wait for Grafana to start
         uses: grafana/plugin-actions/wait-for-grafana@main
+        with:
+          url: "${{ inputs.grafana-url }}"
 
       - name: Run Playwright tests
         id: run-tests

--- a/.github/workflows/playwright-docker.yml
+++ b/.github/workflows/playwright-docker.yml
@@ -48,7 +48,7 @@ on:
         description: Path to the folder to use to upload the artifacts
         default: playwright-report/
       grafana-url:
-        description: The URL to check
+        description: The Grafana URL to wait for before running the tests
         type: string
         required: false
         default: http://localhost:3000/

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -46,10 +46,10 @@ on:
         default: playwright.config.ts
         description: Path to the Playwright config file to use for testing
       grafana-url:
-        description: "The URL to check"
+        description: The URL to check
         type: string
         required: false
-        default: "http://localhost:3000/"
+        default: http://localhost:3000/
 
 permissions:
   contents: read

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -46,7 +46,7 @@ on:
         default: playwright.config.ts
         description: Path to the Playwright config file to use for testing
       grafana-url:
-        description: The URL to check
+        description: The Grafana URL to wait for before running the tests
         type: string
         required: false
         default: http://localhost:3000/

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -31,6 +31,11 @@ on:
         required: false
         type: boolean
         default: false
+      report-path:
+        required: false
+        type: string
+        description: Path to the folder to use to upload the artifacts
+        default: playwright-report/
       docker-compose-file:
         required: false
         type: string
@@ -40,6 +45,11 @@ on:
         type: string
         default: playwright.config.ts
         description: Path to the Playwright config file to use for testing
+      grafana-url:
+        description: "The URL to check"
+        type: string
+        required: false
+        default: "http://localhost:3000/"
 
 permissions:
   contents: read
@@ -116,11 +126,13 @@ jobs:
       - name: Start Grafana
         # add the -f argument only if "inputs.docker-compose-file" is defined
         run: |
-         dcf="${{ inputs.docker-compose-file }}"
-         GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose ${dcf:+-f "$dcf"} up -d
+          dcf="${{ inputs.docker-compose-file }}"
+          GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose ${dcf:+-f "$dcf"} up -d
 
       - name: Wait for Grafana to start
         uses: grafana/plugin-actions/wait-for-grafana@main
+        with:
+          url: "${{ inputs.grafana-url }}"
 
       - name: Run Playwright tests
         id: run-tests
@@ -131,5 +143,5 @@ jobs:
         if: ${{ (inputs.upload-artifacts == true) && ((always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure')) }}
         with:
           name: playwright-report-${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}
-          path: playwright-report/
+          path: ${{ inputs.report-path }}
           retention-days: 30


### PR DESCRIPTION
Adds `playwright-docker.yml`

Under CI.yml adds a `run-playwright-docker` boolean which can be used to run a docker container to run the playwright tests with. (Useful for screenshot testing)

Main differences with normal `playwright.yml` file are that we get rid of the following steps:

- Setup Node.js environment
- Install npm dependencies
- Install Playwright Browsers

And the `Run Playwright tests` is run instead with `docker compose -f ${{ inputs.playwright-compose-file }} up`

Additional params:

```
playwright-compose-file: Path to the docker-compose file to use for testing
report-path: Path to the folder to use to upload the artifacts
grafana-url: url to run the wait-for-grafana action
```