### PR TITLE
Chore: Use get-vault-secrets without exporting env variables

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -443,25 +443,26 @@ jobs:
 
       - name: Get secrets from Vault
         id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main # zizmor: ignore[unpinned-uses]
+        uses: grafana/shared-workflows/actions/get-vault-secrets@9f37f656e063f0ad0b0bfc38d49894b57d363936 # v1.2.1
         with:
           vault_instance: ${{ env.VAULT_INSTANCE }}
           common_secrets: |
             GCOM_PUBLISH_TOKEN_DEV=plugins/gcom-publish-token:dev
             GCOM_PUBLISH_TOKEN_OPS=plugins/gcom-publish-token:ops
             GCOM_PUBLISH_TOKEN_PROD=plugins/gcom-publish-token:prod
+          export_env: false
 
       - name: Determine which token to use
         run: |
           if [ "${ENVIRONMENT}" == 'dev' ]; then
             echo "Picked dev token"
-            token="${{ env.GCOM_PUBLISH_TOKEN_DEV }}"
+            token="${{ fromJSON(steps.get-secrets.outputs.secrets).GCOM_PUBLISH_TOKEN_DEV }}"
           elif [ "${ENVIRONMENT}" == 'ops' ]; then
             echo "Picked ops token"
-            token="${{ env.GCOM_PUBLISH_TOKEN_OPS }}"
+            token="${{ fromJSON(steps.get-secrets.outputs.secrets).GCOM_PUBLISH_TOKEN_OPS }}"
           elif [ "${ENVIRONMENT}" == 'prod' ]; then
             echo "Picked prod token"
-            token="${{ env.GCOM_PUBLISH_TOKEN_PROD }}"
+            token="${{ fromJSON(steps.get-secrets.outputs.secrets).GCOM_PUBLISH_TOKEN_PROD }}"
           else
             echo "Invalid environment: ${ENVIRONMENT}"
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,21 +233,22 @@ jobs:
       - name: Get secrets from Vault
         id: get-secrets
         if: ${{ env.IS_FORK == 'false' }}
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main # zizmor: ignore[unpinned-uses]
+        uses: grafana/shared-workflows/actions/get-vault-secrets@9f37f656e063f0ad0b0bfc38d49894b57d363936 # v1.2.1
         with:
           vault_instance: ${{ env.VAULT_INSTANCE }}
           common_secrets: |
             SIGN_PLUGIN_ACCESS_POLICY_TOKEN=plugins/sign-plugin-access-policy-token:token
             GITHUB_APP_ID=plugins-platform-bot-app:app-id
             GITHUB_APP_PRIVATE_KEY=plugins-platform-bot-app:private-key
+          export_env: false
 
       - name: Generate GitHub token
         id: generate-github-token
         uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         if: ${{ env.IS_FORK == 'false' }}
         with:
-          app-id: ${{ env.GITHUB_APP_ID }}
-          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
+          app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
+          private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       - name: Spellcheck
@@ -302,7 +303,7 @@ jobs:
           universal: "true"
           dist-folder: dist
           output-folder: dist-artifacts
-          access-policy-token: ${{ env.SIGN_PLUGIN_ACCESS_POLICY_TOKEN || '' }}
+          access-policy-token: ${{ fromJSON(steps.get-secrets.outputs.secrets).SIGN_PLUGIN_ACCESS_POLICY_TOKEN || '' }}
           allow-unsigned: ${{ env.IS_FORK == 'true' }}
 
       - name: Package os/arch ZIPs
@@ -312,7 +313,7 @@ jobs:
           universal: "false"
           dist-folder: dist
           output-folder: dist-artifacts
-          access-policy-token: ${{ env.SIGN_PLUGIN_ACCESS_POLICY_TOKEN || '' }}
+          access-policy-token: ${{ fromJSON(steps.get-secrets.outputs.secrets).SIGN_PLUGIN_ACCESS_POLICY_TOKEN || '' }}
           allow-unsigned: ${{ env.IS_FORK == 'true' }}
 
       - name: Trufflehog secrets scanning

--- a/actions/plugins/version-bump-changelog/action.yml
+++ b/actions/plugins/version-bump-changelog/action.yml
@@ -22,7 +22,7 @@ runs:
   steps:
     - name: Get secrets from Vault
       id: get-secrets
-      uses: grafana/shared-workflows/actions/get-vault-secrets@main # zizmor: ignore[unpinned-uses]
+      uses: grafana/shared-workflows/actions/get-vault-secrets@9f37f656e063f0ad0b0bfc38d49894b57d363936 # v1.2.1
       env:
         VAULT_INSTANCE: ops
       with:
@@ -30,13 +30,14 @@ runs:
         common_secrets: |
           GITHUB_APP_ID=plugins-platform-bot-app:app-id
           GITHUB_APP_PRIVATE_KEY=plugins-platform-bot-app:private-key
+        export_env: false
 
     - name: Generate GitHub token
       id: generate-github-token
       uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
       with:
-        app-id: ${{ env.GITHUB_APP_ID }}
-        private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
+        app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
+        private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
 
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -68,7 +69,7 @@ runs:
       env:
         INPUT_VERSION: ${{ inputs.version }}
         GITHUB_TOKEN: ${{ steps.generate-github-token.outputs.token }}
-    
+
     - name: Generate changelog
       if: ${{ inputs.generate-changelog == 'true' }}
       shell: bash


### PR DESCRIPTION
Moves the usage of get-vault-secrets to use step outputs instead of global env variables

Part of https://github.com/grafana/grafana-community-team/issues/427