### PR TITLE
CD: Allow git tag creation to fail

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -667,10 +667,9 @@ jobs:
       # This dependency can be skipped if gcs-only is true. In that case, this step
       # is still executed due to the "!(failure() || cancelled())" condition.
       - publish-to-catalog
-    # TODO: REMOVE THE DEV CHECK
     if: >-
       ${{
-        contains(fromJSON(needs.define-variables.outputs.environments), 'dev')
+        contains(fromJSON(needs.define-variables.outputs.environments), 'prod')
         && !(failure() || cancelled())
       }}
     steps:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -700,6 +700,9 @@ jobs:
 
       - name: Create tag
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        # Allow the tag creation to fail, in case it already exists
+        # (e.g.: created manually, or re-triggering a release).
+        continue-on-error: true
         with:
           script: |
             const { PLUGIN_VERSION } = process.env

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -667,9 +667,10 @@ jobs:
       # This dependency can be skipped if gcs-only is true. In that case, this step
       # is still executed due to the "!(failure() || cancelled())" condition.
       - publish-to-catalog
+    # TODO: REMOVE THE DEV CHECK
     if: >-
       ${{
-        contains(fromJSON(needs.define-variables.outputs.environments), 'prod')
+        contains(fromJSON(needs.define-variables.outputs.environments), 'dev')
         && !(failure() || cancelled())
       }}
     steps:


### PR DESCRIPTION
Fix #98

Example run when the tag already exists: https://github.com/grafana/plugins-drone-to-gha/actions/runs/15107621898/job/42459866382 (see logs for the "Create tag" step)