### PR TITLE
CD: Fix syntax error in publish action when RUNNER_DEBUG is not defined

### DIFF
--- a/actions/plugins/publish/publish/publish.sh
+++ b/actions/plugins/publish/publish/publish.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-if [ $RUNNER_DEBUG == "1" ]; then
+if [ "$RUNNER_DEBUG" == "1" ]; then
     set -x
 fi
 


### PR DESCRIPTION
Fixes https://github.com/grafana/plugin-ci-workflows/pull/73#discussion_r2070704350