### PR TITLE
Chore: bump setup-go hash

### DIFF
--- a/actions/plugins/setup/action.yml
+++ b/actions/plugins/setup/action.yml
@@ -21,7 +21,7 @@ runs:
         node-version: "${{ inputs.node-version }}"
 
     - name: Go
-      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version: "${{ inputs.go-version }}"
 

--- a/actions/plugins/setup/action.yml
+++ b/actions/plugins/setup/action.yml
@@ -24,6 +24,7 @@ runs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version: "${{ inputs.go-version }}"
+        cache: false
 
     - name: Mage
       shell: bash


### PR DESCRIPTION
Changes:
- Bumping setup-go version to 5.5.0
- setting cache:false to avoid cache collisions (https://github.com/actions/setup-go/blob/main/docs/adrs/0000-caching-dependencies.md)