### PR TITLE
CI: Allow passing secrets to Playwright

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -129,6 +129,14 @@ on:
         type: string
         required: false
         default: http://localhost:3000/
+      playwright-secrets:
+        description: |
+          The secrets to use for Playwright tests.
+          This uses the grafana/shared-workflows/actions/get-vault-secrets action under the hood,
+          so the syntax is the same. It fetches from the repo's secrets.
+        type: string
+        required: false
+        default: ""
 
       # Trufflehog
       run-trufflehog:
@@ -309,6 +317,7 @@ jobs:
       playwright-docker-compose-file: ${{ inputs.playwright-docker-compose-file }}
       playwright-config: ${{ inputs.playwright-config }}
       playwright-grafana-url: ${{ inputs.playwright-grafana-url }}
+      playwright-secrets: ${{ inputs.playwright-secrets }}
       run-trufflehog: ${{ inputs.run-trufflehog }}
       trufflehog-version: ${{ inputs.trufflehog-version }}
       trufflehog-include-detectors: ${{ inputs.trufflehog-include-detectors }}
@@ -507,7 +516,6 @@ jobs:
           gcloud-auth-token: ${{ steps.gcloud.outputs.id_token }}
           ignore-conflicts: ${{ steps.determine-continue.outputs.ignore_conflicts }}
 
-
   trigger-argo-workflow:
     name: Trigger Argo Workflow for Grafana Cloud deployment
     runs-on: ubuntu-latest
@@ -587,11 +595,10 @@ jobs:
           workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
           service_account: github-plugin-ci-workflows@grafanalabs-workload-identity.iam.gserviceaccount.com
 
-      
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a' # v2.1.4
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a" # v2.1.4
         with:
-          version: '>= 363.0.0'
+          version: ">= 363.0.0"
 
       - name: Determine GCS artifacts paths
         id: paths
@@ -626,9 +633,9 @@ jobs:
         id: gcs_artifacts_exist
         run: |
           bucket_path="gs://${GCS_ARTIFACTS_RELEASE_PATH_TAG}/${PLATFORM}/"
-          
+
           echo "Checking for any existing artifacts in: $bucket_path"
-          
+
           if gsutil ls "$bucket_path" 2>/dev/null | grep -q "."; then
             echo "⚠️Existing artifact found, skipping upload"
             echo "gcs_artifacts_exist=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,8 +400,7 @@ jobs:
 
   playwright:
     name: Playwright E2E tests
-    # TODO: change
-    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@giuseppe/playwright-secrets # zizmor: ignore[unpinned-uses]
+    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@main # zizmor: ignore[unpinned-uses]
     if: ${{ inputs.run-playwright == true }}
     needs:
       - test-and-build
@@ -421,8 +420,7 @@ jobs:
 
   playwright-docker:
     name: Plugins - Dockerized Playwright E2E tests
-    # TODO: change
-    uses: grafana/plugin-ci-workflows/.github/workflows/playwright-docker.yml@giuseppe/playwright-secrets # zizmor: ignore[unpinned-uses]
+    uses: grafana/plugin-ci-workflows/.github/workflows/playwright-docker.yml@main # zizmor: ignore[unpinned-uses]
     if: ${{ inputs.run-playwright-docker == true }}
     needs:
       - test-and-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,10 @@ on:
         required: false
         default: http://localhost:3000/
       playwright-secrets:
-        description: The secrets to use for Playwright tests
+        description: |
+          The secrets to use for Playwright tests.
+          This uses the grafana/shared-workflows/actions/get-vault-secrets action under the hood,
+          so the syntax is the same. It fetches from the repo's secrets.
         type: string
         required: false
         default: ""
@@ -397,7 +400,7 @@ jobs:
 
   playwright:
     name: Playwright E2E tests
-    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@playwrightsecrets # zizmor: ignore[unpinned-uses]
+    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@giuseppe/playwright-secrets # zizmor: ignore[unpinned-uses]
     if: ${{ inputs.run-playwright == true }}
     needs:
       - test-and-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,7 +397,7 @@ jobs:
 
   playwright:
     name: Playwright E2E tests
-    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@main # zizmor: ignore[unpinned-uses]
+    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@playwrightsecrets # zizmor: ignore[unpinned-uses]
     if: ${{ inputs.run-playwright == true }}
     needs:
       - test-and-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,11 @@ on:
         type: string
         required: false
         default: http://localhost:3000/
+      playwright-secrets:
+        description: The secrets to use for Playwright tests
+        type: string
+        required: false
+        default: ""
 
       # Trufflehog
       run-trufflehog:
@@ -408,6 +413,7 @@ jobs:
       playwright-config: ${{ inputs.playwright-config }}
       report-path: ${{ inputs.playwright-report-path }}
       grafana-url: ${{ inputs.playwright-grafana-url }}
+      secrets: ${{ inputs.playwright-secrets }}
 
   playwright-docker:
     name: Plugins - Dockerized Playwright E2E tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,6 +400,7 @@ jobs:
 
   playwright:
     name: Playwright E2E tests
+    # TODO: change
     uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@giuseppe/playwright-secrets # zizmor: ignore[unpinned-uses]
     if: ${{ inputs.run-playwright == true }}
     needs:
@@ -416,11 +417,12 @@ jobs:
       playwright-config: ${{ inputs.playwright-config }}
       report-path: ${{ inputs.playwright-report-path }}
       grafana-url: ${{ inputs.playwright-grafana-url }}
-      secrets: ${{ inputs.playwright-secrets }}
+      secrets: ${{ (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && inputs.playwright-secrets != '') && inputs.playwright-secrets || '' }}
 
   playwright-docker:
     name: Plugins - Dockerized Playwright E2E tests
-    uses: grafana/plugin-ci-workflows/.github/workflows/playwright-docker.yml@main # zizmor: ignore[unpinned-uses]
+    # TODO: change
+    uses: grafana/plugin-ci-workflows/.github/workflows/playwright-docker.yml@giuseppe/playwright-secrets # zizmor: ignore[unpinned-uses]
     if: ${{ inputs.run-playwright-docker == true }}
     needs:
       - test-and-build
@@ -434,6 +436,7 @@ jobs:
       grafana-compose-file: ${{ inputs.playwright-docker-compose-file }}
       report-path: ${{ inputs.playwright-report-path }}
       grafana-url: ${{ inputs.playwright-grafana-url }}
+      secrets: ${{ (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && inputs.playwright-secrets != '') && inputs.playwright-secrets || '' }}
 
   upload-to-gcs:
     name: Upload to GCS

--- a/.github/workflows/playwright-docker.yml
+++ b/.github/workflows/playwright-docker.yml
@@ -119,8 +119,6 @@ jobs:
         uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1
         with:
           repo_secrets: ${{ inputs.secrets }}
-          # TODO: remove
-          vault_instance: dev
           export_env: false
 
       - name: Set secrets

--- a/.github/workflows/playwright-docker.yml
+++ b/.github/workflows/playwright-docker.yml
@@ -42,6 +42,10 @@ on:
         type: string
         description: Path to the folder to use to upload the artifacts
         default: playwright-report/
+      secrets:
+        required: false
+        type: string
+        description: The secrets to use for Playwright tests
       grafana-url:
         description: The Grafana URL to wait for before running the tests
         type: string
@@ -108,6 +112,24 @@ jobs:
         env:
           PLUGIN_ID: ${{ inputs.id }}
           PLUGIN_VERSION: ${{ inputs.version }}
+
+      - name: Get secrets from Vault
+        if: inputs.secrets != ''
+        id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1
+        with:
+          repo_secrets: ${{ inputs.secrets }}
+          # TODO: remove
+          vault_instance: dev
+          export_env: false
+
+      - name: Set secrets
+        if: inputs.secrets != ''
+        run: |
+          echo '${{ steps.get-secrets.outputs.secrets }}' | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> .env
+          cat .env
+        # No support for subdirectories when running with Docker
+        # working-directory: ${{ inputs.plugin-directory }}
 
       - name: Start Grafana
         # add the -f argument only if "inputs.grafana-compose-file" is defined

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -162,8 +162,6 @@ jobs:
         uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1
         with:
           repo_secrets: ${{ inputs.secrets }}
-          # TODO: remove
-          vault_instance: dev
           export_env: false
 
       - name: Set secrets

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -159,6 +159,7 @@ jobs:
       - name: Set secrets
         run: |
           echo "${{ inputs.secrets }}" > .env
+          cat .env
         working-directory: ${{ inputs.plugin-directory }}
 
       - name: Run Playwright tests

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -159,7 +159,7 @@ jobs:
       - name: Determine if secrets should be fetched
         id: fetch-secrets
         run: |
-          echo "should-fetch=${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && inputs.secrets != '' }}" >> $GITHUB_OUTPUT
+          echo "should-fetch=${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && inputs.secrets != '' }}" >> "$GITHUB_OUTPUT"
         shell: bash
 
       - name: Get secrets from Vault

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -156,14 +156,8 @@ jobs:
         with:
           url: "${{ inputs.grafana-url }}"
 
-      - name: Determine if secrets should be fetched
-        id: fetch-secrets
-        run: |
-          echo "should-fetch=${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && inputs.secrets != '' }}" >> "$GITHUB_OUTPUT"
-        shell: bash
-
       - name: Get secrets from Vault
-        if: steps.fetch-secrets.outputs.should-fetch == 'true'
+        if: inputs.secrets != ''
         id: get-secrets
         uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1
         with:
@@ -173,7 +167,7 @@ jobs:
           export_env: false
 
       - name: Set secrets
-        if: steps.fetch-secrets.outputs.should-fetch == 'true'
+        if: inputs.secrets != ''
         run: |
           echo '${{ steps.get-secrets.outputs.secrets }}' | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> .env
           cat .env

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -156,9 +156,16 @@ jobs:
         with:
           url: "${{ inputs.grafana-url }}"
 
+      - name: Get secrets from vault
+        if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && inputs.secrets != ''
+        id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1
+        with:
+          repo_secrets: ${{ inputs.secrets }}
+          export_env: false
       - name: Set secrets
         run: |
-          echo "${{ fromJson(inputs.secrets) }}" > .env
+          echo "${{ steps.get-secrets.outputs.secrets }}" >> .env
           cat .env
         working-directory: ${{ inputs.plugin-directory }}
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -168,6 +168,8 @@ jobs:
         uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1
         with:
           repo_secrets: ${{ inputs.secrets }}
+          # TODO: remove
+          vault_instance: dev
           export_env: false
 
       - name: Set secrets

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -156,15 +156,22 @@ jobs:
         with:
           url: "${{ inputs.grafana-url }}"
 
-      - name: Get secrets from vault
-        if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && inputs.secrets != ''
+      - name: Determine if secrets should be fetched
+        id: fetch-secrets
+        run: |
+          echo "should-fetch=${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && inputs.secrets != '' }}" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Get secrets from Vault
+        if: steps.fetch-secrets.outputs.should-fetch == 'true'
         id: get-secrets
         uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1
         with:
           repo_secrets: ${{ inputs.secrets }}
           export_env: false
+
       - name: Set secrets
-        if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && inputs.secrets != ''
+        if: steps.fetch-secrets.outputs.should-fetch == 'true'
         run: |
           echo '${{ steps.get-secrets.outputs.secrets }}' | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> .env
           cat .env

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -164,8 +164,9 @@ jobs:
           repo_secrets: ${{ inputs.secrets }}
           export_env: false
       - name: Set secrets
+        if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && inputs.secrets != ''
         run: |
-          echo "${{ steps.get-secrets.outputs.secrets }}" >> .env
+          echo "${{ fromJson(steps.get-secrets.outputs.secrets) }}" >> .env
           cat .env
         working-directory: ${{ inputs.plugin-directory }}
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -166,7 +166,7 @@ jobs:
       - name: Set secrets
         if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && inputs.secrets != ''
         run: |
-          echo "${{ fromJson(steps.get-secrets.outputs.secrets) }}" >> .env
+          echo '${{ steps.get-secrets.outputs.secrets }}' | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> .env
           cat .env
         working-directory: ${{ inputs.plugin-directory }}
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -158,7 +158,7 @@ jobs:
 
       - name: Set secrets
         run: |
-          echo "${{ inputs.secrets }}" > .env
+          echo "${{ fromJson(inputs.secrets) }}" > .env
           cat .env
         working-directory: ${{ inputs.plugin-directory }}
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -50,6 +50,10 @@ on:
         type: string
         default: playwright.config.ts
         description: Path to the Playwright config file to use for testing
+      secrets:
+        required: false
+        type: string
+        description: The secrets to use for Playwright tests
       grafana-url:
         description: The Grafana URL to wait for before running the tests
         type: string
@@ -151,6 +155,11 @@ jobs:
         uses: grafana/plugin-actions/wait-for-grafana@main # zizmor: ignore[unpinned-uses]
         with:
           url: "${{ inputs.grafana-url }}"
+
+      - name: Set secrets
+        run: |
+          echo "${{ inputs.secrets }}" > .env
+        working-directory: ${{ inputs.plugin-directory }}
 
       - name: Run Playwright tests
         id: run-tests


### PR DESCRIPTION
Allows to pass custom repo secrets from Vault to Playwright

Fixes #125

Test PR: https://github.com/grafana/plugins-drone-to-gha/pull/34

Example usage:

```yaml
uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main
with:
  # ...
  playwright-secrets: |
    ONE=playwright:one
    TWO=playwright:two
```