### PR TITLE
feat(playwright): allow custom plugin directories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,6 +398,7 @@ jobs:
     with:
       id: ${{ fromJSON(needs.test-and-build.outputs.plugin).id}}
       version: ${{ fromJSON(needs.test-and-build.outputs.plugin).version}}
+      plugin-directory: ${{ inputs.plugin-directory }}
       grafana-dependency: ${{ inputs.run-playwright-with-grafana-dependency }}
       skip-grafana-dev-image: ${{ inputs.run-playwright-with-skip-grafana-dev-image }}
       version-resolver-type: ${{ inputs.run-playwright-with-version-resolver-type }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -142,8 +142,9 @@ jobs:
         # add the -f argument only if "inputs.docker-compose-file" is defined
         run: |
           GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose ${DOCKER_COMPOSE_FILE:+-f "$DOCKER_COMPOSE_FILE"} up -d
+        working-directory: ${{ inputs.plugin-directory }}
         env:
-          DOCKER_COMPOSE_FILE: ${{ inputs.plugin-directory }}/${{ inputs.docker-compose-file }}
+          DOCKER_COMPOSE_FILE: ${{ inputs.docker-compose-file }}
 
       - name: Wait for Grafana to start
         uses: grafana/plugin-actions/wait-for-grafana@main # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -15,6 +15,11 @@ on:
         description: Plugin version
         type: string
         required: true
+      plugin-directory:
+        description: Directory of the plugin, if not in the root of the repository.
+        type: string
+        required: false
+        default: .
       # https://github.com/grafana/plugin-actions/blob/main/e2e-version/action.yml
       skip-grafana-dev-image:
         default: false
@@ -75,6 +80,7 @@ jobs:
           skip-grafana-dev-image: ${{ inputs.skip-grafana-dev-image }}
           version-resolver-type: ${{ inputs.version-resolver-type }}
           grafana-dependency: ${{ inputs.grafana-dependency }}
+          plugin-directory: ${{ inputs.plugin-directory }}
 
   playwright-tests:
     needs: resolve-versions
@@ -93,7 +99,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version-file: .nvmrc
+          node-version-file: ${{ inputs.plugin-directory }}/.nvmrc
 
       - name: Install npm dependencies
         # TODO: find a better way
@@ -104,6 +110,7 @@ jobs:
             npm ci
           fi
         shell: bash
+        working-directory: ${{ inputs.plugin-directory }}
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
@@ -129,13 +136,14 @@ jobs:
         env:
           PLUGIN_ID: ${{ inputs.id }}
           PLUGIN_VERSION: ${{ inputs.version }}
+        working-directory: ${{ inputs.plugin-directory }}
 
       - name: Start Grafana
         # add the -f argument only if "inputs.docker-compose-file" is defined
         run: |
           GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose ${DOCKER_COMPOSE_FILE:+-f "$DOCKER_COMPOSE_FILE"} up -d
         env:
-          DOCKER_COMPOSE_FILE: ${{ inputs.docker-compose-file }}
+          DOCKER_COMPOSE_FILE: ${{ inputs.plugin-directory }}/${{ inputs.docker-compose-file }}
 
       - name: Wait for Grafana to start
         uses: grafana/plugin-actions/wait-for-grafana@main # zizmor: ignore[unpinned-uses]
@@ -147,13 +155,14 @@ jobs:
         run: npx playwright test --config "${PLAYWRIGHT_CONFIG}"
         env:
           PLAYWRIGHT_CONFIG: ${{ inputs.playwright-config }}
+        working-directory: ${{ inputs.plugin-directory }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: ${{ (inputs.upload-artifacts == true) && ((always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure')) }}
         with:
           name: playwright-report-${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}
-          path: ${{ inputs.report-path }}
+          path: ${{ inputs.plugin-directory }}/${{ inputs.report-path }}
           retention-days: 30
 
   check-playwright-status:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -123,6 +123,7 @@ jobs:
 
       - name: Move dist artifacts
         run: |
+          rm -rf dist
           mkdir -p dist
           src=$(pwd)
 


### PR DESCRIPTION
Similar to recent PRs, this will allow the Playwright workflow to be
run for plugins that are located outside the root of the repository,
such as the grafana-llm-app.
