### PR TITLE
CI: Fix checkout for forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,6 +232,7 @@ jobs:
       - name: Generate GitHub token
         id: generate-github-token
         uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
+        if: ${{ env.IS_FORK == 'false' }}
         with:
           app-id: ${{ env.GITHUB_APP_ID }}
           private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ on:
         description: Branch to build from. Can be used to build PRs.
         type: string
         required: false
-        default: ${{ github.head_ref || github.ref_name }}
+        default: ${{ github.ref || github.ref_name }}
 
     outputs:
       plugin:


### PR DESCRIPTION
- Fix `checkout` step failing for forks
- Do not generate github token for forks (secret is not present and the step will fail otherwise)

Test runs:
- https://github.com/grafana/clock-panel/actions/runs/15040164235?pr=267: clock-panel (frontend) external fork
- https://github.com/grafana/grafana-zabbix/actions/runs/15040330649?pr=2031: zabbix (backend) external fork
- https://github.com/grafana/plugins-drone-to-gha/actions/runs/15040373325?pr=25: internal pr (not a fork)

Fixes #69 