### PR TITLE
feat: allow custom working directory for plugins

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -281,7 +281,7 @@ jobs:
 
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@custom-working-directory # zizmor: ignore[unpinned-uses]
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main # zizmor: ignore[unpinned-uses]
     needs:
       - setup
     with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -64,6 +64,13 @@ on:
         type: string
         required: false
 
+      # Build options.
+      working-directory:
+        description: Working directory for the action
+        type: string
+        required: false
+        default: .
+
       # Playwright
       run-playwright:
         description: Whether to run Playwright E2E tests.
@@ -274,6 +281,7 @@ jobs:
       - setup
     with:
       branch: ${{ inputs.branch }}
+      working-directory: ${{ inputs.working-directory }}
       go-version: ${{ inputs.go-version }}
       node-version: ${{ inputs.node-version }}
       golangci-lint-version: ${{ inputs.golangci-lint-version }}
@@ -364,7 +372,7 @@ jobs:
               echo 'environments=["dev", "ops"]'
               echo 'publish-docs=false'
             } >> "$GITHUB_OUTPUT"
-            
+
           elif [ "${ENVIRONMENT}" == 'prod' ]; then
             {
               echo 'environments=["dev", "ops", "prod"]'
@@ -376,7 +384,7 @@ jobs:
               echo 'environments=[]'
               echo 'publish-docs=false'
             } >> "$GITHUB_OUTPUT"
-            
+
           else
             echo "Invalid environment: ${ENVIRONMENT}"
             exit 1

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -66,10 +66,15 @@ on:
 
       # Build options.
       working-directory:
-        description: Working directory for the action
+        description: Working directory for the action. If provided, package-manager must also be provided.
         type: string
         required: false
         default: .
+      package-manager:
+        description: The package manager to use.
+        type: string
+        required: false
+        default: ""
 
       # Playwright
       run-playwright:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -65,8 +65,8 @@ on:
         required: false
 
       # Build options.
-      working-directory:
-        description: Working directory for the action. If provided, package-manager must also be provided.
+      plugin-directory:
+        description: Directory of the plugin, if not in the root of the repository. If provided, package-manager must also be provided.
         type: string
         required: false
         default: .
@@ -286,7 +286,7 @@ jobs:
       - setup
     with:
       branch: ${{ inputs.branch }}
-      working-directory: ${{ inputs.working-directory }}
+      plugin-directory: ${{ inputs.plugin-directory }}
       package-manager: ${{ inputs.package-manager }}
       go-version: ${{ inputs.go-version }}
       node-version: ${{ inputs.node-version }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -287,6 +287,7 @@ jobs:
     with:
       branch: ${{ inputs.branch }}
       working-directory: ${{ inputs.working-directory }}
+      package-manager: ${{ inputs.package-manager }}
       go-version: ${{ inputs.go-version }}
       node-version: ${{ inputs.node-version }}
       golangci-lint-version: ${{ inputs.golangci-lint-version }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -276,7 +276,7 @@ jobs:
 
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main # zizmor: ignore[unpinned-uses]
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@custom-working-directory # zizmor: ignore[unpinned-uses]
     needs:
       - setup
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,13 +262,14 @@ jobs:
       - name: Replace plugin version
         if: ${{ inputs.plugin-version-suffix != '' }}
         run: |
-          package_json_path="${{ inputs.plugin-directory }}/package.json"
+          package_json_path="$PLUGIN_DIRECTORY/package.json"
           version=$(jq -r .version "$package_json_path")
           pr_version="$version+${PLUGIN_VERSION_SUFFIX}"
           echo "Replacing plugin version \"$version\" with \"$pr_version\" in $package_json_path"
           jq --arg pr_version "$pr_version" '.version = $pr_version' "$package_json_path" > /tmp/package.json
           mv /tmp/package.json "$package_json_path"
         env:
+          PLUGIN_DIRECTORY: ${{ inputs.plugin-directory }}
           PLUGIN_VERSION_SUFFIX: ${{ inputs.plugin-version-suffix }}
         shell: bash
 
@@ -397,6 +398,7 @@ jobs:
     with:
       id: ${{ fromJSON(needs.test-and-build.outputs.plugin).id}}
       version: ${{ fromJSON(needs.test-and-build.outputs.plugin).version}}
+      plugin-directory: ${{ inputs.plugin-directory }}
       grafana-dependency: ${{ inputs.run-playwright-with-grafana-dependency }}
       skip-grafana-dev-image: ${{ inputs.run-playwright-with-skip-grafana-dev-image }}
       version-resolver-type: ${{ inputs.run-playwright-with-version-resolver-type }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,8 @@ on:
         required: false
 
       # Build options.
-      working-directory:
-        description: Working directory for the action. If provided, package-manager must also be provided.
+      plugin-directory:
+        description: Directory of the plugin, if not in the root of the repository. If provided, package-manager must also be provided.
         type: string
         required: false
         default: .
@@ -262,7 +262,7 @@ jobs:
       - name: Replace plugin version
         if: ${{ inputs.plugin-version-suffix != '' }}
         run: |
-          package_json_path="${{ inputs.working-directory }}/package.json"
+          package_json_path="${{ inputs.plugin-directory }}/package.json"
           version=$(jq -r .version "$package_json_path")
           pr_version="$version+${PLUGIN_VERSION_SUFFIX}"
           echo "Replacing plugin version \"$version\" with \"$pr_version\" in $package_json_path"
@@ -279,20 +279,20 @@ jobs:
           [ -f "Magefile.go" ] && r=true
           echo "has-backend=$r" >> "$GITHUB_OUTPUT"
         shell: bash
-        working-directory: ${{ inputs.working-directory }}
+        working-directory: ${{ inputs.plugin-directory }}
 
       - name: Test and build frontend
         uses: grafana/plugin-ci-workflows/actions/plugins/frontend@custom-working-directory # zizmor: ignore[unpinned-uses]
         with:
           package-manager: ${{ inputs.package-manager }}
-          working-directory: ${{ inputs.working-directory }}
+          plugin-directory: ${{ inputs.plugin-directory }}
 
       - name: Test and build backend
         if: ${{ steps.check-for-backend.outputs.has-backend == 'true' }}
         uses: grafana/plugin-ci-workflows/actions/plugins/backend@custom-working-directory # zizmor: ignore[unpinned-uses]
         with:
           github-token: ${{ steps.generate-github-token.outputs.token }}
-          working-directory: ${{ inputs.working-directory }}
+          plugin-directory: ${{ inputs.plugin-directory }}
 
       - name: Package universal ZIP
         id: universal-zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,13 +274,14 @@ jobs:
           [ -f "Magefile.go" ] && r=true
           echo "has-backend=$r" >> "$GITHUB_OUTPUT"
         shell: bash
+        working-directory: ${{ inputs.working-directory }}
 
       - name: Test and build frontend
-        uses: grafana/plugin-ci-workflows/actions/plugins/frontend@main # zizmor: ignore[unpinned-uses]
+        uses: grafana/plugin-ci-workflows/actions/plugins/frontend@custom-working-directory # zizmor: ignore[unpinned-uses]
 
       - name: Test and build backend
         if: ${{ steps.check-for-backend.outputs.has-backend == 'true' }}
-        uses: grafana/plugin-ci-workflows/actions/plugins/backend@main # zizmor: ignore[unpinned-uses]
+        uses: grafana/plugin-ci-workflows/actions/plugins/backend@custom-working-directory # zizmor: ignore[unpinned-uses]
         with:
           github-token: ${{ steps.generate-github-token.outputs.token }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,14 +283,14 @@ jobs:
         working-directory: ${{ inputs.plugin-directory }}
 
       - name: Test and build frontend
-        uses: grafana/plugin-ci-workflows/actions/plugins/frontend@custom-working-directory # zizmor: ignore[unpinned-uses]
+        uses: grafana/plugin-ci-workflows/actions/plugins/frontend@main # zizmor: ignore[unpinned-uses]
         with:
           package-manager: ${{ inputs.package-manager }}
           plugin-directory: ${{ inputs.plugin-directory }}
 
       - name: Test and build backend
         if: ${{ steps.check-for-backend.outputs.has-backend == 'true' }}
-        uses: grafana/plugin-ci-workflows/actions/plugins/backend@custom-working-directory # zizmor: ignore[unpinned-uses]
+        uses: grafana/plugin-ci-workflows/actions/plugins/backend@main # zizmor: ignore[unpinned-uses]
         with:
           github-token: ${{ steps.generate-github-token.outputs.token }}
           plugin-directory: ${{ inputs.plugin-directory }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,13 @@ on:
         type: string
         required: false
 
+      # Build options.
+      working-directory:
+        description: Working directory for the action
+        type: string
+        required: false
+        default: .
+
       # Playwright
       run-playwright:
         description: Whether to run Playwright E2E tests.
@@ -250,11 +257,12 @@ jobs:
       - name: Replace plugin version
         if: ${{ inputs.plugin-version-suffix != '' }}
         run: |
-          version=$(jq -r .version package.json)
+          package_json_path="${{ inputs.working-directory }}/package.json"
+          version=$(jq -r .version "$package_json_path")
           pr_version="$version+${PLUGIN_VERSION_SUFFIX}"
-          echo "Replacing plugin version \"$version\" with \"$pr_version\" in package.json"
-          jq --arg pr_version "$pr_version" '.version = $pr_version' package.json > /tmp/package.json
-          mv /tmp/package.json package.json
+          echo "Replacing plugin version \"$version\" with \"$pr_version\" in $package_json_path"
+          jq --arg pr_version "$pr_version" '.version = $pr_version' "$package_json_path" > /tmp/package.json
+          mv /tmp/package.json "$package_json_path"
         env:
           PLUGIN_VERSION_SUFFIX: ${{ inputs.plugin-version-suffix }}
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,12 +278,15 @@ jobs:
 
       - name: Test and build frontend
         uses: grafana/plugin-ci-workflows/actions/plugins/frontend@custom-working-directory # zizmor: ignore[unpinned-uses]
+        with:
+          working-directory: ${{ inputs.working-directory }}
 
       - name: Test and build backend
         if: ${{ steps.check-for-backend.outputs.has-backend == 'true' }}
         uses: grafana/plugin-ci-workflows/actions/plugins/backend@custom-working-directory # zizmor: ignore[unpinned-uses]
         with:
           github-token: ${{ steps.generate-github-token.outputs.token }}
+          working-directory: ${{ inputs.working-directory }}
 
       - name: Package universal ZIP
         id: universal-zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,15 @@ on:
 
       # Build options.
       working-directory:
-        description: Working directory for the action
+        description: Working directory for the action. If provided, package-manager must also be provided.
         type: string
         required: false
         default: .
+      package-manager:
+        description: The package manager to use.
+        type: string
+        required: false
+        default: ""
 
       # Playwright
       run-playwright:
@@ -279,6 +284,7 @@ jobs:
       - name: Test and build frontend
         uses: grafana/plugin-ci-workflows/actions/plugins/frontend@custom-working-directory # zizmor: ignore[unpinned-uses]
         with:
+          package-manager: ${{ inputs.package-manager }}
           working-directory: ${{ inputs.working-directory }}
 
       - name: Test and build backend

--- a/actions/plugins/backend/action.yml
+++ b/actions/plugins/backend/action.yml
@@ -5,8 +5,8 @@ inputs:
   github-token:
     description: GitHub token for downloading dependencies from private repos, if necessary
     required: true
-  working-directory:
-    description: Working directory for the action
+  plugin-directory:
+    description: Directory of the plugin, if not in the root of the repository. If provided, package-manager must also be provided.
     required: false
     default: .
 
@@ -21,31 +21,31 @@ runs:
 
     - name: Install dependencies
       run: go mod download
-      working-directory: ${{ inputs.working-directory }}
+      working-directory: ${{ inputs.plugin-directory }}
       shell: bash
 
     - name: Lint
       run: golangci-lint run --timeout=5m
-      working-directory: ${{ inputs.working-directory }}
+      working-directory: ${{ inputs.plugin-directory }}
       shell: bash
 
     - name: Test
       run: mage -v test
-      working-directory: ${{ inputs.working-directory }}
+      working-directory: ${{ inputs.plugin-directory }}
       shell: bash
 
     - name: Build
       run: mage -v buildAll
-      working-directory: ${{ inputs.working-directory }}
+      working-directory: ${{ inputs.plugin-directory }}
       shell: bash
 
     # The action should end up with a dist/ folder, but if the working directory is not the root of the repo,
     # we need to copy the dist/ folder to the root of the repo.
     - name: Copy dist if needed
       run: |
-        if [ "${{ inputs.working-directory }}" != "." ]; then
+        if [ "${{ inputs.plugin-directory }}" != "." ]; then
           mkdir -p dist
-          cp -r ${{ inputs.working-directory }}/dist/* dist/
+          cp -r ${{ inputs.plugin-directory }}/dist/* dist/
         fi
       shell: bash
-      if: inputs.working-directory != '.'
+      if: inputs.plugin-directory != '.'

--- a/actions/plugins/backend/action.yml
+++ b/actions/plugins/backend/action.yml
@@ -43,9 +43,11 @@ runs:
     # we need to copy the dist/ folder to the root of the repo.
     - name: Copy dist if needed
       run: |
-        if [ "${{ inputs.plugin-directory }}" != "." ]; then
+        if [ "$PLUGIN_DIRECTORY" != "." ]; then
           mkdir -p dist
-          cp -r ${{ inputs.plugin-directory }}/dist/* dist/
+          cp -r $PLUGIN_DIRECTORY/dist/* dist/
         fi
       shell: bash
+      env:
+        PLUGIN_DIRECTORY: ${{ inputs.plugin-directory }}
       if: inputs.plugin-directory != '.'

--- a/actions/plugins/backend/action.yml
+++ b/actions/plugins/backend/action.yml
@@ -5,6 +5,10 @@ inputs:
   github-token:
     description: GitHub token for downloading dependencies from private repos, if necessary
     required: true
+  working-directory:
+    description: Working directory for the action
+    required: false
+    default: .
 
 runs:
   using: composite
@@ -17,16 +21,31 @@ runs:
 
     - name: Install dependencies
       run: go mod download
+      working-directory: ${{ inputs.working-directory }}
       shell: bash
 
     - name: Lint
       run: golangci-lint run --timeout=5m
+      working-directory: ${{ inputs.working-directory }}
       shell: bash
 
     - name: Test
       run: mage -v test
+      working-directory: ${{ inputs.working-directory }}
       shell: bash
 
     - name: Build
       run: mage -v buildAll
+      working-directory: ${{ inputs.working-directory }}
       shell: bash
+
+    # The action should end up with a dist/ folder, but if the working directory is not the root of the repo,
+    # we need to copy the dist/ folder to the root of the repo.
+    - name: Copy dist if needed
+      run: |
+        if [ "${{ inputs.working-directory }}" != "." ]; then
+          mkdir -p dist
+          cp -r ${{ inputs.working-directory }}/dist/* dist/
+        fi
+      shell: bash
+      if: inputs.working-directory != '.'

--- a/actions/plugins/frontend/action.yml
+++ b/actions/plugins/frontend/action.yml
@@ -3,9 +3,13 @@ description: Tests, lints, typechecks and builds the frontend.
 
 inputs:
   working-directory:
-    description: Working directory for the action
+    description: Working directory for the action. If provided, package-manager must also be provided.
     required: false
     default: .
+  package-manager:
+    description: The package manager to use.
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -14,26 +18,36 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: ${{ github.action_path }}/pm.sh install
+      env:
+        PACKAGE_MANAGER: ${{ inputs.package-manager }}
 
     - name: Lint
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: ${{ github.action_path }}/pm.sh lint
+      env:
+        PACKAGE_MANAGER: ${{ inputs.package-manager }}
 
     - name: Typecheck
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: ${{ github.action_path }}/pm.sh typecheck
+      env:
+        PACKAGE_MANAGER: ${{ inputs.package-manager }}
 
     - name: Test
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: ${{ github.action_path }}/pm.sh test:ci
+      env:
+        PACKAGE_MANAGER: ${{ inputs.package-manager }}
 
     - name: Build
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: ${{ github.action_path }}/pm.sh build
+      env:
+        PACKAGE_MANAGER: ${{ inputs.package-manager }}
 
     # The action should end up with a dist/ folder, but if the working directory is not the root of the repo,
     # we need to copy the dist/ folder to the root of the repo.

--- a/actions/plugins/frontend/action.yml
+++ b/actions/plugins/frontend/action.yml
@@ -53,9 +53,11 @@ runs:
     # we need to copy the dist/ folder to the root of the repo.
     - name: Copy dist if needed
       run: |
-        if [ "${{ inputs.plugin-directory }}" != "." ]; then
+        if [ "$PLUGIN_DIRECTORY" != "." ]; then
           mkdir -p dist
-          cp -r ${{ inputs.plugin-directory }}/dist/* dist/
+          cp -r $PLUGIN_DIRECTORY/dist/* dist/
         fi
       shell: bash
       if: inputs.plugin-directory != '.'
+      env:
+        PLUGIN_DIRECTORY: ${{ inputs.plugin-directory }}

--- a/actions/plugins/frontend/action.yml
+++ b/actions/plugins/frontend/action.yml
@@ -2,8 +2,8 @@ name: Plugins - Frontend - Test and build
 description: Tests, lints, typechecks and builds the frontend.
 
 inputs:
-  working-directory:
-    description: Working directory for the action. If provided, package-manager must also be provided.
+  plugin-directory:
+    description: Directory of the plugin, if not in the root of the repository. If provided, package-manager must also be provided.
     required: false
     default: .
   package-manager:
@@ -16,35 +16,35 @@ runs:
   steps:
     - name: Install dependencies
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
+      working-directory: ${{ inputs.plugin-directory }}
       run: ${{ github.action_path }}/pm.sh install
       env:
         PACKAGE_MANAGER: ${{ inputs.package-manager }}
 
     - name: Lint
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
+      working-directory: ${{ inputs.plugin-directory }}
       run: ${{ github.action_path }}/pm.sh lint
       env:
         PACKAGE_MANAGER: ${{ inputs.package-manager }}
 
     - name: Typecheck
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
+      working-directory: ${{ inputs.plugin-directory }}
       run: ${{ github.action_path }}/pm.sh typecheck
       env:
         PACKAGE_MANAGER: ${{ inputs.package-manager }}
 
     - name: Test
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
+      working-directory: ${{ inputs.plugin-directory }}
       run: ${{ github.action_path }}/pm.sh test:ci
       env:
         PACKAGE_MANAGER: ${{ inputs.package-manager }}
 
     - name: Build
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
+      working-directory: ${{ inputs.plugin-directory }}
       run: ${{ github.action_path }}/pm.sh build
       env:
         PACKAGE_MANAGER: ${{ inputs.package-manager }}
@@ -53,9 +53,9 @@ runs:
     # we need to copy the dist/ folder to the root of the repo.
     - name: Copy dist if needed
       run: |
-        if [ "${{ inputs.working-directory }}" != "." ]; then
+        if [ "${{ inputs.plugin-directory }}" != "." ]; then
           mkdir -p dist
-          cp -r ${{ inputs.working-directory }}/dist/* dist/
+          cp -r ${{ inputs.plugin-directory }}/dist/* dist/
         fi
       shell: bash
-      if: inputs.working-directory != '.'
+      if: inputs.plugin-directory != '.'

--- a/actions/plugins/frontend/action.yml
+++ b/actions/plugins/frontend/action.yml
@@ -1,25 +1,47 @@
 name: Plugins - Frontend - Test and build
 description: Tests, lints, typechecks and builds the frontend.
 
+inputs:
+  working-directory:
+    description: Working directory for the action
+    required: false
+    default: .
+
 runs:
   using: composite
   steps:
     - name: Install dependencies
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
       run: ${{ github.action_path }}/pm.sh install
 
     - name: Lint
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
       run: ${{ github.action_path }}/pm.sh lint
 
     - name: Typecheck
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
       run: ${{ github.action_path }}/pm.sh typecheck
 
     - name: Test
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
       run: ${{ github.action_path }}/pm.sh test:ci
 
     - name: Build
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
       run: ${{ github.action_path }}/pm.sh build
+
+    # The action should end up with a dist/ folder, but if the working directory is not the root of the repo,
+    # we need to copy the dist/ folder to the root of the repo.
+    - name: Copy dist if needed
+      run: |
+        if [ "${{ inputs.working-directory }}" != "." ]; then
+          mkdir -p dist
+          cp -r ${{ inputs.working-directory }}/dist/* dist/
+        fi
+      shell: bash
+      if: inputs.working-directory != '.'

--- a/actions/plugins/frontend/pm.sh
+++ b/actions/plugins/frontend/pm.sh
@@ -14,8 +14,11 @@ install_pnpm_if_not_present() {
     fi
 }
 
+# Use provided package manager if set in PACKAGE_MANAGER environment variable
+if [ -n "$PACKAGE_MANAGER" ]; then
+	pm="$PACKAGE_MANAGER"
 # Detect the package manager
-if [ -f yarn.lock ]; then
+elif [ -f yarn.lock ]; then
 	pm="yarn"
 elif [ -f pnpm-lock.yaml ]; then
 	install_pnpm_if_not_present


### PR DESCRIPTION
This allows the actions to be used when plugins aren't located at the repo root, e.g. for the `grafana-llm-app` and `grafana-ml-app` plugins. You can see it in use [here](https://github.com/grafana/grafana-llm-app/pull/707).

It doesn't yet propagate this setting down to the playwright actions (e.g. the bit that determines Grafana dependency versions). I have a commit which does, but it needs changes to https://github.com/grafana/plugin-actions/tree/main/e2e-version too.

Note to self: before merging I'll need to switch all the nested workflow refs back to `main`!