### PR TITLE
fix: use string default for go-setup-caching

### DIFF
--- a/actions/plugins/setup/action.yml
+++ b/actions/plugins/setup/action.yml
@@ -12,10 +12,9 @@ inputs:
     description: golangci-lint version to use.
     required: true
   go-setup-caching:
-    description: Defines if setup-go action should have caching enabled (https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs) 
-    required: true
-    type: boolean
-    default: true
+    description: Defines if setup-go action should have caching enabled (https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs)
+    required: false
+    default: "true"
 
 runs:
   using: composite


### PR DESCRIPTION
Actions can't have 'type' set to anything other than string
it seems, and it's ignored if it's not a string, so this was
defaulting to '' and caching wasn't being enabled by default.
