### PR TITLE
feat: add optional node and npm dependency caching

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -87,6 +87,10 @@ on:
         type: boolean
         required: false
         default: false
+      node-cache-dependency-path:
+        description: Used to specify the path to a dependency file - package-lock.json, yarn.lock, etc. Supports wildcards or a list of file names for caching multiple dependencies (https://github.com/actions/setup-node#caching-global-packages-data)
+        type: string
+        required: false
 
       # Playwright
       run-playwright:
@@ -334,6 +338,7 @@ jobs:
       npm-registry-auth: ${{ inputs.npm-registry-auth }}
       go-version: ${{ inputs.go-version }}
       go-setup-caching: ${{ inputs.go-setup-caching }}
+      node-cache-dependency-path: ${{ inputs.node-cache-dependency-path }}
       node-version: ${{ inputs.node-version }}
       golangci-lint-version: ${{ inputs.golangci-lint-version }}
       run-playwright: ${{ inputs.run-playwright }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -328,7 +328,7 @@ jobs:
 
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main # zizmor: ignore[unpinned-uses]
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@add-optional-node-caching # zizmor: ignore[unpinned-uses]
     needs:
       - setup
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ on:
         type: string
         required: false
       go-setup-caching:
-        description: Defines if setup-go action should have caching enabled (https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs)olangci-lint version to use
+        description: Defines if setup-go action should have caching enabled (https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs)
         type: boolean
         required: false
       trufflehog-version:
@@ -62,6 +62,10 @@ on:
         type: boolean
         required: false
         default: false
+      node-cache-dependency-path:
+        description: Used to specify the path to a dependency file - package-lock.json, yarn.lock, etc. Supports wildcards or a list of file names for caching multiple dependencies (https://github.com/actions/setup-node#caching-global-packages-data)
+        type: string
+        required: false
 
       # Playwright
       run-playwright:
@@ -279,6 +283,8 @@ jobs:
           node-version-file: ${{ inputs.plugin-directory }}/.nvmrc
           golangci-lint-version: ${{ inputs.golangci-lint-version || env.DEFAULT_GOLANGCI_LINT_VERSION }}
           go-setup-caching: ${{ inputs.go-setup-caching }}
+          node-cache: ${{ inputs.package-manager }}
+          node-cache-dependency-path: ${{ inputs.node-cache-dependency-path }}
 
       - name: Get secrets from Vault
         id: get-secrets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,7 +276,7 @@ jobs:
             return o
 
       - name: Setup
-        uses: grafana/plugin-ci-workflows/actions/plugins/setup@main # zizmor: ignore[unpinned-uses]
+        uses: grafana/plugin-ci-workflows/actions/plugins/setup@add-optional-node-caching # zizmor: ignore[unpinned-uses]
         with:
           go-version: ${{ inputs.go-version || env.DEFAULT_GO_VERSION }}
           node-version: ${{ inputs.node-version || env.DEFAULT_NODE_VERSION }}

--- a/actions/plugins/setup/action.yml
+++ b/actions/plugins/setup/action.yml
@@ -19,6 +19,14 @@ inputs:
     description: Node.js version file to use.
     required: false
     default: ""
+  node-cache:
+    description: Used to specify a package manager for caching in the default directory. Supported values npm, yarn, pnpm (https://github.com/actions/setup-node#caching-global-packages-data)
+    required: false
+    default: ""
+  node-cache-dependency-path:
+    description: Used to specify the path to a dependency file - package-lock.json, yarn.lock, etc. Supports wildcards or a list of file names for caching multiple dependencies (https://github.com/actions/setup-node#caching-global-packages-data)
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -28,6 +36,8 @@ runs:
       with:
         node-version: "${{ inputs.node-version }}"
         node-version-file: "${{ inputs.node-version-file }}"
+        cache: "${{ inputs.node-cache }}"
+        cache-dependency-path: "${{ inputs.node-cache-dependency-path }}"
 
     - name: Go
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0


### PR DESCRIPTION
Similar to https://github.com/grafana/plugin-ci-workflows/pull/181 but for node and npm. This has to be manually enabled
because we don't know the user's package manager.