### PR TITLE
fix(publish): Fix 'unary operator expected' error in publish script

### DIFF
--- a/actions/plugins/publish/publish/publish.sh
+++ b/actions/plugins/publish/publish/publish.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-if [ "$RUNNER_DEBUG" == "1" ]; then
+if [[ "$RUNNER_DEBUG" == "1" ]]; then
     set -x
 fi
 


### PR DESCRIPTION
Small bugfix to suppress a warning.

Related to #121