### PR TITLE
feat: simplify playwright docker e2e with profiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,11 @@ on:
         required: false
         default: true
       run-playwright-docker:
-        description: Whether to run dockerized Playwright E2E tests.
+        description: |
+          Whether to run dockerized Playwright E2E tests.
+          Make sure to have a both a 'playwright' service with a 'playwright' profile
+          in your docker-compose.yaml file for the tests to run against
+          see: https://docs.docker.com/compose/how-tos/profiles/
         type: boolean
         required: false
         default: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,10 +86,6 @@ on:
         type: string
         default: playwright.config.ts
         description: Path to the Playwright config file to use for testing
-      playwright-e2e-docker-compose-file:
-        required: false
-        type: string
-        description: Path to the playwright docker-compose file
       playwright-grafana-url:
         description: The URL where Grafana is available at when running Playwright tests
         type: string
@@ -402,7 +398,6 @@ jobs:
       version-resolver-type: ${{ inputs.run-playwright-with-version-resolver-type }}
       upload-artifacts: ${{ inputs.upload-playwright-artifacts }}
       grafana-compose-file: ${{ inputs.playwright-docker-compose-file }}
-      playwright-compose-file: ${{ inputs.playwright-e2e-docker-compose-file }}
       report-path: ${{ inputs.playwright-report-path }}
       grafana-url: ${{ inputs.playwright-grafana-url }}
 

--- a/.github/workflows/playwright-docker.yml
+++ b/.github/workflows/playwright-docker.yml
@@ -5,10 +5,6 @@
 # eg e2e:/app/e2e
 
 name: Plugins - Dockerized Playwright E2E tests
-description: |
-  Make sure to have a both a 'playwright' service with a 'playwright' profile
-  in your docker-compose.yaml file for the tests to run against
-  see: https://docs.docker.com/compose/how-tos/profiles/
 
 on:
   workflow_call:

--- a/.github/workflows/playwright-docker.yml
+++ b/.github/workflows/playwright-docker.yml
@@ -122,7 +122,8 @@ jobs:
           url: "${{ inputs.grafana-url }}"
 
       - name: Run Playwright Tests
-        id: run-tests-profile
+        id: run-tests
+        # add the -f argument only if "inputs.grafana-compose-file" is defined
         run: |
           docker compose ${DOCKER_COMPOSE_FILE:+-f "$DOCKER_COMPOSE_FILE"} up --profile playwright --exit-code-from playwright
         env:

--- a/.github/workflows/playwright-docker.yml
+++ b/.github/workflows/playwright-docker.yml
@@ -37,11 +37,6 @@ on:
         required: false
         type: string
         description: Path to the docker-compose file to use for testing
-      playwright-compose-file:
-        required: false
-        type: string
-        description: Path to the docker-compose file to use for testing
-        default: docker-compose.playwright.yaml
       report-path:
         required: false
         type: string
@@ -126,11 +121,12 @@ jobs:
         with:
           url: "${{ inputs.grafana-url }}"
 
-      - name: Run Playwright tests
-        id: run-tests
-        run: docker compose -f "${PLAYWRIGHT_COMPOSE_FILE}" up --exit-code-from playwright
+      - name: Run Playwright Tests
+        id: run-tests-profile
+        run: |
+          docker compose ${DOCKER_COMPOSE_FILE:+-f "$DOCKER_COMPOSE_FILE"} up --profile playwright --exit-code-from playwright
         env:
-          PLAYWRIGHT_COMPOSE_FILE: ${{ inputs.playwright-compose-file }}
+          DOCKER_COMPOSE_FILE: ${{ inputs.grafana-compose-file }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/playwright-docker.yml
+++ b/.github/workflows/playwright-docker.yml
@@ -122,10 +122,14 @@ jobs:
           url: "${{ inputs.grafana-url }}"
 
       - name: Run Playwright Tests
+        description: |
+          Make sure to have a both a 'playwright' service with a 'playwright' profile
+          in your docker-compose.yaml file for the tests to run against
+          see: https://docs.docker.com/compose/how-tos/profiles/
         id: run-tests
         # add the -f argument only if "inputs.grafana-compose-file" is defined
         run: |
-          docker compose ${DOCKER_COMPOSE_FILE:+-f "$DOCKER_COMPOSE_FILE"} up --profile playwright --exit-code-from playwright
+          docker compose --profile playwright ${DOCKER_COMPOSE_FILE:+-f "$DOCKER_COMPOSE_FILE"} up playwright --exit-code-from playwright
         env:
           DOCKER_COMPOSE_FILE: ${{ inputs.grafana-compose-file }}
 

--- a/.github/workflows/playwright-docker.yml
+++ b/.github/workflows/playwright-docker.yml
@@ -5,6 +5,10 @@
 # eg e2e:/app/e2e
 
 name: Plugins - Dockerized Playwright E2E tests
+description: |
+  Make sure to have a both a 'playwright' service with a 'playwright' profile
+  in your docker-compose.yaml file for the tests to run against
+  see: https://docs.docker.com/compose/how-tos/profiles/
 
 on:
   workflow_call:
@@ -122,10 +126,6 @@ jobs:
           url: "${{ inputs.grafana-url }}"
 
       - name: Run Playwright Tests
-        description: |
-          Make sure to have a both a 'playwright' service with a 'playwright' profile
-          in your docker-compose.yaml file for the tests to run against
-          see: https://docs.docker.com/compose/how-tos/profiles/
         id: run-tests
         # add the -f argument only if "inputs.grafana-compose-file" is defined
         run: |


### PR DESCRIPTION
Simplify the playwright action by not needing a separate `docker-compose` for the playwright tests making use of docker profiles:

https://docs.docker.com/compose/how-tos/profiles/

This requires the root docker-compose to have a `playwright` service with a profile tag of `playwright` to run. That way the service won't start when doing a normal `docker compose up` and can only be called on demand when running the e2e tests.