### PR TITLE
CI: Add final job to check for E2E tests matrix status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,36 +405,6 @@ jobs:
       report-path: ${{ inputs.playwright-report-path }}
       grafana-url: ${{ inputs.playwright-grafana-url }}
 
-  check-playwright-status:
-    name: Check Playwright E2E status
-    needs:
-      - playwright
-      - playwright-docker
-    runs-on: ubuntu-latest
-    # TODO: ensure always() works if playwright is disabled
-    if: always()
-    steps:
-      - name: Check matrix job status
-        run: |
-          code=1
-          if [ "${RUN_PLAYWRIGHT}" == "true" && "${PLAYWRIGHT_SUCCESS}" == "true" ]; then
-            code=0
-          fi
-          if [ "${RUN_PLAYWRIGHT_DOCKER}" == "true" && "${PLAYWRIGHT_DOCKER_SUCCESS}" == "true" ]; then
-            code=0
-          fi
-          if [ $code == 0 ]; then
-            echo "All E2E test jobs succeeded"
-          else
-            echo "One or more jobs in the E2E testing matrix failed"
-          fi
-          exit $code
-    env:
-      RUN_PLAYWRIGHT: ${{ inputs.run-playwright }}
-      PLAYWRIGHT_SUCCESS: ${{ needs.playwright.outputs.success }}
-      RUN_PLAYWRIGHT_DOCKER: ${{ inputs.run-playwright-docker }}
-      PLAYWRIGHT_DOCKER_SUCCESS: ${{ needs.playwright-docker.outputs.success }}
-
   upload-to-gcs:
     name: Upload to GCS
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,7 +371,7 @@ jobs:
 
   playwright:
     name: Playwright E2E tests
-    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@main # zizmor: ignore[unpinned-uses]
+    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@giuseppe/e2e-sink # zizmor: ignore[unpinned-uses]
     if: ${{ inputs.run-playwright == true }}
     needs:
       - test-and-build
@@ -389,7 +389,7 @@ jobs:
 
   playwright-docker:
     name: Plugins - Dockerized Playwright E2E tests
-    uses: grafana/plugin-ci-workflows/.github/workflows/playwright-docker.yml@main # zizmor: ignore[unpinned-uses]
+    uses: grafana/plugin-ci-workflows/.github/workflows/playwright-docker.yml@giuseppe/e2e-sink # zizmor: ignore[unpinned-uses]
     if: ${{ inputs.run-playwright-docker == true }}
     needs:
       - test-and-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,7 +371,7 @@ jobs:
 
   playwright:
     name: Playwright E2E tests
-    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@giuseppe/e2e-sink # zizmor: ignore[unpinned-uses]
+    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@main # zizmor: ignore[unpinned-uses]
     if: ${{ inputs.run-playwright == true }}
     needs:
       - test-and-build
@@ -389,7 +389,7 @@ jobs:
 
   playwright-docker:
     name: Plugins - Dockerized Playwright E2E tests
-    uses: grafana/plugin-ci-workflows/.github/workflows/playwright-docker.yml@giuseppe/e2e-sink # zizmor: ignore[unpinned-uses]
+    uses: grafana/plugin-ci-workflows/.github/workflows/playwright-docker.yml@main # zizmor: ignore[unpinned-uses]
     if: ${{ inputs.run-playwright-docker == true }}
     needs:
       - test-and-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,6 +405,36 @@ jobs:
       report-path: ${{ inputs.playwright-report-path }}
       grafana-url: ${{ inputs.playwright-grafana-url }}
 
+  check-playwright-status:
+    name: Check Playwright E2E status
+    needs:
+      - playwright
+      - playwright-docker
+    runs-on: ubuntu-latest
+    # TODO: ensure always() works if playwright is disabled
+    if: always()
+    steps:
+      - name: Check matrix job status
+        run: |
+          code=1
+          if [ "${RUN_PLAYWRIGHT}" == "true" && "${PLAYWRIGHT_SUCCESS}" == "true" ]; then
+            code=0
+          fi
+          if [ "${RUN_PLAYWRIGHT_DOCKER}" == "true" && "${PLAYWRIGHT_DOCKER_SUCCESS}" == "true" ]; then
+            code=0
+          fi
+          if [ $code == 0 ]; then
+            echo "All E2E test jobs succeeded"
+          else
+            echo "One or more jobs in the E2E testing matrix failed"
+          fi
+          exit $code
+    env:
+      RUN_PLAYWRIGHT: ${{ inputs.run-playwright }}
+      PLAYWRIGHT_SUCCESS: ${{ needs.playwright.outputs.success }}
+      RUN_PLAYWRIGHT_DOCKER: ${{ inputs.run-playwright-docker }}
+      PLAYWRIGHT_DOCKER_SUCCESS: ${{ needs.playwright-docker.outputs.success }}
+
   upload-to-gcs:
     name: Upload to GCS
     runs-on: ubuntu-latest

--- a/.github/workflows/playwright-docker.yml
+++ b/.github/workflows/playwright-docker.yml
@@ -52,6 +52,9 @@ on:
         type: string
         required: false
         default: http://localhost:3000/
+    outputs:
+      success:
+        value: ${{ jobs.check-playwright-matrix-status.outputs.success }}
 
 permissions:
   contents: read
@@ -140,18 +143,17 @@ jobs:
           path: ${{ inputs.report-path }}
           retention-days: 30
 
-  check-playwright-status:
+  check-playwright-matrix-status:
     needs: playwright-tests
     name: Check Playwright E2E matrix status
     runs-on: ubuntu-latest
     if: always()
     steps:
       - name: Check matrix job status
-        # This step will fail if any of the matrix jobs failed
+        id: check
         run: |
           if [ "${{ contains(needs.playwright-tests.result, 'failure') }}" = "true" ]; then
-            echo "One or more jobs in the E2E testing matrix failed"
-            exit 1
+            echo "success=false" >> $GITHUB_OUTPUT
           else
-            echo "All E2E test jobs succeeded"
+            echo "success=true" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/playwright-docker.yml
+++ b/.github/workflows/playwright-docker.yml
@@ -139,3 +139,18 @@ jobs:
           name: playwright-report-${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}
           path: ${{ inputs.report-path }}
           retention-days: 30
+
+  check-playwright-status:
+    needs: playwright-tests
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check matrix job status
+        # This step will fail if any of the matrix jobs failed
+        run: |
+          if [ "${{ contains(needs.playwright-tests.result, 'failure') }}" = "true" ]; then
+            echo "One or more jobs in the E2E testing matrix failed"
+            exit 1
+          else
+            echo "All E2E test jobs succeeded"
+          fi

--- a/.github/workflows/playwright-docker.yml
+++ b/.github/workflows/playwright-docker.yml
@@ -52,9 +52,6 @@ on:
         type: string
         required: false
         default: http://localhost:3000/
-    outputs:
-      success:
-        value: ${{ jobs.check-playwright-matrix-status.outputs.success }}
 
 permissions:
   contents: read
@@ -143,17 +140,18 @@ jobs:
           path: ${{ inputs.report-path }}
           retention-days: 30
 
-  check-playwright-matrix-status:
+  check-playwright-status:
     needs: playwright-tests
     name: Check Playwright E2E matrix status
     runs-on: ubuntu-latest
     if: always()
     steps:
       - name: Check matrix job status
-        id: check
+        # This step will fail if any of the matrix jobs failed
         run: |
           if [ "${{ contains(needs.playwright-tests.result, 'failure') }}" = "true" ]; then
-            echo "success=false" >> $GITHUB_OUTPUT
+            echo "One or more jobs in the E2E testing matrix failed"
+            exit 1
           else
-            echo "success=true" >> $GITHUB_OUTPUT
+            echo "All E2E test jobs succeeded"
           fi

--- a/.github/workflows/playwright-docker.yml
+++ b/.github/workflows/playwright-docker.yml
@@ -142,6 +142,7 @@ jobs:
 
   check-playwright-status:
     needs: playwright-tests
+    name: Check Playwright E2E matrix status
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -50,9 +50,6 @@ on:
         type: string
         required: false
         default: http://localhost:3000/
-    outputs:
-      success:
-        value: ${{ jobs.check-playwright-matrix-status.outputs.success }}
 
 permissions:
   contents: read
@@ -159,17 +156,18 @@ jobs:
           path: ${{ inputs.report-path }}
           retention-days: 30
 
-  check-playwright-matrix-status:
+  check-playwright-status:
     needs: playwright-tests
     name: Check Playwright E2E matrix status
     runs-on: ubuntu-latest
     if: always()
     steps:
       - name: Check matrix job status
-        id: check
+        # This step will fail if any of the matrix jobs failed
         run: |
-          if [ "${{ contains(needs.playwright-tests.result, 'failure') }}" == "true" ]; then
-            echo "success=false" >> $GITHUB_OUTPUT
+          if [ "${{ contains(needs.playwright-tests.result, 'failure') }}" = "true" ]; then
+            echo "One or more jobs in the E2E testing matrix failed"
+            exit 1
           else
-            echo "success=true" >> $GITHUB_OUTPUT
+            echo "All E2E test jobs succeeded"
           fi

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -158,6 +158,7 @@ jobs:
 
   check-playwright-status:
     needs: playwright-tests
+    name: Check Playwright E2E matrix status
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -155,3 +155,18 @@ jobs:
           name: playwright-report-${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}
           path: ${{ inputs.report-path }}
           retention-days: 30
+
+  check-playwright-status:
+    needs: playwright-tests
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check matrix job status
+        # This step will fail if any of the matrix jobs failed
+        run: |
+          if [ "${{ contains(needs.playwright-tests.result, 'failure') }}" = "true" ]; then
+            echo "One or more jobs in the E2E testing matrix failed"
+            exit 1
+          else
+            echo "All E2E test jobs succeeded"
+          fi

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -50,6 +50,9 @@ on:
         type: string
         required: false
         default: http://localhost:3000/
+    outputs:
+      success:
+        value: ${{ jobs.check-playwright-matrix-status.outputs.success }}
 
 permissions:
   contents: read
@@ -156,18 +159,17 @@ jobs:
           path: ${{ inputs.report-path }}
           retention-days: 30
 
-  check-playwright-status:
+  check-playwright-matrix-status:
     needs: playwright-tests
     name: Check Playwright E2E matrix status
     runs-on: ubuntu-latest
     if: always()
     steps:
       - name: Check matrix job status
-        # This step will fail if any of the matrix jobs failed
+        id: check
         run: |
-          if [ "${{ contains(needs.playwright-tests.result, 'failure') }}" = "true" ]; then
-            echo "One or more jobs in the E2E testing matrix failed"
-            exit 1
+          if [ "${{ contains(needs.playwright-tests.result, 'failure') }}" == "true" ]; then
+            echo "success=false" >> $GITHUB_OUTPUT
           else
-            echo "All E2E test jobs succeeded"
+            echo "success=true" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
Adds a job after all the e2e jobs in the matrix, which exits with 0 if each job succeeds, otherwise it exitst with 1.

This is handy to define status checks for e2e tests.

Test PR: https://github.com/grafana/plugins-drone-to-gha/pull/24

Example runs:
- https://github.com/grafana/plugins-drone-to-gha/actions/runs/15023454722
- https://github.com/grafana/plugins-drone-to-gha/actions/runs/15023878573

Fixes #28 

Fixes #95