### PR TITLE
docs: Add README to each base example and add script to generate root README

### DIFF
--- a/examples/base/README.md
+++ b/examples/base/README.md
@@ -1,3 +1,5 @@
+<!-- THIS FILE IS AUTO-GENERATED, DO NOT EDIT MANUALLY! RUN "go run genreadme.go" TO RE-GENERATE -->
+
 # plugin-ci-workflows examples
 
 > [!WARNING]
@@ -9,13 +11,6 @@ This folder contains some examples on how to use the shared workflows (CI and CD
 The `yaml` files should be put in your repository's `.github/workflows` folder, and customized depending on your needs.
 
 **Each workflow file is just a template/example. Remember to address all the TODOs before starting to use the workflows.**
-
-## [`simple`](./simple/)
-
-A simple setup for a non-provisioned plugin, gets you started quickly and you can test your plugin on a grafana cloud instance.
-
-- CI for each PR and push to main
-- Manual deployment to the catalog
 
 ## [`provisioned-plugin-auto-cd`](./provisioned-plugin-auto-cd/)
 
@@ -31,3 +26,11 @@ An example setup for a provisioned plugin. Use this workflow if you wish to have
 
 - CI for each PR and push to main
 - Manual deployment to the catalog and Grafana Cloud via Argo workflow + deployment_tools
+
+## [`simple`](./simple/)
+
+A simple setup for a non-provisioned plugin, gets you started quickly and you can test your plugin on a grafana cloud instance.
+
+- CI for each PR and push to main
+- Manual deployment to the catalog
+

--- a/examples/base/README.md
+++ b/examples/base/README.md
@@ -12,6 +12,13 @@ The `yaml` files should be put in your repository's `.github/workflows` folder, 
 
 **Each workflow file is just a template/example. Remember to address all the TODOs before starting to use the workflows.**
 
+## [`simple`](./simple/)
+
+A simple setup for a non-provisioned plugin, gets you started quickly and you can test your plugin on a grafana cloud instance.
+
+- CI for each PR and push to main
+- Manual deployment to the catalog
+
 ## [`provisioned-plugin-auto-cd`](./provisioned-plugin-auto-cd/)
 
 An example setup for a provisioned plugin with continuous delivery from the `main` branch. This is the **recommended** workflow to use for new plugins that want to be automatically installed on Grafana Cloud Instances.
@@ -26,11 +33,4 @@ An example setup for a provisioned plugin. Use this workflow if you wish to have
 
 - CI for each PR and push to main
 - Manual deployment to the catalog and Grafana Cloud via Argo workflow + deployment_tools
-
-## [`simple`](./simple/)
-
-A simple setup for a non-provisioned plugin, gets you started quickly and you can test your plugin on a grafana cloud instance.
-
-- CI for each PR and push to main
-- Manual deployment to the catalog
 

--- a/examples/base/README.tmpl
+++ b/examples/base/README.tmpl
@@ -1,16 +1,18 @@
-# simple
+<!-- THIS FILE IS AUTO-GENERATED, DO NOT EDIT MANUALLY! RUN "go run genreadme.go" TO RE-GENERATE -->
+
+# plugin-ci-workflows examples
 
 > [!WARNING]
 >
 > Please [read the docs](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions) before using any of these workflows in your repository.
 
+This folder contains some examples on how to use the shared workflows (CI and CD) in various scenarios.
+
 The `yaml` files should be put in your repository's `.github/workflows` folder, and customized depending on your needs.
 
 **Each workflow file is just a template/example. Remember to address all the TODOs before starting to use the workflows.**
+{{range .Subfolders}}
+## [`{{.FolderName}}`](./{{.FolderName}}/)
 
-<!-- README start -->
-
-A simple setup for a non-provisioned plugin, gets you started quickly and you can test your plugin on a grafana cloud instance.
-
-- CI for each PR and push to main
-- Manual deployment to the catalog
+{{.Content}}
+{{end}}

--- a/examples/base/genreadme.go
+++ b/examples/base/genreadme.go
@@ -1,0 +1,130 @@
+// Generate README.md files for each subdirectory based on the root README.md
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+const generatedHeader = `<!-- THIS FILE IS AUTO-GENERATED. DO NOT EDIT MANUALLY. RUN: "go run genreadme.go" TO RE-GENERATE -->`
+
+const fixedSection = `
+> [!WARNING]
+>
+> Please [read the docs](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions) before using any of these workflows in your repository.
+` +
+	"The `yaml` files should be put in your repository's `.github/workflows` folder, and customized depending on your needs."
+
+func main() {
+	// Read the root README.md file
+	rootReadme, err := os.ReadFile("README.md")
+	if err != nil {
+		log.Fatalf("Error reading README.md: %v", err)
+	}
+
+	// Parse sections from the root README
+	sections := parseSections(string(rootReadme))
+
+	// Get all subdirectories
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		log.Fatalf("Error reading current directory: %v", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() && !strings.HasPrefix(entry.Name(), ".") {
+			folderName := entry.Name()
+
+			// Check if there's a section for this folder
+			if sectionContent, exists := sections[folderName]; exists {
+				generateReadme(folderName, sectionContent)
+				fmt.Printf("Generated README.md for folder: %s\n", folderName)
+			}
+		}
+	}
+}
+
+func parseSections(content string) map[string]string {
+	sections := make(map[string]string)
+	scanner := bufio.NewScanner(strings.NewReader(content))
+
+	// Regex to match section headers like ## [`simple`](./simple/)
+	headerRegex := regexp.MustCompile(`^## \[` + "`" + `([^` + "`" + `]+)` + "`" + `\]\(\.\/[^\/]+\/\)`)
+
+	var currentSection string
+	var currentContent strings.Builder
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Check if this line is a section header
+		if matches := headerRegex.FindStringSubmatch(line); matches != nil {
+			// Save previous section if it exists
+			if currentSection != "" {
+				sections[currentSection] = strings.TrimSpace(currentContent.String())
+			}
+
+			// Start new section
+			currentSection = matches[1]
+			currentContent.Reset()
+			continue
+		}
+
+		// If we're in a section, collect content until we hit another ## header or end
+		if currentSection != "" {
+			// Stop if we hit another ## header that's not our target format
+			if strings.HasPrefix(line, "## ") && !headerRegex.MatchString(line) {
+				sections[currentSection] = strings.TrimSpace(currentContent.String())
+				currentSection = ""
+				currentContent.Reset()
+				continue
+			}
+
+			// Add line to current section content
+			if currentContent.Len() > 0 {
+				currentContent.WriteString("\n")
+			}
+			currentContent.WriteString(line)
+		}
+	}
+
+	// Don't forget the last section
+	if currentSection != "" {
+		sections[currentSection] = strings.TrimSpace(currentContent.String())
+	}
+
+	return sections
+}
+
+func generateReadme(folderName, sectionContent string) {
+	readmePath := filepath.Join(folderName, "README.md")
+
+	// Create the content
+	var builder strings.Builder
+	builder.WriteString(generatedHeader)
+	builder.WriteString("\n\n# ")
+	builder.WriteString(folderName)
+	builder.WriteString("\n")
+	builder.WriteString(fixedSection)
+	builder.WriteString("\n\n")
+	builder.WriteString(sectionContent)
+
+	// Write to file
+	// Open file for writing
+	file, err := os.Create(readmePath)
+	if err != nil {
+		log.Printf("Error creating README.md for %s: %v", folderName, err)
+		return
+	}
+	defer file.Close()
+
+	_, err = file.WriteString(builder.String())
+	if err != nil {
+		log.Printf("Error writing README.md for %s: %v", folderName, err)
+	}
+}

--- a/examples/base/genreadme.go
+++ b/examples/base/genreadme.go
@@ -31,10 +31,10 @@ const (
 
 var orderRegex = regexp.MustCompile(`<!--\s*order:\s*(\d+)\s*-->`)
 
-func main() {
+func _main() error {
 	currentDir, err := os.Getwd()
 	if err != nil {
-		log.Fatal("Error getting current directory:", err)
+		return fmt.Errorf("error getting current directory: %w", err)
 	}
 
 	var subfolders []SubfolderContent
@@ -42,7 +42,7 @@ func main() {
 	// Read all subdirectories
 	entries, err := os.ReadDir(currentDir)
 	if err != nil {
-		log.Fatal("Error reading directory:", err)
+		return fmt.Errorf("error reading directory: %w", err)
 	}
 
 	for _, entry := range entries {
@@ -82,7 +82,7 @@ func main() {
 	// Load template from file
 	tmpl, err := template.ParseFiles(tmplFileName)
 	if err != nil {
-		log.Fatal("Error parsing template file:", err)
+		return fmt.Errorf("error parsing template file: %w", err)
 	}
 
 	// Generate the root README.md
@@ -91,7 +91,7 @@ func main() {
 	outputPath := filepath.Join(currentDir, outputFileName)
 	file, err := os.Create(outputPath)
 	if err != nil {
-		log.Fatalf("Error creating %s: %v", outputFileName, err)
+		return fmt.Errorf("error creating %s: %w", outputFileName, err)
 	}
 	defer func() {
 		if cerr := file.Close(); cerr != nil {
@@ -101,10 +101,11 @@ func main() {
 
 	err = tmpl.Execute(file, data)
 	if err != nil {
-		log.Fatal("Error executing template:", err)
+		return fmt.Errorf("error executing template: %w", err)
 	}
 
 	fmt.Printf("Generated %s with %d subfolders\n", outputFileName, len(subfolders))
+	return nil
 }
 
 func extractContentAfterMarker(filePath string) (string, int, error) {
@@ -153,4 +154,10 @@ func extractContentAfterMarker(filePath string) (string, int, error) {
 	content = strings.TrimSpace(content)
 
 	return content, order, nil
+}
+
+func main() {
+	if err := _main(); err != nil {
+		log.Fatalf("Error: %v", err)
+	}
 }

--- a/examples/base/provisioned-plugin-auto-cd/README.md
+++ b/examples/base/provisioned-plugin-auto-cd/README.md
@@ -3,10 +3,10 @@
 > [!WARNING]
 >
 > Please [read the docs](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions) before using any of these workflows in your repository.
-
-The `yaml` files should be put in your repository's `.github/workflows` folder, and customized depending on your needs.
-
-**Each workflow file is just a template/example. Remember to address all the TODOs before starting to use the workflows.**
+>
+> The `yaml` files should be put in your repository's `.github/workflows` folder, and customized depending on your needs.
+>
+> **Each workflow file is just a template/example. Remember to address all the TODOs before starting to use the workflows.**
 
 <!-- README start -->
 <!-- order: 10 -->

--- a/examples/base/provisioned-plugin-auto-cd/README.md
+++ b/examples/base/provisioned-plugin-auto-cd/README.md
@@ -1,0 +1,14 @@
+<!-- THIS FILE IS AUTO-GENERATED. DO NOT EDIT MANUALLY. RUN: "go run genreadme.go" TO RE-GENERATE -->
+
+# provisioned-plugin-auto-cd
+
+> [!WARNING]
+>
+> Please [read the docs](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions) before using any of these workflows in your repository.
+The `yaml` files should be put in your repository's `.github/workflows` folder, and customized depending on your needs.
+
+An example setup for a provisioned plugin with continuous delivery from the `main` branch. This is the **recommended** workflow to use for new plugins that want to be automatically installed on Grafana Cloud Instances.
+
+- CI for each PR
+- CI + CD for each push to main: deployment to the catalog and Grafana Cloud ("dev", and optionally also "ops") via Argo workflow + deployment_tools
+- Manual deployment to the catalog and Grafana Cloud via Argo workflow + deployment_tools (for prod deployment)

--- a/examples/base/provisioned-plugin-auto-cd/README.md
+++ b/examples/base/provisioned-plugin-auto-cd/README.md
@@ -1,11 +1,14 @@
-<!-- THIS FILE IS AUTO-GENERATED. DO NOT EDIT MANUALLY. RUN: "go run genreadme.go" TO RE-GENERATE -->
-
 # provisioned-plugin-auto-cd
 
 > [!WARNING]
 >
 > Please [read the docs](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions) before using any of these workflows in your repository.
+
 The `yaml` files should be put in your repository's `.github/workflows` folder, and customized depending on your needs.
+
+**Each workflow file is just a template/example. Remember to address all the TODOs before starting to use the workflows.**
+
+<!-- README start -->
 
 An example setup for a provisioned plugin with continuous delivery from the `main` branch. This is the **recommended** workflow to use for new plugins that want to be automatically installed on Grafana Cloud Instances.
 

--- a/examples/base/provisioned-plugin-auto-cd/README.md
+++ b/examples/base/provisioned-plugin-auto-cd/README.md
@@ -9,6 +9,7 @@ The `yaml` files should be put in your repository's `.github/workflows` folder, 
 **Each workflow file is just a template/example. Remember to address all the TODOs before starting to use the workflows.**
 
 <!-- README start -->
+<!-- order: 10 -->
 
 An example setup for a provisioned plugin with continuous delivery from the `main` branch. This is the **recommended** workflow to use for new plugins that want to be automatically installed on Grafana Cloud Instances.
 

--- a/examples/base/provisioned-plugin-manual-deployment/README.md
+++ b/examples/base/provisioned-plugin-manual-deployment/README.md
@@ -3,10 +3,10 @@
 > [!WARNING]
 >
 > Please [read the docs](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions) before using any of these workflows in your repository.
-
-The `yaml` files should be put in your repository's `.github/workflows` folder, and customized depending on your needs.
-
-**Each workflow file is just a template/example. Remember to address all the TODOs before starting to use the workflows.**
+>
+> The `yaml` files should be put in your repository's `.github/workflows` folder, and customized depending on your needs.
+>
+> **Each workflow file is just a template/example. Remember to address all the TODOs before starting to use the workflows.**
 
 <!-- README start -->
 <!-- order: 20 -->

--- a/examples/base/provisioned-plugin-manual-deployment/README.md
+++ b/examples/base/provisioned-plugin-manual-deployment/README.md
@@ -1,11 +1,14 @@
-<!-- THIS FILE IS AUTO-GENERATED. DO NOT EDIT MANUALLY. RUN: "go run genreadme.go" TO RE-GENERATE -->
-
 # provisioned-plugin-manual-deployment
 
 > [!WARNING]
 >
 > Please [read the docs](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions) before using any of these workflows in your repository.
+
 The `yaml` files should be put in your repository's `.github/workflows` folder, and customized depending on your needs.
+
+**Each workflow file is just a template/example. Remember to address all the TODOs before starting to use the workflows.**
+
+<!-- README start -->
 
 An example setup for a provisioned plugin. Use this workflow if you wish to have manual control of version rollouts.
 

--- a/examples/base/provisioned-plugin-manual-deployment/README.md
+++ b/examples/base/provisioned-plugin-manual-deployment/README.md
@@ -1,0 +1,13 @@
+<!-- THIS FILE IS AUTO-GENERATED. DO NOT EDIT MANUALLY. RUN: "go run genreadme.go" TO RE-GENERATE -->
+
+# provisioned-plugin-manual-deployment
+
+> [!WARNING]
+>
+> Please [read the docs](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions) before using any of these workflows in your repository.
+The `yaml` files should be put in your repository's `.github/workflows` folder, and customized depending on your needs.
+
+An example setup for a provisioned plugin. Use this workflow if you wish to have manual control of version rollouts.
+
+- CI for each PR and push to main
+- Manual deployment to the catalog and Grafana Cloud via Argo workflow + deployment_tools

--- a/examples/base/provisioned-plugin-manual-deployment/README.md
+++ b/examples/base/provisioned-plugin-manual-deployment/README.md
@@ -9,6 +9,7 @@ The `yaml` files should be put in your repository's `.github/workflows` folder, 
 **Each workflow file is just a template/example. Remember to address all the TODOs before starting to use the workflows.**
 
 <!-- README start -->
+<!-- order: 20 -->
 
 An example setup for a provisioned plugin. Use this workflow if you wish to have manual control of version rollouts.
 

--- a/examples/base/simple/README.md
+++ b/examples/base/simple/README.md
@@ -1,0 +1,13 @@
+<!-- THIS FILE IS AUTO-GENERATED. DO NOT EDIT MANUALLY. RUN: "go run genreadme.go" TO RE-GENERATE -->
+
+# simple
+
+> [!WARNING]
+>
+> Please [read the docs](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions) before using any of these workflows in your repository.
+The `yaml` files should be put in your repository's `.github/workflows` folder, and customized depending on your needs.
+
+A simple setup for a non-provisioned plugin, gets you started quickly and you can test your plugin on a grafana cloud instance.
+
+- CI for each PR and push to main
+- Manual deployment to the catalog

--- a/examples/base/simple/README.md
+++ b/examples/base/simple/README.md
@@ -3,10 +3,10 @@
 > [!WARNING]
 >
 > Please [read the docs](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions) before using any of these workflows in your repository.
-
-The `yaml` files should be put in your repository's `.github/workflows` folder, and customized depending on your needs.
-
-**Each workflow file is just a template/example. Remember to address all the TODOs before starting to use the workflows.**
+>
+> The `yaml` files should be put in your repository's `.github/workflows` folder, and customized depending on your needs.
+>
+> **Each workflow file is just a template/example. Remember to address all the TODOs before starting to use the workflows.**
 
 <!-- README start -->
 <!-- order: 0 -->

--- a/examples/base/simple/README.md
+++ b/examples/base/simple/README.md
@@ -9,6 +9,7 @@ The `yaml` files should be put in your repository's `.github/workflows` folder, 
 **Each workflow file is just a template/example. Remember to address all the TODOs before starting to use the workflows.**
 
 <!-- README start -->
+<!-- order: 0 -->
 
 A simple setup for a non-provisioned plugin, gets you started quickly and you can test your plugin on a grafana cloud instance.
 


### PR DESCRIPTION
Copied each example's README.md into its own directory. This adds a README visible in GitHub when linking a specific example.

Adds a script to generate the root folder's README.md file, by combining all the README.md files for each example.