### PR TITLE
CI: Fix error when packaging plugin for fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,7 +311,7 @@ jobs:
           universal: "true"
           dist-folder: dist
           output-folder: dist-artifacts
-          access-policy-token: ${{ fromJSON(steps.get-secrets.outputs.secrets).SIGN_PLUGIN_ACCESS_POLICY_TOKEN || '' }}
+          access-policy-token: ${{ env.IS_FORK == 'false' && fromJSON(steps.get-secrets.outputs.secrets).SIGN_PLUGIN_ACCESS_POLICY_TOKEN || '' }}
           allow-unsigned: ${{ env.IS_FORK == 'true' }}
 
       - name: Package os/arch ZIPs
@@ -321,7 +321,7 @@ jobs:
           universal: "false"
           dist-folder: dist
           output-folder: dist-artifacts
-          access-policy-token: ${{ fromJSON(steps.get-secrets.outputs.secrets).SIGN_PLUGIN_ACCESS_POLICY_TOKEN || '' }}
+          access-policy-token: ${{ env.IS_FORK == 'false' && fromJSON(steps.get-secrets.outputs.secrets).SIGN_PLUGIN_ACCESS_POLICY_TOKEN || '' }}
           allow-unsigned: ${{ env.IS_FORK == 'true' }}
 
       - name: Trufflehog secrets scanning


### PR DESCRIPTION
Fixes the following error when trying to package zips for plugins coming from external contributors:

```
Error: The template is not valid. grafana/plugin-ci-workflows/.github/workflows/ci.yml@main (Line: 314, Col: 32): Error reading JToken from JsonReader. Path '', line 0, position 0.
```

The error happens because the step to get Vault secrets is skipped, and we cannot get `.SIGN_PLUGIN_ACCESS_POLICY_TOKEN` since `fromJSON(steps.get-secrets.outputs.secrets)` is null.

Example run: https://github.com/grafana/clock-panel/actions/runs/16074277197?pr=285