### PR TITLE
CD: Allow publishing to more than one environment via inputs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -365,9 +365,9 @@ jobs:
         with:
           script: |
             // Helper to get input/env values
-            const getInput = (name, fallback = '') => {
-              return process.env[name] !== undefined ? process.env[name] : fallback;
-            };
+            function getInput(name) {
+              return process.env[name] !== undefined ? process.env[name] : '';
+            }
 
             const ENVIRONMENT = getInput('ENVIRONMENT');
             const DOCS_ONLY = getInput('DOCS_ONLY');

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -365,11 +365,11 @@ jobs:
         with:
           script: |
             // Helper to get input/env values
-            function getInput(name) {
-              return process.env[name] !== undefined ? process.env[name] : '';
+            function getInput(name, fallback = '') {
+              return process.env[name] !== undefined ? process.env[name] : fallback;
             }
 
-            const ENVIRONMENT = getInput('ENVIRONMENT');
+            const ENVIRONMENT = getInput('ENVIRONMENT', 'none');
             const DOCS_ONLY = getInput('DOCS_ONLY');
             const HAS_BACKEND = getInput('HAS_BACKEND');
 
@@ -388,7 +388,7 @@ jobs:
             }
 
             // Special case to skip deployment
-            if (!ENVIRONMENT || ENVIRONMENT === 'none') {
+            if (ENVIRONMENT === 'none') {
               core.setOutput('environments', JSON.stringify([]));
               core.setOutput('publish-docs', 'false');
               return;

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -397,7 +397,7 @@ jobs:
               echo 'environments=[]'
               echo 'publish-docs=true'
             } >> "$GITHUB_OUTPUT"
-          elif [ "${environments}" == 'prod' ]; then
+          elif echo "${environments}" | jq 'index("prod") != null'; then
             # Special case: 'prod' deploys to all environments, to keep the catalogs in sync.
             environments="$allowed_environments"
           elif [ "${environments}" == "[]" ]; then

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -241,10 +241,10 @@ jobs:
     steps:
       - name: Check environment
         run: |
-          if [ -n "${ENVIRONMENT}" ] && [ "${ENVIRONMENT}" != 'none' ] && [ "${ENVIRONMENT}" != 'dev' ] && [ "${BRANCH}" != 'main' ]; then
-            echo "Only 'dev' environment is allowed for non-main branches."
-            exit 1
-          fi
+          #if [ -n "${ENVIRONMENT}" ] && [ "${ENVIRONMENT}" != 'none' ] && [ "${ENVIRONMENT}" != 'dev' ] && [ "${BRANCH}" != 'main' ]; then
+          #  echo "Only 'dev' environment is allowed for non-main branches."
+          #  exit 1
+          #fi
 
           if [ "${DOCS_ONLY}" == 'true' ]; then
             if [ "${ENVIRONMENT}" != 'prod' ]; then

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -382,19 +382,23 @@ jobs:
           # Define environments matrix,
           # and deploy docs only if we are publishing to prod
           # Split ENVIRONMENT by comma, remove spaces, and filter only allowed values
-          allowed_environments="dev|ops|prod"
+          allowed_environments='["dev", "ops", "prod"]'
+          allowed_environments_regex=$(echo "${allowed_environments}" | jq -r 'join("|")')
           environments=$(echo "${ENVIRONMENT}" | tr ',' '\n' | sed 's/ //g' | grep -E "^(${allowed_environments})$" | jq -R . | jq -s 'unique')
           # If empty or 'none', set to empty array
           if [ -z "${ENVIRONMENT}" ] || [ "${ENVIRONMENT}" == 'none' ]; then
-          {
-            echo 'environments=[]'
-            echo 'publish-docs=false'
-          } >> "$GITHUB_OUTPUT"
+            {
+              echo 'environments=[]'
+              echo 'publish-docs=false'
+            } >> "$GITHUB_OUTPUT"
           elif [ "${DOCS_ONLY}" == 'true' ]; then
-          {
-            echo 'environments=[]'
-            echo 'publish-docs=true'
-          } >> "$GITHUB_OUTPUT"
+            {
+              echo 'environments=[]'
+              echo 'publish-docs=true'
+            } >> "$GITHUB_OUTPUT"
+          elif [ "${environments}" == 'prod' ]; then
+            # Special case: 'prod' deploys to all environments, to keep the catalogs in sync.
+            environments="$allowed_environments"
           elif [ "${environments}" == "[]" ]; then
             echo "Invalid environment(s): ${ENVIRONMENT}"
             exit 1

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -241,10 +241,10 @@ jobs:
     steps:
       - name: Check environment
         run: |
-          #if [ -n "${ENVIRONMENT}" ] && [ "${ENVIRONMENT}" != 'none' ] && [ "${ENVIRONMENT}" != 'dev' ] && [ "${BRANCH}" != 'main' ]; then
-          #  echo "Only 'dev' environment is allowed for non-main branches."
-          #  exit 1
-          #fi
+          if [ -n "${ENVIRONMENT}" ] && [ "${ENVIRONMENT}" != 'none' ] && [ "${ENVIRONMENT}" != 'dev' ] && [ "${BRANCH}" != 'main' ]; then
+            echo "Only 'dev' environment is allowed for non-main branches."
+            exit 1
+          fi
 
           if [ "${DOCS_ONLY}" == 'true' ]; then
             if [ "${ENVIRONMENT}" != 'prod' ]; then
@@ -442,6 +442,7 @@ jobs:
         with:
           ref: ${{ inputs.branch }}
           persist-credentials: false
+
 
       - name: Determine if it should continue the pipeline if a publishing conflict was detected
         id: determine-continue
@@ -688,8 +689,8 @@ jobs:
           process_gcloudignore: false
 
       # all zip artifacts are already present in /tmp/dist-artifacts
-      # we can generate all the urls here in a single step
-      # as a matrix job this will run for each platform
+      # we can generate all the urls here in a single step 
+      # as a matrix job this will run for each platform 
       # and we will keep the last one. They all generate the same urls.
       - name: Generate GCS release URLs
         id: generate-urls
@@ -699,18 +700,18 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-
+            
             const gcsPrefix = 'https://storage.googleapis.com';
             const gcsPath = process.env.GCS_ARTIFACTS_RELEASE_PATH_TAG;
             const allUrls = [];
-
+            
             // Find all zip files in the artifacts directory
             const artifactsDir = '/tmp/dist-artifacts';
             const files = fs.readdirSync(artifactsDir);
             const zipFiles = files.filter(file => file.endsWith('.zip'));
-
+            
             console.log(`Found ${zipFiles.length} zip files:`, zipFiles);
-
+            
             // Create GCS URLs for all zip files, each in its correct platform directory
             for (const zipFile of zipFiles) {
               let targetPlatform;
@@ -735,7 +736,7 @@ jobs:
               allUrls.push(gcsUrl);
               console.log(`Generated GCS URL: ${gcsUrl}`);
             }
-
+            
             const gcsZipUrls = JSON.stringify(allUrls);
             console.log(`Generated ${allUrls.length} total URLs:`, gcsZipUrls);
             core.setOutput('gcs-zip-urls', gcsZipUrls);

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -389,7 +389,7 @@ jobs:
               return;
             }
 
-            // Speical case to skip deployment
+            // Special case to skip deployment
             if (!ENVIRONMENT || ENVIRONMENT === 'none') {
               core.setOutput('environments', JSON.stringify([]));
               core.setOutput('publish-docs', 'false');

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -361,59 +361,69 @@ jobs:
     steps:
       - name: Define variables
         id: vars
-        run: |
-          # Platforms matrix
-          if [ "${HAS_BACKEND}" == 'true' ]; then
-            platforms='["linux", "darwin", "windows", "any"]'
-          else
-            platforms='["any"]'
-          fi
-          echo "platforms=$platforms" >> "$GITHUB_OUTPUT"
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            // Helper to get input/env values
+            const getInput = (name, fallback = '') => {
+              return process.env[name] !== undefined ? process.env[name] : fallback;
+            };
 
-          # If we are publishing docs only, we don't need to deploy the plugin
-          if [ "${DOCS_ONLY}" == 'true' ]; then
-            {
-              echo 'environments=[]'
-              echo 'publish-docs=true'
-            } >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+            const ENVIRONMENT = getInput('ENVIRONMENT');
+            const DOCS_ONLY = getInput('DOCS_ONLY');
+            const HAS_BACKEND = getInput('HAS_BACKEND');
 
-          allowed_environments='["dev", "ops", "prod"]'
-          allowed_environments_regex=$(echo "${allowed_environments}" | jq -r 'join("|")')
+            // Platforms matrix
+            let platforms;
+            if (HAS_BACKEND === 'true') {
+              platforms = ['linux', 'darwin', 'windows', 'any'];
+            } else {
+              platforms = ['any'];
+            }
+            core.setOutput('platforms', JSON.stringify(platforms));
 
-          # Define environments matrix,
-          # and deploy docs only if we are publishing to prod
-          # Split ENVIRONMENT by comma, remove spaces, and filter only allowed values
-          environments=$(echo "${ENVIRONMENT}" | tr ',' '\n' | sed 's/ //g' | grep -E "^(${allowed_environments_regex})$" | jq -R . | jq -s 'unique')
-          # If empty or 'none', set to empty array
-          if [ -z "${ENVIRONMENT}" ] || [ "${ENVIRONMENT}" == 'none' ]; then
-            {
-              echo 'environments=[]'
-              echo 'publish-docs=false'
-            } >> "$GITHUB_OUTPUT"
-            exit 0
-          elif [[ "${environments}" == *"prod"* ]]; then
-            # Special case: 'prod' deploys to all environments, to keep the catalogs in sync.
-            environments="$allowed_environments"
-          elif [ "${environments}" == "[]" ]; then
-            echo "Invalid environment(s): ${ENVIRONMENT}"
-            exit 1
-          fi
+            // Docs only: skip plugin deployment
+            if (DOCS_ONLY === 'true') {
+              core.setOutput('environments', JSON.stringify([]));
+              core.setOutput('publish-docs', 'true');
+              return;
+            }
 
-          # publish-docs is true if 'prod' is in the environments list
-          publish_docs=$(echo "${environments}" | jq 'index("prod") != null')
-          # minify "environments" to a single line, or it won't be parsed properly
-          environments=$(echo "${environments}" | jq -Mc .)
-          {
-            echo "environments=${environments}"
-            echo "publish-docs=${publish_docs}"
-          } >> "$GITHUB_OUTPUT"
+            // Speical case to skip deployment
+            if (!ENVIRONMENT || ENVIRONMENT === 'none') {
+              core.setOutput('environments', JSON.stringify([]));
+              core.setOutput('publish-docs', 'false');
+              return;
+            }
+
+            // Parse and filter environments
+            const allowedEnvironments = ['dev', 'ops', 'prod'];
+            let environments = [];
+            environments = ENVIRONMENT.split(',')
+              .map(e => e.trim())
+              .filter(e => allowedEnvironments.includes(e));
+
+            // Special case: 'prod' means all environments
+            if (environments.includes('prod')) {
+              environments = allowedEnvironments;
+            }
+
+            // Remove duplicates and sort
+            environments = Array.from(new Set(environments));
+
+            if (environments.length === 0) {
+              core.setFailed(`Invalid environment(s): ${ENVIRONMENT}`);
+              return;
+            }
+
+            // publish-docs is true if 'prod' is in the environments list
+            const publishDocs = environments.includes('prod');
+            core.setOutput('environments', JSON.stringify(environments));
+            core.setOutput('publish-docs', String(publishDocs));
         env:
           ENVIRONMENT: ${{ inputs.environment }}
           DOCS_ONLY: ${{ inputs.docs-only }}
           HAS_BACKEND: ${{ fromJSON(needs.ci.outputs.plugin).has-backend }}
-        shell: bash
 
   publish-to-catalog:
     name: Publish to catalog (${{ matrix.environment }})
@@ -630,9 +640,9 @@ jobs:
         id: gcs_artifacts_exist
         run: |
           bucket_path="gs://${GCS_ARTIFACTS_RELEASE_PATH_TAG}/${PLATFORM}/"
-          
+
           echo "Checking for any existing artifacts in: $bucket_path"
-          
+
           if gsutil ls "$bucket_path" 2>/dev/null | grep -q "."; then
             echo "⚠️Existing artifact found, skipping upload"
             echo "gcs_artifacts_exist=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -241,10 +241,10 @@ jobs:
     steps:
       - name: Check environment
         run: |
-          #if [ -n "${ENVIRONMENT}" ] && [ "${ENVIRONMENT}" != 'none' ] && [ "${ENVIRONMENT}" != 'dev' ] && [ "${BRANCH}" != 'main' ]; then
-          #  echo "Only 'dev' environment is allowed for non-main branches."
-          #  exit 1
-          #fi
+          if [ -n "${ENVIRONMENT}" ] && [ "${ENVIRONMENT}" != 'none' ] && [ "${ENVIRONMENT}" != 'dev' ] && [ "${BRANCH}" != 'main' ]; then
+            echo "Only 'dev' environment is allowed for non-main branches."
+            exit 1
+          fi
 
           if [ "${DOCS_ONLY}" == 'true' ]; then
             if [ "${ENVIRONMENT}" != 'prod' ]; then

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -241,10 +241,10 @@ jobs:
     steps:
       - name: Check environment
         run: |
-          if [ -n "${ENVIRONMENT}" ] && [ "${ENVIRONMENT}" != 'none' ] && [ "${ENVIRONMENT}" != 'dev' ] && [ "${BRANCH}" != 'main' ]; then
-            echo "Only 'dev' environment is allowed for non-main branches."
-            exit 1
-          fi
+          #if [ -n "${ENVIRONMENT}" ] && [ "${ENVIRONMENT}" != 'none' ] && [ "${ENVIRONMENT}" != 'dev' ] && [ "${BRANCH}" != 'main' ]; then
+          #  echo "Only 'dev' environment is allowed for non-main branches."
+          #  exit 1
+          #fi
 
           if [ "${DOCS_ONLY}" == 'true' ]; then
             if [ "${ENVIRONMENT}" != 'prod' ]; then
@@ -442,7 +442,6 @@ jobs:
         with:
           ref: ${{ inputs.branch }}
           persist-credentials: false
-
 
       - name: Determine if it should continue the pipeline if a publishing conflict was detected
         id: determine-continue
@@ -689,8 +688,8 @@ jobs:
           process_gcloudignore: false
 
       # all zip artifacts are already present in /tmp/dist-artifacts
-      # we can generate all the urls here in a single step 
-      # as a matrix job this will run for each platform 
+      # we can generate all the urls here in a single step
+      # as a matrix job this will run for each platform
       # and we will keep the last one. They all generate the same urls.
       - name: Generate GCS release URLs
         id: generate-urls
@@ -700,18 +699,18 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            
+
             const gcsPrefix = 'https://storage.googleapis.com';
             const gcsPath = process.env.GCS_ARTIFACTS_RELEASE_PATH_TAG;
             const allUrls = [];
-            
+
             // Find all zip files in the artifacts directory
             const artifactsDir = '/tmp/dist-artifacts';
             const files = fs.readdirSync(artifactsDir);
             const zipFiles = files.filter(file => file.endsWith('.zip'));
-            
+
             console.log(`Found ${zipFiles.length} zip files:`, zipFiles);
-            
+
             // Create GCS URLs for all zip files, each in its correct platform directory
             for (const zipFile of zipFiles) {
               let targetPlatform;
@@ -736,7 +735,7 @@ jobs:
               allUrls.push(gcsUrl);
               console.log(`Generated GCS URL: ${gcsUrl}`);
             }
-            
+
             const gcsZipUrls = JSON.stringify(allUrls);
             console.log(`Generated ${allUrls.length} total URLs:`, gcsZipUrls);
             core.setOutput('gcs-zip-urls', gcsZipUrls);

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -374,11 +374,9 @@ jobs:
             const HAS_BACKEND = getInput('HAS_BACKEND');
 
             // Platforms matrix
-            let platforms;
+            let platforms = ['any'];
             if (HAS_BACKEND === 'true') {
               platforms = ['linux', 'darwin', 'windows', 'any'];
-            } else {
-              platforms = ['any'];
             }
             core.setOutput('platforms', JSON.stringify(platforms));
 
@@ -403,13 +401,13 @@ jobs:
               .map(e => e.trim())
               .filter(e => allowedEnvironments.includes(e));
 
-            // Special case: 'prod' means all environments
+            // Special case: 'prod' means we deploy to all environments
             if (environments.includes('prod')) {
               environments = allowedEnvironments;
             }
 
             // Remove duplicates and sort
-            environments = Array.from(new Set(environments));
+            environments = Array.from(new Set(environments)).sort();
 
             if (environments.length === 0) {
               core.setFailed(`Invalid environment(s): ${ENVIRONMENT}`);

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -175,13 +175,18 @@ on:
       environment:
         description: |
           Environment(s) to publish to.
-          Can be 'none' (or empty string), 'dev', 'ops', or 'prod'.
+          This will decide which environment(s) are used to publish to:
+          - The plugins catalog
+          - Grafana Cloud (if configured)
 
-          Publishing to 'ops' will also deploy to 'dev'.
-          Publishing to 'prod' will also deploy to 'ops' and 'dev'.
-          Setting it to 'none' will skip the deployment and run CI only.
+          Allowed values:
+          - `none` (or empty string): Skip deployment (run only CI)
+          - `dev`: Deploy to dev catalog
+          - `ops`: Deploy to ops catalog
+          - `prod`: Deploy to dev AND ops AND prod
+          - A comma separated combination of the values above. E.g.: `dev,ops`
 
-          Docs will only be published to the website when targeting 'prod'.
+          Docs will only be published to the website when targeting `prod`.
         required: true
         type: string
       docs-only:
@@ -376,32 +381,30 @@ jobs:
 
           # Define environments matrix,
           # and deploy docs only if we are publishing to prod
-          if [ "${ENVIRONMENT}" == 'dev' ]; then
-            {
-              echo 'environments=["dev"]'
-              echo 'publish-docs=false'
-            } >> "$GITHUB_OUTPUT"
-          elif [ "${ENVIRONMENT}" == 'ops' ]; then
-            {
-              echo 'environments=["ops"]'
-              echo 'publish-docs=false'
-            } >> "$GITHUB_OUTPUT"
-
-          elif [ "${ENVIRONMENT}" == 'prod' ]; then
-            {
-              echo 'environments=["dev", "ops", "prod"]'
-              echo 'publish-docs=true'
-            } >> "$GITHUB_OUTPUT"
-
-          elif [ -z "${ENVIRONMENT}" ] || [ "${ENVIRONMENT}" == 'none' ]; then
-            {
-              echo 'environments=[]'
-              echo 'publish-docs=false'
-            } >> "$GITHUB_OUTPUT"
-
-          else
-            echo "Invalid environment: ${ENVIRONMENT}"
+          # Split ENVIRONMENT by comma, remove spaces, and filter only allowed values
+          allowed_environments="dev|ops|prod"
+          environments=$(echo "${ENVIRONMENT}" | tr ',' '\n' | sed 's/ //g' | grep -E "^(${allowed_environments})$" | jq -R . | jq -s 'unique')
+          # If empty or 'none', set to empty array
+          if [ -z "${ENVIRONMENT}" ] || [ "${ENVIRONMENT}" == 'none' ]; then
+          {
+            echo 'environments=[]'
+            echo 'publish-docs=false'
+          } >> "$GITHUB_OUTPUT"
+          elif [ "${DOCS_ONLY}" == 'true' ]; then
+          {
+            echo 'environments=[]'
+            echo 'publish-docs=true'
+          } >> "$GITHUB_OUTPUT"
+          elif [ "${environments}" == "[]" ]; then
+            echo "Invalid environment(s): ${ENVIRONMENT}"
             exit 1
+          else
+          # publish-docs is true if 'prod' is in the environments list
+          publish_docs=$(echo "${environments}" | jq 'index("prod") != null')
+          {
+            echo "environments=${environments}"
+            echo "publish-docs=${publish_docs}"
+          } >> "$GITHUB_OUTPUT"
           fi
         env:
           ENVIRONMENT: ${{ inputs.environment }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -397,19 +397,21 @@ jobs:
               echo 'environments=[]'
               echo 'publish-docs=true'
             } >> "$GITHUB_OUTPUT"
-          elif echo "${environments}" | jq 'index("prod") != null'; then
+          elif [[ "${environments}" == *"prod"* ]]; then
             # Special case: 'prod' deploys to all environments, to keep the catalogs in sync.
             environments="$allowed_environments"
           elif [ "${environments}" == "[]" ]; then
             echo "Invalid environment(s): ${ENVIRONMENT}"
             exit 1
           else
-          # publish-docs is true if 'prod' is in the environments list
-          publish_docs=$(echo "${environments}" | jq 'index("prod") != null')
-          {
-            echo "environments=${environments}"
-            echo "publish-docs=${publish_docs}"
-          } >> "$GITHUB_OUTPUT"
+            # publish-docs is true if 'prod' is in the environments list
+            publish_docs=$(echo "${environments}" | jq 'index("prod") != null')
+            # minify "environments" to a single line, or it won't be parsed properly
+            environments=$(echo "${environments}" | jq -Mc .)
+            {
+              echo "environments=${environments}"
+              echo "publish-docs=${publish_docs}"
+            } >> "$GITHUB_OUTPUT"
           fi
         env:
           ENVIRONMENT: ${{ inputs.environment }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -392,27 +392,23 @@ jobs:
               echo 'environments=[]'
               echo 'publish-docs=false'
             } >> "$GITHUB_OUTPUT"
-          elif [ "${DOCS_ONLY}" == 'true' ]; then
-            {
-              echo 'environments=[]'
-              echo 'publish-docs=true'
-            } >> "$GITHUB_OUTPUT"
+            exit 0
           elif [[ "${environments}" == *"prod"* ]]; then
             # Special case: 'prod' deploys to all environments, to keep the catalogs in sync.
             environments="$allowed_environments"
           elif [ "${environments}" == "[]" ]; then
             echo "Invalid environment(s): ${ENVIRONMENT}"
             exit 1
-          else
-            # publish-docs is true if 'prod' is in the environments list
-            publish_docs=$(echo "${environments}" | jq 'index("prod") != null')
-            # minify "environments" to a single line, or it won't be parsed properly
-            environments=$(echo "${environments}" | jq -Mc .)
-            {
-              echo "environments=${environments}"
-              echo "publish-docs=${publish_docs}"
-            } >> "$GITHUB_OUTPUT"
           fi
+
+          # publish-docs is true if 'prod' is in the environments list
+          publish_docs=$(echo "${environments}" | jq 'index("prod") != null')
+          # minify "environments" to a single line, or it won't be parsed properly
+          environments=$(echo "${environments}" | jq -Mc .)
+          {
+            echo "environments=${environments}"
+            echo "publish-docs=${publish_docs}"
+          } >> "$GITHUB_OUTPUT"
         env:
           ENVIRONMENT: ${{ inputs.environment }}
           DOCS_ONLY: ${{ inputs.docs-only }}
@@ -517,7 +513,6 @@ jobs:
           gcloud-auth-token: ${{ steps.gcloud.outputs.id_token }}
           ignore-conflicts: ${{ steps.determine-continue.outputs.ignore_conflicts }}
 
-
   trigger-argo-workflow:
     name: Trigger Argo Workflow for Grafana Cloud deployment
     runs-on: ubuntu-latest
@@ -597,11 +592,10 @@ jobs:
           workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
           service_account: github-plugin-ci-workflows@grafanalabs-workload-identity.iam.gserviceaccount.com
 
-      
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a' # v2.1.4
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a" # v2.1.4
         with:
-          version: '>= 363.0.0'
+          version: ">= 363.0.0"
 
       - name: Determine GCS artifacts paths
         id: paths

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -379,12 +379,13 @@ jobs:
             exit 0
           fi
 
+          allowed_environments='["dev", "ops", "prod"]'
+          allowed_environments_regex=$(echo "${allowed_environments}" | jq -r 'join("|")')
+
           # Define environments matrix,
           # and deploy docs only if we are publishing to prod
           # Split ENVIRONMENT by comma, remove spaces, and filter only allowed values
-          allowed_environments='["dev", "ops", "prod"]'
-          allowed_environments_regex=$(echo "${allowed_environments}" | jq -r 'join("|")')
-          environments=$(echo "${ENVIRONMENT}" | tr ',' '\n' | sed 's/ //g' | grep -E "^(${allowed_environments})$" | jq -R . | jq -s 'unique')
+          environments=$(echo "${ENVIRONMENT}" | tr ',' '\n' | sed 's/ //g' | grep -E "^(${allowed_environments_regex})$" | jq -R . | jq -s 'unique')
           # If empty or 'none', set to empty array
           if [ -z "${ENVIRONMENT}" ] || [ "${ENVIRONMENT}" == 'none' ]; then
             {


### PR DESCRIPTION
Allow to deploy to multiple environments by passing a comma-separated string to `environments` (catalog + Argo).

The default behaviour is still deploying to one env when targeting dev and ops, and deploy to all envs when targeting prod.

However you can now pass: `dev,ops` to publish to `dev + ops` (effectively, the way `ops` behaved before #131)

This is handy for provisioned plugins that want to continuously deploy main to ops, like the Logs Drilldown app.

Fixes #134

**Test runs**:

Dev only: https://github.com/grafana/plugins-drone-to-gha/actions/runs/15995008964

Ops only: https://github.com/grafana/plugins-drone-to-gha/actions/runs/15995177803

Dev + Ops: https://github.com/grafana/plugins-drone-to-gha/actions/runs/15995366988

Prod: https://github.com/grafana/plugins-drone-to-gha/actions/runs/15995609109

(Ignore the failures, these are from GCOM, just see the results of the "environments" matrix)