### PR TITLE
CD: Add Argo summary step

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -225,6 +225,27 @@ env:
   GCS_ARTIFACTS_BUCKET: integration-artifacts
 
 jobs:
+  summary-test:
+    name: Summary test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Print job summary
+        run: |
+          echo "# 🐙 Deployment to Grafana Cloud triggered successfully via Argo
+
+          A deployment to Grafana Cloud via Argo Workflow has successfully been triggered.
+          - Plugin Version: `1.0.0`
+          - Environment(s): ${{ env.ENVIRONMENT }}
+
+          **You can follow the deployment [here](https://argo-workflows.grafana.net/)**
+          " >> "$GITHUB_STEP_SUMMARY"
+        shell: bash
+        # - Plugin Version: ${{ fromJSON(needs.ci.outputs.plugin).version }}
+        # **You can follow the deployment [here](${{ steps.trigger-argo-workflow.outputs.uri }})**
+        env:
+          ENVIRONMENT: ${{ inputs.environment }}
+
   setup:
     name: Check and setup environment
     runs-on: ubuntu-latest
@@ -507,7 +528,6 @@ jobs:
           gcloud-auth-token: ${{ steps.gcloud.outputs.id_token }}
           ignore-conflicts: ${{ steps.determine-continue.outputs.ignore_conflicts }}
 
-
   trigger-argo-workflow:
     name: Trigger Argo Workflow for Grafana Cloud deployment
     runs-on: ubuntu-latest
@@ -536,6 +556,7 @@ jobs:
         shell: bash
 
       - name: Trigger Argo Workflow
+        id: trigger-argo-workflow
         uses: grafana/shared-workflows/actions/trigger-argo-workflow@main # zizmor: ignore[unpinned-uses]
         with:
           namespace: grafana-plugins-cd
@@ -587,11 +608,10 @@ jobs:
           workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
           service_account: github-plugin-ci-workflows@grafanalabs-workload-identity.iam.gserviceaccount.com
 
-      
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a' # v2.1.4
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a" # v2.1.4
         with:
-          version: '>= 363.0.0'
+          version: ">= 363.0.0"
 
       - name: Determine GCS artifacts paths
         id: paths
@@ -626,9 +646,9 @@ jobs:
         id: gcs_artifacts_exist
         run: |
           bucket_path="gs://${GCS_ARTIFACTS_RELEASE_PATH_TAG}/${PLATFORM}/"
-          
+
           echo "Checking for any existing artifacts in: $bucket_path"
-          
+
           if gsutil ls "$bucket_path" 2>/dev/null | grep -q "."; then
             echo "⚠️Existing artifact found, skipping upload"
             echo "gcs_artifacts_exist=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -551,14 +551,14 @@ jobs:
 
       - name: Print job summary
         run: |
-          echo '# 🐙 Grafana Cloud deployment via Argo Workflows
+          echo "# 🐙 Grafana Cloud deployment via Argo Workflows
 
           A deployment to Grafana Cloud via the plugins CD Argo Workflow has successfully been triggered.
-          - Plugin Version: `${{ fromJSON(needs.ci.outputs.plugin).version }}`
-          - Environment(s): `'"${ENVIRONMENT}"'`
+          - Plugin Version: \`${{ fromJSON(needs.ci.outputs.plugin).version }}\`
+          - Environment(s): \`${ENVIRONMENT}\`
 
           **👉 You can follow the deployment [here](${{ steps.trigger-argo-workflow.outputs.uri }})**
-          ' >> "$GITHUB_STEP_SUMMARY"
+          " >> "$GITHUB_STEP_SUMMARY"
         shell: bash
         env:
           ENVIRONMENT: ${{ inputs.environment }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -232,14 +232,14 @@ jobs:
     steps:
       - name: Print job summary
         run: |
-          echo "# 🐙 Deployment to Grafana Cloud triggered successfully via Argo
+          echo '# 🐙 Grafana Cloud deployment via Argo
 
           A deployment to Grafana Cloud via Argo Workflow has successfully been triggered.
           - Plugin Version: `1.0.0`
-          - Environment(s): ${{ env.ENVIRONMENT }}
+          - Environment(s): '"${ENVIRONMENT}"'
 
-          **You can follow the deployment [here](https://argo-workflows.grafana.net/)**
-          " >> "$GITHUB_STEP_SUMMARY"
+          **👉 You can follow the deployment [here](https://argo-workflows.grafana.net/)**
+          ' >> "$GITHUB_STEP_SUMMARY"
         shell: bash
         # - Plugin Version: ${{ fromJSON(needs.ci.outputs.plugin).version }}
         # **You can follow the deployment [here](${{ steps.trigger-argo-workflow.outputs.uri }})**

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -225,27 +225,6 @@ env:
   GCS_ARTIFACTS_BUCKET: integration-artifacts
 
 jobs:
-  summary-test:
-    name: Summary test
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Print job summary
-        run: |
-          echo '# 🐙 Grafana Cloud deployment via Argo
-
-          A deployment to Grafana Cloud via Argo Workflow has successfully been triggered.
-          - Plugin Version: `1.0.0`
-          - Environment(s): '"${ENVIRONMENT}"'
-
-          **👉 You can follow the deployment [here](https://argo-workflows.grafana.net/)**
-          ' >> "$GITHUB_STEP_SUMMARY"
-        shell: bash
-        # - Plugin Version: ${{ fromJSON(needs.ci.outputs.plugin).version }}
-        # **You can follow the deployment [here](${{ steps.trigger-argo-workflow.outputs.uri }})**
-        env:
-          ENVIRONMENT: ${{ inputs.environment }}
-
   setup:
     name: Check and setup environment
     runs-on: ubuntu-latest
@@ -569,6 +548,20 @@ jobs:
             commit=${{ github.sha }}
             commit_link=https://${{ github.repository_owner }}/${{ github.event.repository.name }}/commit/${{ github.sha }}
             auto_merge_environments=${{ inputs.auto-merge-environments }}
+
+      - name: Print job summary
+        run: |
+          echo '# 🐙 Grafana Cloud deployment via Argo Workflow
+
+          A deployment to Grafana Cloud via the plugins CD Argo Workflow has successfully been triggered.
+          - Plugin Version: `${{ fromJSON(needs.ci.outputs.plugin).version }}`
+          - Environment(s): '"${ENVIRONMENT}"'
+
+          **👉 You can follow the deployment [here](${{ steps.trigger-argo-workflow.outputs.uri }})**
+          ' >> "$GITHUB_STEP_SUMMARY"
+        shell: bash
+        env:
+          ENVIRONMENT: ${{ inputs.environment }}
 
   # Note: This job can be removed once provisioned plugins releases are moved to the
   # tailored plugins catalog instead of using GCS.

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -551,7 +551,7 @@ jobs:
 
       - name: Print job summary
         run: |
-          echo '# 🐙 Grafana Cloud deployment via Argo Workflow
+          echo '# 🐙 Grafana Cloud deployment via Argo Workflows
 
           A deployment to Grafana Cloud via the plugins CD Argo Workflow has successfully been triggered.
           - Plugin Version: `${{ fromJSON(needs.ci.outputs.plugin).version }}`

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -555,7 +555,7 @@ jobs:
 
           A deployment to Grafana Cloud via the plugins CD Argo Workflow has successfully been triggered.
           - Plugin Version: `${{ fromJSON(needs.ci.outputs.plugin).version }}`
-          - Environment(s): '"${ENVIRONMENT}"'
+          - Environment(s): `'"${ENVIRONMENT}"'`
 
           **👉 You can follow the deployment [here](${{ steps.trigger-argo-workflow.outputs.uri }})**
           ' >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Adds a summary step that makes the Argo workflow URL more visible for each CD job run.

Example:

![immagine](https://github.com/user-attachments/assets/ad61ef8f-27fa-49c7-85e4-e248afab7657)


https://github.com/grafana/grafana-pluginsplatformprovisioned-app/actions/runs/15996857874
