### PR TITLE
CD: use provided plugin-directory for changelog-path

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -697,6 +697,8 @@ jobs:
       - name: Parse changelog
         id: changelog
         uses: grafana/plugin-ci-workflows/actions/plugins/changelog@main # zizmor: ignore[unpinned-uses]
+        with:
+          changelog-path: ${{ inputs.plugin-directory }}/CHANGELOG.md
 
       - name: Print changelog
         run: |


### PR DESCRIPTION
The new plugin-directory input is used to specify where the plugin lives,
but I hadn't got as far as the changelog action to notice we needed to
also provide the changelog-path input.

This commit does that.
