### PR TITLE
fix: fix CD action to avoid referring to non-existent input

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -112,10 +112,6 @@ on:
         type: string
         default: playwright.config.ts
         description: Path to the Playwright config file to use for testing
-      playwright-e2e-docker-compose-file:
-        required: false
-        type: string
-        description: Path to the playwright docker-compose file
       playwright-grafana-url:
         description: The URL where Grafana is available at when running Playwright tests
         type: string
@@ -290,7 +286,6 @@ jobs:
       playwright-report-path: ${{ inputs.playwright-report-path }}
       playwright-docker-compose-file: ${{ inputs.playwright-docker-compose-file }}
       playwright-config: ${{ inputs.playwright-config }}
-      playwright-e2e-docker-compose-file: ${{ inputs.playwright-e2e-docker-compose-file }}
       playwright-grafana-url: ${{ inputs.playwright-grafana-url }}
       run-trufflehog: ${{ inputs.run-trufflehog }}
       trufflehog-version: ${{ inputs.trufflehog-version }}


### PR DESCRIPTION
PR #103 removed the input `playwright-e2e-docker-compose-file` from the
CI workflow, so when the current CD workflow tries to run it, it fails
with an 'invalid input' error (see [this example][example]).

This commit fixes the CD workflow to not use the input anymore.

[example]: https://github.com/grafana/grafana-assistant-app/actions/runs/15257411199
