### PR TITLE
CD: Add docs link when stub doesn't exist

### DIFF
--- a/actions/plugins/publish/check-and-create-stub/check-and-create-stub.sh
+++ b/actions/plugins/publish/check-and-create-stub/check-and-create-stub.sh
@@ -88,6 +88,9 @@ gcom_signature_type=$(
 )
 if [ "$gcom_signature_type" == "null" ]; then
     echo "Invalid signature type in prod - make sure the stub exists in grafana.com"
+    echo "If this is a brand new plugin, you need to create the stub in grafana.com (prod) first, also when publishing to dev or ops."
+    echo "See the documentation for more details:"
+    echo "https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#publishing-a-brand-new-plugin-for-the-first-time"
     exit 1
 fi
 echo "Signature type for $plugin_id is $gcom_signature_type"


### PR DESCRIPTION
Clarifies what to do when a stub doesn't exist in prod by adding a link to the docs