### PR TITLE
Prevent re-uploading artifacts with the same tag/platform to GCS

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -497,7 +497,7 @@ jobs:
           gcloud-auth-token: ${{ steps.gcloud.outputs.id_token }}
 
       - name: Publish to catalog
-        uses: grafana/plugin-ci-workflows/actions/plugins/publish/publish@academo/prevent-republish # zizmor: ignore[unpinned-uses]
+        uses: grafana/plugin-ci-workflows/actions/plugins/publish/publish@main # zizmor: ignore[unpinned-uses]
         with:
           zips: ${{ needs.ci.outputs.gcs-zip-urls-commit }}
           environment: ${{ matrix.environment }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -236,10 +236,10 @@ jobs:
     steps:
       - name: Check environment
         run: |
-          # if [ -n "${ENVIRONMENT}" ] && [ "${ENVIRONMENT}" != 'none' ] && [ "${ENVIRONMENT}" != 'dev' ] && [ "${BRANCH}" != 'main' ]; then
-          #   echo "Only 'dev' environment is allowed for non-main branches."
-          #   exit 1
-          # fi
+          if [ -n "${ENVIRONMENT}" ] && [ "${ENVIRONMENT}" != 'none' ] && [ "${ENVIRONMENT}" != 'dev' ] && [ "${BRANCH}" != 'main' ]; then
+            echo "Only 'dev' environment is allowed for non-main branches."
+            exit 1
+          fi
 
           if [ "${DOCS_ONLY}" == 'true' ]; then
             if [ "${ENVIRONMENT}" != 'prod' ]; then

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -622,6 +622,7 @@ jobs:
       # this createse conflicts with checksums and will break the release
       # all environments use the same artifacts
       - name: Check if artifacts already exist
+        id: gcs_artifacts_exist
         run: |
           bucket_path="gs://${GCS_ARTIFACTS_RELEASE_PATH_TAG}/${PLATFORM}/"
           
@@ -641,7 +642,7 @@ jobs:
         shell: bash
 
       - name: Upload GCS release artifact (tag)
-        if: ${{ steps.paths.outputs.gcs_artifacts_exist == 'false' }}
+        if: ${{ steps.gcs_artifacts_exist.outputs.gcs_artifacts_exist == 'false' }}
         uses: google-github-actions/upload-cloud-storage@7c6e11cb7291594c5dfe0bc1dd9cd905e31e600c # v2.2.2
         with:
           path: /tmp/dist-artifacts
@@ -651,7 +652,7 @@ jobs:
           process_gcloudignore: false
 
       - name: Upload GCS release artifact (latest)
-        if: ${{ steps.paths.outputs.gcs_artifacts_exist == 'false' }}
+        if: ${{ steps.gcs_artifacts_exist.outputs.gcs_artifacts_exist == 'false' }}
         uses: google-github-actions/upload-cloud-storage@7c6e11cb7291594c5dfe0bc1dd9cd905e31e600c # v2.2.2
         with:
           path: /tmp/dist-artifacts-latest
@@ -661,7 +662,7 @@ jobs:
           process_gcloudignore: false
 
       - name: Upload GCS release artifacts (latest, any)
-        if: ${{ matrix.platform == 'any' && steps.paths.outputs.gcs_artifacts_exist == 'false' }}
+        if: ${{ matrix.platform == 'any' && steps.gcs_artifacts_exist.outputs.gcs_artifacts_exist == 'false' }}
         uses: google-github-actions/upload-cloud-storage@7c6e11cb7291594c5dfe0bc1dd9cd905e31e600c # v2.2.2
         with:
           path: /tmp/dist-artifacts-latest/${{ fromJSON(needs.ci.outputs.plugin).id }}-latest.zip

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -428,6 +428,22 @@ jobs:
           ref: ${{ inputs.branch }}
           persist-credentials: false
 
+      - name: Determine if it should continue the pipeline if a publishing conflict was detected
+        id: determine-continue
+        run: |
+          # when we deploy to prod, we also deploy to ops and dev by default
+          # when deploying to prod we ignore conflict errors in ops and dev
+          # because it is likely the plugin was deployed previously to those environments for testing
+          # we don't allow prod to fail on republishing
+          if [ "${is_cd_to_prod}" == 'true' ] && [ "${current_environment}" != 'prod' ]; then
+            echo "ignore_conflicts=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ignore_conflicts=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          is_cd_to_prod: ${{ contains(needs.define-variables.outputs.environments, 'prod') }}
+          current_environment: ${{ matrix.environment }}
+
       - name: Login to Google Cloud (ID token for IAP)
         id: gcloud
         uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
@@ -488,6 +504,8 @@ jobs:
           scopes: ${{ inputs.scopes }}
           gcom-publish-token: ${{ env.GCOM_PUBLISH_TOKEN }}
           gcloud-auth-token: ${{ steps.gcloud.outputs.id_token }}
+          ignore-conflicts: ${{ steps.determine-continue.outputs.ignore_conflicts }}
+
 
   trigger-argo-workflow:
     name: Trigger Argo Workflow for Grafana Cloud deployment

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -570,7 +570,7 @@ jobs:
 
       
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v2'
+        uses: 'google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a' # v2.1.4
         with:
           version: '>= 363.0.0'
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -600,6 +600,9 @@ jobs:
           GCS_UNIVERSAL_ZIP_URL_COMMIT: ${{ needs.ci.outputs.gcs-universal-zip-url-commit }}
         shell: bash
 
+      # if an artifact already exists we don't want to overwrite it
+      # this createse conflicts with checksums and will break the release
+      # all environments use the same artifacts
       - name: Check if artifacts already exist
         run: |
           bucket_path="gs://${GCS_ARTIFACTS_RELEASE_PATH_TAG}/${PLATFORM}/"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -236,10 +236,10 @@ jobs:
     steps:
       - name: Check environment
         run: |
-          if [ -n "${ENVIRONMENT}" ] && [ "${ENVIRONMENT}" != 'none' ] && [ "${ENVIRONMENT}" != 'dev' ] && [ "${BRANCH}" != 'main' ]; then
-            echo "Only 'dev' environment is allowed for non-main branches."
-            exit 1
-          fi
+          # if [ -n "${ENVIRONMENT}" ] && [ "${ENVIRONMENT}" != 'none' ] && [ "${ENVIRONMENT}" != 'dev' ] && [ "${BRANCH}" != 'main' ]; then
+          #   echo "Only 'dev' environment is allowed for non-main branches."
+          #   exit 1
+          # fi
 
           if [ "${DOCS_ONLY}" == 'true' ]; then
             if [ "${ENVIRONMENT}" != 'prod' ]; then

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -619,7 +619,7 @@ jobs:
         shell: bash
 
       # if an artifact already exists we don't want to overwrite it
-      # this createse conflicts with checksums and will break the release
+      # this creates conflicts with checksums and will break the release
       # all environments use the same artifacts
       - name: Check if artifacts already exist
         id: gcs_artifacts_exist

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -383,7 +383,7 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           elif [ "${ENVIRONMENT}" == 'ops' ]; then
             {
-              echo 'environments=["dev", "ops"]'
+              echo 'environments=["ops"]'
               echo 'publish-docs=false'
             } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -607,12 +607,11 @@ jobs:
           echo "Checking for any existing artifacts in: $bucket_path"
           
           if gsutil ls "$bucket_path" 2>/dev/null | grep -q "."; then
-            echo "❌ Artifacts already exist:"
-            gsutil ls "$bucket_path"
-            echo "::error::Release artifacts already exist for version $PLUGIN_VERSION platform $PLATFORM"
-            exit 1
+            echo "⚠️Existing artifact found, skipping upload"
+            echo "gcs_artifacts_exist=true" >> "$GITHUB_OUTPUT"
           else
             echo "✅ No existing artifacts found, proceeding with upload"
+            echo "gcs_artifacts_exist=false" >> "$GITHUB_OUTPUT"
           fi
         env:
           PLATFORM: ${{ matrix.platform }}
@@ -621,6 +620,7 @@ jobs:
         shell: bash
 
       - name: Upload GCS release artifact (tag)
+        if: ${{ steps.paths.outputs.gcs_artifacts_exist == 'false' }}
         uses: google-github-actions/upload-cloud-storage@7c6e11cb7291594c5dfe0bc1dd9cd905e31e600c # v2.2.2
         with:
           path: /tmp/dist-artifacts
@@ -630,6 +630,7 @@ jobs:
           process_gcloudignore: false
 
       - name: Upload GCS release artifact (latest)
+        if: ${{ steps.paths.outputs.gcs_artifacts_exist == 'false' }}
         uses: google-github-actions/upload-cloud-storage@7c6e11cb7291594c5dfe0bc1dd9cd905e31e600c # v2.2.2
         with:
           path: /tmp/dist-artifacts-latest
@@ -639,7 +640,7 @@ jobs:
           process_gcloudignore: false
 
       - name: Upload GCS release artifacts (latest, any)
-        if: ${{ matrix.platform == 'any' }}
+        if: ${{ matrix.platform == 'any' && steps.paths.outputs.gcs_artifacts_exist == 'false' }}
         uses: google-github-actions/upload-cloud-storage@7c6e11cb7291594c5dfe0bc1dd9cd905e31e600c # v2.2.2
         with:
           path: /tmp/dist-artifacts-latest/${{ fromJSON(needs.ci.outputs.plugin).id }}-latest.zip

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -497,7 +497,7 @@ jobs:
           gcloud-auth-token: ${{ steps.gcloud.outputs.id_token }}
 
       - name: Publish to catalog
-        uses: grafana/plugin-ci-workflows/actions/plugins/publish/publish@main # zizmor: ignore[unpinned-uses]
+        uses: grafana/plugin-ci-workflows/actions/plugins/publish/publish@academo/prevent-republish # zizmor: ignore[unpinned-uses]
         with:
           zips: ${{ needs.ci.outputs.gcs-zip-urls-commit }}
           environment: ${{ matrix.environment }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -568,6 +568,12 @@ jobs:
           workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
           service_account: github-plugin-ci-workflows@grafanalabs-workload-identity.iam.gserviceaccount.com
 
+      
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v2'
+        with:
+          version: '>= 363.0.0'
+
       - name: Determine GCS artifacts paths
         id: paths
         run: |
@@ -592,6 +598,26 @@ jobs:
           PLUGIN_ID: ${{ fromJSON(needs.ci.outputs.plugin).id }}
           PLUGIN_VERSION: ${{ fromJSON(needs.ci.outputs.plugin).version }}
           GCS_UNIVERSAL_ZIP_URL_COMMIT: ${{ needs.ci.outputs.gcs-universal-zip-url-commit }}
+        shell: bash
+
+      - name: Check if artifacts already exist
+        run: |
+          bucket_path="gs://${GCS_ARTIFACTS_RELEASE_PATH_TAG}/${PLATFORM}/"
+          
+          echo "Checking for any existing artifacts in: $bucket_path"
+          
+          if gsutil ls "$bucket_path" 2>/dev/null | grep -q "."; then
+            echo "❌ Artifacts already exist:"
+            gsutil ls "$bucket_path"
+            echo "::error::Release artifacts already exist for version $PLUGIN_VERSION platform $PLATFORM"
+            exit 1
+          else
+            echo "✅ No existing artifacts found, proceeding with upload"
+          fi
+        env:
+          PLATFORM: ${{ matrix.platform }}
+          PLUGIN_VERSION: ${{ fromJSON(needs.ci.outputs.plugin).version }}
+          GCS_ARTIFACTS_RELEASE_PATH_TAG: ${{ steps.paths.outputs.gcs_artifacts_release_path_tag }}
         shell: bash
 
       - name: Upload GCS release artifact (tag)

--- a/actions/plugins/publish/publish/action.yml
+++ b/actions/plugins/publish/publish/action.yml
@@ -42,6 +42,13 @@ inputs:
       Required only for publishing to dev or ops.
     required: false
     default: ""
+  ignore-conflicts:
+    description: |
+      If "true", ignore conflicts when publishing to the catalog.
+      A conflict occurs when publishing a plugin with the same name and version
+      Note: this is not a force publish.
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -67,4 +74,6 @@ runs:
         ZIPS: ${{ inputs.zips }}
         ENVIRONMENT: ${{ inputs.environment }}
         SCOPES: ${{ inputs.scopes }}
+
+        IGNORE_CONFLICTS: ${{ inputs.ignore-conflicts }}
       shell: bash

--- a/actions/plugins/publish/publish/publish.sh
+++ b/actions/plugins/publish/publish/publish.sh
@@ -146,9 +146,17 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
+# Determine if publish succeeded
 if [[ $(echo "$out" | jq -r '.plugin.id? // empty') != "" ]]; then
     echo -e "\nPlugin published successfully"
 else
+    error_code=$(echo "$out" | jq -r '.code? // empty')
+    error_message=$(echo "$out" | jq -r '.message? // empty')
+    if [[ "${IGNORE_CONFLICTS,,}" == "true" && "${error_code}" == "InvalidArgument" && "${error_message}" == *"version already exists"* ]]; then
+        echo -e "\nPlugin version already exists; IGNORE_CONFLICTS=true so treating as success"
+        exit 0
+    fi
+
     echo -e "\nPlugin publish failed"
     exit 1
 fi


### PR DESCRIPTION
This PR contains three main changes:

* It prevents GCS artifacts from being overwritten [1]
* It allows ops and dev to ignore gcom re-publishing errors when the deploy target is prod. [2]
* Releasing to ops doesn't longer releases to dev. This introduces higher complexity in the pipeline and it is not always the desired behaviour 

Leaving a longer explanation here for future reference

# [1] prevent GCS artifacts overwrite

Overwriting GCS artifacts creates issues on checksums due to several caching mechanisms in cloud. We generally don't want under almost any circumstance that a plugin artifact in GCS gets overwritten. 

The fix: if the artifact already exists (checked by version-name-platform), it skips the uploading step.

Why not fail if the artifact exists?

Because we use the same artifact in all environments, if we were to do a stepped deploy, first to dev, ops and prod. We'll get an error in ops because the artifact was already there from the dev deployment.

# [2] ignore re-publishing errors in dev and ops when deploying to prod. 

We generally don't want any plugin version to be republished. So we will always fail if a plugin tries to republish in prod.

Why do we allow ops and dev to ignore errors on republish?

We only ignore the errors if we target prod. deploying to prod also triggers a deploy to ops and dev. In the case of a stepped release where we released to dev, then ops, then prod, we will find errors when releasing to prod because dev and ops already exist. 

We will always fail a re-publish in prod. 

Will it fail for errors other than republishing?

yes, we only ignore republishing errors.  

# test runs

Success dev release: https://github.com/grafana/plugins-drone-to-gha/actions/runs/15872094097
error dev re-release of the same version: https://github.com/grafana/plugins-drone-to-gha/actions/runs/15872606544
success prod release: https://github.com/grafana/plugins-drone-to-gha/actions/runs/15872264335

in the prod release test, we got a stub error in ops, this is unrelated to the pr changes. 

It proves both that we only ignore republishing errors and that we correctly ignore republishing errors (in the case of dev)