### PR TITLE
CD: Publish action: Make md5 files in GCS optional, add local-md5 option

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -422,8 +422,6 @@ jobs:
           scopes: ${{ inputs.scopes }}
           gcom-publish-token: ${{ env.GCOM_PUBLISH_TOKEN }}
           gcloud-auth-token: ${{ steps.gcloud.outputs.id_token }}
-          # TODO: remove
-          local-md5: true
 
   trigger-argo-workflow:
     name: Trigger Argo Workflow for Grafana Cloud deployment

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -415,7 +415,7 @@ jobs:
           gcloud-auth-token: ${{ steps.gcloud.outputs.id_token }}
 
       - name: Publish to catalog
-        uses: grafana/plugin-ci-workflows/actions/plugins/publish/publish@giuseppe/publish-plugin-args
+        uses: grafana/plugin-ci-workflows/actions/plugins/publish/publish@main
         with:
           zips: ${{ needs.ci.outputs.gcs-zip-urls-commit }}
           environment: ${{ matrix.environment }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -415,13 +415,15 @@ jobs:
           gcloud-auth-token: ${{ steps.gcloud.outputs.id_token }}
 
       - name: Publish to catalog
-        uses: grafana/plugin-ci-workflows/actions/plugins/publish/publish@main
+        uses: grafana/plugin-ci-workflows/actions/plugins/publish/publish@giuseppe/publish-plugin-args
         with:
           zips: ${{ needs.ci.outputs.gcs-zip-urls-commit }}
           environment: ${{ matrix.environment }}
           scopes: ${{ inputs.scopes }}
           gcom-publish-token: ${{ env.GCOM_PUBLISH_TOKEN }}
           gcloud-auth-token: ${{ steps.gcloud.outputs.id_token }}
+          # TODO: remove
+          local-md5: true
 
   trigger-argo-workflow:
     name: Trigger Argo Workflow for Grafana Cloud deployment

--- a/actions/plugins/publish/publish/action.yml
+++ b/actions/plugins/publish/publish/action.yml
@@ -10,6 +10,15 @@ inputs:
       - a combination of both.
     required: true
 
+  local-md5:
+    description: |
+      If true, download the ZIP files and calculate their MD5 hashes locally.
+      Otherwise, get them from the URLs, by appending ".md5" to each URL.
+      Default is false. It's recommended to keep it set to false if possible,
+      unless you are not uploading to the "integration-artifacts" bucket.
+    required: false
+    default: "false"
+
   environment:
     description: |
       Environment to publish to.
@@ -45,10 +54,16 @@ runs:
 
         # Convert the "zips" JSON array to a space-separated string
         # (used to pass each ZIP in the JSON array as a separate argument)
-        files=$(echo '${{ inputs.zips }}' | jq -r 'join(" ")')
+        args=()
+        if [[ ${{ inputs.local-md5 }} == 'true' ]]; then
+          args+=("--local-md5")
+        fi
+        args+=($(echo '${{ inputs.zips }}' | jq -r 'join(" ")'))
 
+        # TODO: REMOVE --dry-run
         ${{ github.action_path }}/publish.sh \
           --environment "${{ inputs.environment }}" \
           --scopes '${{ inputs.scopes }}' \
-          "${files[@]}"
+          --dry-run \
+          "${args[@]}"
       shell: bash

--- a/actions/plugins/publish/publish/action.yml
+++ b/actions/plugins/publish/publish/action.yml
@@ -60,10 +60,8 @@ runs:
         fi
         args+=($(echo '${{ inputs.zips }}' | jq -r 'join(" ")'))
 
-        # TODO: REMOVE --dry-run
         ${{ github.action_path }}/publish.sh \
           --environment "${{ inputs.environment }}" \
           --scopes '${{ inputs.scopes }}' \
-          --dry-run \
           "${args[@]}"
       shell: bash

--- a/actions/plugins/publish/publish/action.yml
+++ b/actions/plugins/publish/publish/action.yml
@@ -58,7 +58,7 @@ runs:
         if [[ ${{ inputs.local-md5 }} == 'true' ]]; then
           args+=("--local-md5")
         fi
-        args+=$(echo '${{ inputs.zips }}' | jq -r 'join(" ")')
+        args+=($(echo '${{ inputs.zips }}' | jq -r 'join(" ")'))
 
         # TODO: REMOVE --dry-run
         ${{ github.action_path }}/publish.sh \

--- a/actions/plugins/publish/publish/action.yml
+++ b/actions/plugins/publish/publish/action.yml
@@ -58,7 +58,7 @@ runs:
         if [[ ${{ inputs.local-md5 }} == 'true' ]]; then
           args+=("--local-md5")
         fi
-        args+=($(echo '${{ inputs.zips }}' | jq -r 'join(" ")'))
+        args+=$(echo '${{ inputs.zips }}' | jq -r 'join(" ")')
 
         # TODO: REMOVE --dry-run
         ${{ github.action_path }}/publish.sh \

--- a/actions/plugins/publish/publish/publish.sh
+++ b/actions/plugins/publish/publish/publish.sh
@@ -111,7 +111,7 @@ for zip_url in $gcs_zip_urls; do
         tmp=$(mktemp -d)
         pushd "$tmp" > /dev/null
         echo "Downloading $zip_url to calculate MD5"
-        curl -o "$file" "$zip_url"
+        curl -s -o "$file" "$zip_url"
         md5=$(md5sum "$file" | cut -d ' ' -f 1)
         popd
         rm -rf "$tmp"

--- a/actions/plugins/publish/publish/publish.sh
+++ b/actions/plugins/publish/publish/publish.sh
@@ -112,7 +112,7 @@ for zip_url in $gcs_zip_urls; do
         pushd "$tmp" > /dev/null
         echo "Downloading $zip_url to calculate MD5"
         curl -o "$file" "$zip_url"
-        md5=$(md5sum "$file")
+        md5=$(md5sum "$file" | cut -d ' ' -f 1)
         popd
         rm -rf "$tmp"
     else
@@ -123,8 +123,8 @@ for zip_url in $gcs_zip_urls; do
             echo "Failed to fetch md5: $md5_url"
             exit 1
         fi
-        md5=$(echo $md5 | tr -d '\n')
     fi
+    md5=$(echo $md5 | tr -d '\n')
 
     # Make sure the md5 is valid length (valid response)
     if [ ${#md5} -ne 32 ]; then

--- a/actions/plugins/publish/publish/publish.sh
+++ b/actions/plugins/publish/publish/publish.sh
@@ -12,11 +12,13 @@ json_obj() {
 gcs_zip_urls=()
 scopes=''
 dry_run=false
+local_md5=false
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         --environment) gcom_env=$2; shift 2;;
         --scopes) scopes=$(echo $2 | jq -Rc 'split(",")'); shift 2;;
         --dry-run) dry_run=true; shift;;
+        --local-md5) local_md5=true; shift;;
         --help)
             usage
             exit 0
@@ -103,14 +105,26 @@ for zip_url in $gcs_zip_urls; do
         platform="$os-$arch"
     fi
 
-    # Try to get the .md5 for the zip file
-    md5_url="$zip_url.md5"
-    md5=$(curl --fail -s "$md5_url")
-    if [ $? -ne 0 ]; then
-        echo "Failed to fetch md5: $md5_url"
-        exit 1
+    
+    if [ $local_md5 == true ]; then
+        # Calculate md5 locally
+        tmp=$(mktemp -d)
+        pushd "$tmp" > /dev/null
+        echo "Downloading $zip_url to calculate MD5"
+        curl -o "$file" "$zip_url"
+        md5=$(md5sum "$file")
+        popd
+        rm -rf "$tmp"
+    else
+        # Try to get the .md5 for the zip file from GCS
+        md5_url="$zip_url.md5"
+        md5=$(curl --fail -s "$md5_url")
+        if [ $? -ne 0 ]; then
+            echo "Failed to fetch md5: $md5_url"
+            exit 1
+        fi
+        md5=$(echo $md5 | tr -d '\n')
     fi
-    md5=$(echo $md5 | tr -d '\n')
 
     # Make sure the md5 is valid length (valid response)
     if [ ${#md5} -ne 32 ]; then

--- a/actions/plugins/publish/publish/publish.sh
+++ b/actions/plugins/publish/publish/publish.sh
@@ -29,7 +29,6 @@ while [[ "$#" -gt 0 ]]; do
             ;;
     esac
 done
-echo $gcs_zip_urls
 
 if [ -z "$gcs_zip_urls" ]; then
     echo "Plugin ZIP URLs not provided."
@@ -91,7 +90,7 @@ fi
 
 # Build JSON payload for publishing
 jq_download_args=()
-for zip_url in $gcs_zip_urls; do
+for zip_url in ${gcs_zip_urls[@]}; do
     platform=any
     os=""
     arch=""


### PR DESCRIPTION
Removes the need to have md5 files in GCS in order to make the publish action a bit more flexible when re-used in other custom workflows (e.g.: grafana-irm-app).

Adds a new option `local-md5`, which will download the zip and calculate the md5 rather than fetching it from GCS.