### PR TITLE
feat: add a new go caching input and turning cache on by default

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -60,6 +60,10 @@ on:
         description: golangci-lint version to use
         type: string
         required: false
+      go-setup-caching:
+        description: Defines if setup-go action should have caching enabled (https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs) 
+        type: 'boolean'
+        required: false
       trufflehog-version:
         description: Trufflehog version to use
         type: string
@@ -311,6 +315,7 @@ jobs:
       plugin-directory: ${{ inputs.plugin-directory }}
       package-manager: ${{ inputs.package-manager }}
       go-version: ${{ inputs.go-version }}
+      go-setup-caching: ${{ inputs.go-setup-caching }}
       node-version: ${{ inputs.node-version }}
       golangci-lint-version: ${{ inputs.golangci-lint-version }}
       run-playwright: ${{ inputs.run-playwright }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,10 @@ on:
         description: golangci-lint version to use
         type: string
         required: false
+      go-setup-caching:
+        description: Defines if setup-go action should have caching enabled (https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs)olangci-lint version to use
+        type: boolean
+        required: false
       trufflehog-version:
         description: Trufflehog version to use
         type: string
@@ -237,6 +241,7 @@ jobs:
           go-version: ${{ inputs.go-version || env.DEFAULT_GO_VERSION }}
           node-version: ${{ inputs.node-version || env.DEFAULT_NODE_VERSION }}
           golangci-lint-version: ${{ inputs.golangci-lint-version || env.DEFAULT_GOLANGCI_LINT_VERSION }}
+          go-setup-caching: ${{ inputs.go-setup-caching }}
 
       - name: Get secrets from Vault
         id: get-secrets

--- a/actions/plugins/setup/action.yml
+++ b/actions/plugins/setup/action.yml
@@ -11,6 +11,11 @@ inputs:
   golangci-lint-version:
     description: golangci-lint version to use.
     required: true
+  go-setup-caching:
+    description: Defines if setup-go action should have caching enabled (https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs) 
+    required: true
+    type: boolean
+    default: true
 
 runs:
   using: composite
@@ -24,7 +29,7 @@ runs:
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version: "${{ inputs.go-version }}"
-        cache: false
+        cache: "${{ inputs.go-setup-caching }}"
 
     - name: Mage
       shell: bash


### PR DESCRIPTION
While chasing some theories we have disabled caching a while back https://github.com/grafana/plugin-ci-workflows/pull/104

Now we can bring it back on by default and make it configurable for those who want to opt out