### PR TITLE
feat(cd): Pass Playwright inputs to the ci workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -56,6 +56,11 @@ on:
         type: boolean
         required: false
         default: true
+      run-playwright-docker:
+        description: Whether to run dockerized Playwright E2E tests.
+        type: boolean
+        required: false
+        default: false
       # https://github.com/grafana/plugin-actions/blob/main/e2e-version/action.yml
       run-playwright-with-grafana-dependency:
         description: "Optionally, use this input to pass a semver range of supported Grafana versions to test against. This is only used when version-resolver-type is plugin-grafana-dependency. If not provided, the action will try to read grafanaDependency from the plugin.json file."
@@ -79,6 +84,29 @@ on:
         required: false
         type: boolean
         default: false
+      playwright-report-path:
+        required: false
+        type: string
+        description: Path to the folder to use to upload the artifacts
+        default: playwright-report/
+      playwright-docker-compose-file:
+        required: false
+        type: string
+        description: Path to the docker-compose file to use for testing
+      playwright-config:
+        required: false
+        type: string
+        default: playwright.config.ts
+        description: Path to the Playwright config file to use for testing
+      playwright-e2e-docker-compose-file:
+        required: false
+        type: string
+        description: Path to the playwright docker-compose file
+      playwright-grafana-url:
+        description: The URL where Grafana is available at when running Playwright tests
+        type: string
+        required: false
+        default: http://localhost:3000/
 
       # Trufflehog
       run-trufflehog:
@@ -192,10 +220,16 @@ jobs:
       node-version: ${{ inputs.node-version }}
       golangci-lint-version: ${{ inputs.golangci-lint-version }}
       run-playwright: ${{ inputs.run-playwright }}
+      run-playwright-docker: ${{ inputs.run-playwright-docker }}
       run-playwright-with-grafana-dependency: ${{ inputs.run-playwright-with-grafana-dependency }}
       run-playwright-with-skip-grafana-dev-image: ${{ inputs.run-playwright-with-skip-grafana-dev-image }}
       run-playwright-with-version-resolver-type: ${{ inputs.run-playwright-with-version-resolver-type }}
       upload-playwright-artifacts: ${{ inputs.upload-playwright-artifacts }}
+      playwright-report-path: ${{ inputs.playwright-report-path }}
+      playwright-docker-compose-file: ${{ inputs.playwright-docker-compose-file }}
+      playwright-config: ${{ inputs.playwright-config }}
+      playwright-e2e-docker-compose-file: ${{ inputs.playwright-e2e-docker-compose-file }}
+      playwright-grafana-url: ${{ inputs.playwright-grafana-url }}
       run-trufflehog: ${{ inputs.run-trufflehog }}
       trufflehog-version: ${{ inputs.trufflehog-version }}
       trufflehog-include-detectors: ${{ inputs.trufflehog-include-detectors }}


### PR DESCRIPTION
A follow-up of https://github.com/grafana/plugin-ci-workflows/pull/67 to pass the Playwright inputs to the `ci` workflow.

This is [currently blocking our ability](https://github.com/grafana/metrics-drilldown/actions/runs/14321602690) to  publish Metrics Drilldown to the Grafana plugins catalog.

