### PR TITLE
CD: Trigger Argo Workflow to deploy the plugin to Grafana Cloud

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -449,7 +449,6 @@ jobs:
         shell: bash
 
       - name: Trigger Argo Workflow
-        if: ${{ inputs.grafana-cloud }}
         uses: grafana/shared-workflows/actions/trigger-argo-workflow@main
         with:
           namespace: grafana-plugins-cd

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -397,7 +397,7 @@ jobs:
         uses: grafana/shared-workflows/actions/trigger-argo-workflow@main
         with:
           namespace: grafana-plugins-cd
-          workflow_template: provisioned-plugins-deploy
+          workflow_template: grafana-plugins-deploy
           parameters: |
             environment=dev
             slug=${{ fromJSON(needs.ci.outputs.plugin).id }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -397,7 +397,7 @@ jobs:
         uses: grafana/shared-workflows/actions/trigger-argo-workflow@main
         with:
           namespace: grafana-plugins-cd
-          workflow_template: grafana-plugins-deploy
+          workflow_template: provisioned-plugins-deploy
           parameters: |
             environment=dev
             slug=${{ fromJSON(needs.ci.outputs.plugin).id }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,6 +28,15 @@ on:
         required: false
         default: universal
         type: string
+      grafana-cloud:
+        description: |
+          If true, trigger Argo Workflow to deploy the plugin to the specified environment(s) in Grafana Cloud.
+          Currently, this only works for provisioned plugins that have migrated to grafana_cloud-scoped plugins in the plugins catalog.
+          `gcs_only` must be false for this to work.
+          Default is 'false'.
+        required: false
+        default: false
+        type: boolean
 
       # Those inputs are used to customize the CI workflow, before publishing the plugin.
       # They should match with the ones used in CI (ci.yml/push.yml).
@@ -291,8 +300,8 @@ jobs:
           fi
         shell: bash
 
-  deploy:
-    name: Deploy to ${{ matrix.environment }}
+  publish-to-catalog:
+    name: Publish to catalog (${{ matrix.environment }})
     if: ${{ !inputs.docs-only && !inputs.gcs-only }}
     needs:
       - define-variables
@@ -367,6 +376,32 @@ jobs:
           scopes: ${{ inputs.scopes }}
           gcom-publish-token: ${{ env.GCOM_PUBLISH_TOKEN }}
           gcloud-auth-token: ${{ steps.gcloud.outputs.id_token }}
+
+  deploy-to-grafana-cloud:
+    name: Deploy to Grafana Cloud
+    runs-on: ubuntu-latest
+
+    needs:
+      - ci
+      - publish-to-catalog
+
+    if: ${{ inputs.grafana-cloud }}
+
+    # Allow the job to fail because this is opt-in and experimental.
+    # TODO: remove once the workflow is stable.
+    continue-on-error: true
+
+    steps:
+      - name: Deploy to Grafana Cloud
+        if: ${{ inputs.grafana-cloud }}
+        uses: grafana/shared-workflows/actions/trigger-argo-workflow@main
+        with:
+          namespace: grafana-plugins-cd
+          workflow_template: grafana-plugins-deploy
+          parameters: |
+            environment=dev
+            slug=${{ fromJSON(needs.ci.outputs.plugin).id }}
+            version=${{ fromJSON(needs.ci.outputs.plugin).version }}
 
   # Note: This job can be removed once provisioned plugins releases are moved to the
   # tailored plugins catalog instead of using GCS.
@@ -461,7 +496,7 @@ jobs:
       # Update the docs only after a successful GCOM deployment
       # This dependency can be skipped if gcs-only is true. In that case, this step
       # is still executed due to the "!(failure() || cancelled())" condition.
-      - deploy
+      - publish-to-catalog
     if: >-
       ${{
         (needs.ci.outputs.has-docs == 'true')
@@ -515,7 +550,7 @@ jobs:
       # Create the release only after a successful GCOM deployment
       # This dependency can be skipped if gcs-only is true. In that case, this step
       # is still executed due to the "!(failure() || cancelled())" condition.
-      - deploy
+      - publish-to-catalog
     if: >-
       ${{
         contains(fromJSON(needs.define-variables.outputs.environments), 'prod')

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -431,7 +431,7 @@ jobs:
       - ci
       - publish-to-catalog
 
-    if: ${{ inputs.grafana-cloud }}
+    if: ${{ inputs.grafana-cloud-deployment-type != '' }}
 
     # Allow the job to fail because this is opt-in and experimental.
     # TODO: remove once the workflow is stable.

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -438,6 +438,16 @@ jobs:
     continue-on-error: true
 
     steps:
+      - name: Check deployment type
+        # Right now we only support provisioned plugins.
+        # In the future, we will support managed plugins as well.
+        run: |
+          if [ "${{ inputs.grafana-cloud-deployment-type }}" != 'provisioned' ]; then
+            echo "Invalid deployment type '${{ inputs.grafana-cloud-deployment-type }}', must be 'provisioned'"
+            exit 1
+          fi
+        shell: bash
+
       - name: Trigger Argo Workflow
         if: ${{ inputs.grafana-cloud }}
         uses: grafana/shared-workflows/actions/trigger-argo-workflow@main

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -423,8 +423,8 @@ jobs:
           gcom-publish-token: ${{ env.GCOM_PUBLISH_TOKEN }}
           gcloud-auth-token: ${{ steps.gcloud.outputs.id_token }}
 
-  deploy-to-grafana-cloud:
-    name: Deploy to Grafana Cloud
+  trigger-argo-workflow:
+    name: Trigger Argo Workflow for Grafana Cloud deployment
     runs-on: ubuntu-latest
 
     needs:
@@ -438,7 +438,7 @@ jobs:
     continue-on-error: true
 
     steps:
-      - name: Deploy to Grafana Cloud
+      - name: Trigger Argo Workflow
         if: ${{ inputs.grafana-cloud }}
         uses: grafana/shared-workflows/actions/trigger-argo-workflow@main
         with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,15 +28,20 @@ on:
         required: false
         default: universal
         type: string
-      grafana-cloud:
+      # TODO: 'managed' deployment_type will be added here in the future.
+      grafana-cloud-deployment-type:
         description: |
-          If true, trigger Argo Workflow to deploy the plugin to the specified environment(s) in Grafana Cloud.
-          Currently, this only works for provisioned plugins that have migrated to grafana_cloud-scoped plugins in the plugins catalog.
+          If set, trigger Argo Workflow to deploy the plugin to the specified environment(s) in Grafana Cloud.
           `gcs_only` must be false for this to work.
-          Default is 'false'.
+
+          Supported values:
+            - provisioned
+
+          Currently, this only works for provisioned plugins that have migrated to grafana_cloud-scoped plugins in the plugins catalog.
+          Default is empty (do not trigger Argo Workflow).
         required: false
-        default: false
-        type: boolean
+        default:
+        type: string
 
       # Those inputs are used to customize the CI workflow, before publishing the plugin.
       # They should match with the ones used in CI (ci.yml/push.yml).
@@ -136,6 +141,13 @@ on:
           Only publish docs to the website, do not publish the plugin.
         default: false
         type: boolean
+      argo-workflow-slack-channel:
+        description: |
+          Slack channel to use for Argo Workflow deployment notifications.
+          This is only used when deploying to Grafana Cloud.
+          Default is '#grafana-plugins-platform-ci'.
+        default: "#grafana-plugins-platform-ci"
+        type: string
 
       # Options for deploying PRs. Those values should come from the PR event and should not be set manually.
       branch:
@@ -399,9 +411,12 @@ jobs:
           namespace: grafana-plugins-cd
           workflow_template: grafana-plugins-deploy
           parameters: |
-            environment=dev
             slug=${{ fromJSON(needs.ci.outputs.plugin).id }}
             version=${{ fromJSON(needs.ci.outputs.plugin).version }}
+            environment=${{ inputs.environment }}
+            slack_channel=${{ inputs.argo-workflow-slack-channel }}
+            commit=${{ github.sha}}
+            commit_link=https://${{ github.repository_owner }}/${{ github.event.repository.name }}/commit/${{ github.sha }}
 
   # Note: This job can be removed once provisioned plugins releases are moved to the
   # tailored plugins catalog instead of using GCS.


### PR DESCRIPTION
Adds a `grafana-cloud-deployment-type` input to `cd.yml`.

Currently, it only supports the `provisioned` value. In the future, it will also support `managed`.

When set, the CD workflow  will trigger an Argo Workflow to deploy the plugin to Grafana Cloud by bumping the plugin version in deployment_tools.

Example PR to enable this feature in a plugin: https://github.com/grafana/grafana-pluginsplatformprovisioned-app/pull/2

Example GHA run for a deployment: https://github.com/grafana/grafana-pluginsplatformprovisioned-app/actions/runs/14401399572

Requires https://github.com/grafana/deployment_tools/pull/244612

Part of https://github.com/grafana/grafana-community-team/issues/365