### PR TITLE
Publish action: Add support for debug logging

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -415,7 +415,7 @@ jobs:
           gcloud-auth-token: ${{ steps.gcloud.outputs.id_token }}
 
       - name: Publish to catalog
-        uses: grafana/plugin-ci-workflows/actions/plugins/publish/publish@giuseppe/debug-publish-action
+        uses: grafana/plugin-ci-workflows/actions/plugins/publish/publish@main
         with:
           zips: ${{ needs.ci.outputs.gcs-zip-urls-commit }}
           environment: ${{ matrix.environment }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -415,7 +415,7 @@ jobs:
           gcloud-auth-token: ${{ steps.gcloud.outputs.id_token }}
 
       - name: Publish to catalog
-        uses: grafana/plugin-ci-workflows/actions/plugins/publish/publish@main
+        uses: grafana/plugin-ci-workflows/actions/plugins/publish/publish@giuseppe/debug-publish-action
         with:
           zips: ${{ needs.ci.outputs.gcs-zip-urls-commit }}
           environment: ${{ matrix.environment }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -416,6 +416,8 @@ jobs:
 
       - name: Publish to catalog
         uses: grafana/plugin-ci-workflows/actions/plugins/publish/publish@giuseppe/debug-publish-action
+        env:
+          ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG || env.ACTIONS_STEP_DEBUG }}
         with:
           zips: ${{ needs.ci.outputs.gcs-zip-urls-commit }}
           environment: ${{ matrix.environment }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -416,8 +416,8 @@ jobs:
 
       - name: Publish to catalog
         uses: grafana/plugin-ci-workflows/actions/plugins/publish/publish@giuseppe/debug-publish-action
-        env:
-          ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG || env.ACTIONS_STEP_DEBUG }}
+        #env:
+        #  ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG || env.ACTIONS_STEP_DEBUG }}
         with:
           zips: ${{ needs.ci.outputs.gcs-zip-urls-commit }}
           environment: ${{ matrix.environment }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -416,8 +416,6 @@ jobs:
 
       - name: Publish to catalog
         uses: grafana/plugin-ci-workflows/actions/plugins/publish/publish@giuseppe/debug-publish-action
-        #env:
-        #  ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG || env.ACTIONS_STEP_DEBUG }}
         with:
           zips: ${{ needs.ci.outputs.gcs-zip-urls-commit }}
           environment: ${{ matrix.environment }}

--- a/actions/plugins/publish/publish/publish.sh
+++ b/actions/plugins/publish/publish/publish.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+env
+
 set -e
 if [ $ACTIONS_STEP_DEBUG == "true" ]; then
     set -x

--- a/actions/plugins/publish/publish/publish.sh
+++ b/actions/plugins/publish/publish/publish.sh
@@ -35,8 +35,6 @@ while [[ "$#" -gt 0 ]]; do
     esac
 done
 
-exit 1
-
 if [ -z "$gcs_zip_urls" ]; then
     echo "Plugin ZIP URLs not provided."
     usage

--- a/actions/plugins/publish/publish/publish.sh
+++ b/actions/plugins/publish/publish/publish.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 set -e
+if [[ $ACTIONS_STEP_DEBUG == "true" ]]; then
+    set -x
+fi
 
 usage() {
     echo "Usage: $0 --environment <dev|ops|prod> [--scopes <comma_separated_scopes>] [--dry-run] <plugin_zip_urls...>"

--- a/actions/plugins/publish/publish/publish.sh
+++ b/actions/plugins/publish/publish/publish.sh
@@ -33,6 +33,8 @@ while [[ "$#" -gt 0 ]]; do
     esac
 done
 
+exit 1
+
 if [ -z "$gcs_zip_urls" ]; then
     echo "Plugin ZIP URLs not provided."
     usage

--- a/actions/plugins/publish/publish/publish.sh
+++ b/actions/plugins/publish/publish/publish.sh
@@ -2,7 +2,7 @@
 env
 
 set -e
-if [ $ACTIONS_STEP_DEBUG == "true" ]; then
+if [ $RUNNER_DEBUG == "1" ]; then
     set -x
 fi
 

--- a/actions/plugins/publish/publish/publish.sh
+++ b/actions/plugins/publish/publish/publish.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-if [[ $ACTIONS_STEP_DEBUG == "true" ]]; then
+if [ $ACTIONS_STEP_DEBUG == "true" ]; then
     set -x
 fi
 

--- a/actions/plugins/publish/publish/publish.sh
+++ b/actions/plugins/publish/publish/publish.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-env
-
 set -e
 if [ $RUNNER_DEBUG == "1" ]; then
     set -x


### PR DESCRIPTION
Run `set -x` when debug logging are enabled in GitHub Actions