### PR TITLE
chore(version-bump-changelog): match titles to parse-changelog

### DIFF
--- a/actions/plugins/version-bump-changelog/action.yml
+++ b/actions/plugins/version-bump-changelog/action.yml
@@ -90,6 +90,8 @@ runs:
         printf "# Changelog\n\n" | cat - CHANGELOG.md > temp && mv temp CHANGELOG.md
         # Format headers remove dates and unreleased
         sed -i -E 's/^(#+ [0-9]+\.[0-9]+\.[0-9]+) \(([Uu]nreleased|[0-9]{4}-[0-9]{2}-[0-9]{2})\)/\1/' CHANGELOG.md
+        # Format version headers to use ## instead of #### to match the GitHub release notes format in parse-changelog.sh
+        sed -i -E 's/^#### ([0-9]+\.[0-9]+\.[0-9]+.*)$/## \1/' CHANGELOG.md
 
       env:
         GITHUB_TOKEN: ${{ steps.generate-github-token.outputs.token }}


### PR DESCRIPTION
Format headers to use `##` instead of `####` to match the GitHub release notes format in parse-changelog.sh. I believe this will fix our draft github releases from pulling in extraneous version info 🤞. Tested it out here in [test-release-gh-actions](https://github.com/grafana/test-release-gh-actions/actions/runs/16453552702) 