### PR TITLE
fix(publish): Fix secrets not being passed to Playwright when publishing

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -307,7 +307,7 @@ jobs:
 
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main # zizmor: ignore[unpinned-uses]
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@giuseppe/fix-playwright-publish-secrets # zizmor: ignore[unpinned-uses]
     needs:
       - setup
     with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -307,7 +307,7 @@ jobs:
 
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@giuseppe/fix-playwright-publish-secrets # zizmor: ignore[unpinned-uses]
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main # zizmor: ignore[unpinned-uses]
     needs:
       - setup
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,7 +252,7 @@ jobs:
               github.event_name === 'workflow_dispatch' || (isPR && !isForkPR)
             ) && !isBot;
 
-            return { isTrusted, isForkPR };
+            return { isTrusted, isForkPR, isBot };
 
       - name: Setup
         uses: grafana/plugin-ci-workflows/actions/plugins/setup@main # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,7 @@ jobs:
         id: workflow-context
         with:
           script: |
-            console.log('input context:', JSON.stringify(github));
+            console.log('input context:', JSON.stringify(context));
 
             const bots = [
               'dependabot[bot]',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,7 +241,10 @@ jobs:
         with:
           script: |
             const bots = [
-              'dependabot[bot]'
+              'dependabot[bot]',
+              'renovate[bot]',
+              'github-actions[bot]',
+              'renovate-sh-app[bot]'
             ].map((s) => s.toLowerCase());
 
             const isPR = github.event_name === 'pull_request';

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,7 @@ jobs:
             ].map((s) => s.toLowerCase());
 
             const isPR = github.event_name === 'pull_request';
-            const isBot = bots.includes(github.actor.toLowerCase());
+            const isBot = bots.includes(github.actor?.toLowerCase());
 
             const isForkPR = isPR && github.event.pull_request.head.repo.full_name !== github.repository;
             const isTrusted = (

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,8 +214,6 @@ env:
   GCS_ARTIFACTS_BUCKET: integration-artifacts
   VAULT_INSTANCE: ops
 
-  IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
-
 jobs:
   test-and-build:
     name: Test and build plugin
@@ -228,12 +226,33 @@ jobs:
       os-arch-zips: ${{ steps.outputs.outputs.os-arch-zips }}
       zips: ${{ steps.outputs.outputs.zips }}
 
+      workflow-context: ${{ steps.workflow-context.outputs.result }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.branch }}
           persist-credentials: false
+
+      - name: Determine workflow context
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        id: workflow-context
+        with:
+          script: |
+            const bots = [
+              'dependabot[bot]'
+            ].map((s) => s.toLowerCase());
+
+            const isPR = github.event_name === 'pull_request';
+            const isBot = bots.includes(github.actor.toLowerCase());
+
+            const isForkPR = isPR && github.event.pull_request.head.repo.full_name !== github.repository;
+            const isTrusted = (
+              github.event_name === 'workflow_dispatch' || (isPR && !isForkPR)
+            ) && !isBot;
+
+            return { isTrusted, isForkPR };
 
       - name: Setup
         uses: grafana/plugin-ci-workflows/actions/plugins/setup@main # zizmor: ignore[unpinned-uses]
@@ -245,7 +264,7 @@ jobs:
 
       - name: Get secrets from Vault
         id: get-secrets
-        if: ${{ env.IS_FORK == 'false' }}
+        if: ${{ fromJson(steps.workflow-context.outputs.result).isTrusted }}
         uses: grafana/shared-workflows/actions/get-vault-secrets@9f37f656e063f0ad0b0bfc38d49894b57d363936 # v1.2.1
         with:
           vault_instance: ${{ env.VAULT_INSTANCE }}
@@ -258,7 +277,7 @@ jobs:
       - name: Generate GitHub token
         id: generate-github-token
         uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
-        if: ${{ env.IS_FORK == 'false' }}
+        if: ${{ fromJson(steps.workflow-context.outputs.result).isTrusted }}
         with:
           app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
           private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
@@ -316,8 +335,8 @@ jobs:
           universal: "true"
           dist-folder: dist
           output-folder: dist-artifacts
-          access-policy-token: ${{ env.IS_FORK == 'false' && fromJSON(steps.get-secrets.outputs.secrets).SIGN_PLUGIN_ACCESS_POLICY_TOKEN || '' }}
-          allow-unsigned: ${{ env.IS_FORK == 'true' }}
+          access-policy-token: ${{ fromJson(steps.workflow-context.outputs.result).isTrusted && fromJSON(steps.get-secrets.outputs.secrets).SIGN_PLUGIN_ACCESS_POLICY_TOKEN || '' }}
+          allow-unsigned: ${{ !(fromJson(steps.workflow-context.outputs.result).isTrusted) }}
 
       - name: Package os/arch ZIPs
         id: os-arch-zips
@@ -326,8 +345,8 @@ jobs:
           universal: "false"
           dist-folder: dist
           output-folder: dist-artifacts
-          access-policy-token: ${{ env.IS_FORK == 'false' && fromJSON(steps.get-secrets.outputs.secrets).SIGN_PLUGIN_ACCESS_POLICY_TOKEN || '' }}
-          allow-unsigned: ${{ env.IS_FORK == 'true' }}
+          access-policy-token: ${{ fromJson(steps.workflow-context.outputs.result).isTrusted && fromJSON(steps.get-secrets.outputs.secrets).SIGN_PLUGIN_ACCESS_POLICY_TOKEN || '' }}
+          allow-unsigned: ${{ !(fromJson(steps.workflow-context.outputs.result).isTrusted) }}
 
       - name: Trufflehog secrets scanning
         if: ${{ inputs.run-trufflehog == true }}
@@ -421,7 +440,7 @@ jobs:
       playwright-config: ${{ inputs.playwright-config }}
       report-path: ${{ inputs.playwright-report-path }}
       grafana-url: ${{ inputs.playwright-grafana-url }}
-      secrets: ${{ (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && inputs.playwright-secrets != '') && inputs.playwright-secrets || '' }}
+      secrets: ${{ (fromJson(needs.test-and-build.outputs.workflow-context).isTrusted && inputs.playwright-secrets != '') && inputs.playwright-secrets || '' }}
 
   playwright-docker:
     name: Plugins - Dockerized Playwright E2E tests
@@ -439,15 +458,14 @@ jobs:
       grafana-compose-file: ${{ inputs.playwright-docker-compose-file }}
       report-path: ${{ inputs.playwright-report-path }}
       grafana-url: ${{ inputs.playwright-grafana-url }}
-      secrets: ${{ (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && inputs.playwright-secrets != '') && inputs.playwright-secrets || '' }}
+      secrets: ${{ (fromJson(needs.test-and-build.outputs.workflow-context).isTrusted && inputs.playwright-secrets != '') && inputs.playwright-secrets || '' }}
 
   upload-to-gcs:
     name: Upload to GCS
     runs-on: ubuntu-latest
 
-    # Skip the GCS upload for PRs from forks (no access to the GCS bucket)
-    # This is equivalent to !env.IS_FORK (we don't have access to the env context at this level)
-    if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
+    # Skip the GCS upload (no access to the bucket) for PRs when run in non-trusted context (forks)
+    if: ${{ fromJson(needs.test-and-build.outputs.workflow-context).isTrusted }}
 
     needs:
       - test-and-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,7 +256,7 @@ jobs:
             ) && !isBot;
 
             const o = { isTrusted, isForkPR, isBot };
-            console.log('output context:', JSON.stringify(o));
+            console.log(JSON.stringify(o));
             return o
 
       - name: Setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,6 +240,8 @@ jobs:
         id: workflow-context
         with:
           script: |
+            console.log('input context:', JSON.stringify(github));
+
             const bots = [
               'dependabot[bot]',
               'renovate[bot]',
@@ -255,7 +257,9 @@ jobs:
               github.event_name === 'workflow_dispatch' || (isPR && !isForkPR)
             ) && !isBot;
 
-            return { isTrusted, isForkPR, isBot };
+            const o = { isTrusted, isForkPR, isBot };
+            console.log('output context:', JSON.stringify(o));
+            return o
 
       - name: Setup
         uses: grafana/plugin-ci-workflows/actions/plugins/setup@main # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,12 +249,12 @@ jobs:
               'renovate-sh-app[bot]'
             ].map((s) => s.toLowerCase());
 
-            const isPR = github.event_name === 'pull_request';
-            const isBot = bots.includes(github.actor?.toLowerCase());
+            const isPR = context.eventName === 'pull_request';
+            const isBot = bots.includes(context.actor?.toLowerCase());
 
-            const isForkPR = isPR && github.event.pull_request.head.repo.full_name !== github.repository;
+            const isForkPR = isPR && context.payload.pull_request.head.repo.full_name !== context.payload.repository.full_name;
             const isTrusted = (
-              github.event_name === 'workflow_dispatch' || (isPR && !isForkPR)
+              context.eventName === 'workflow_dispatch' || (isPR && !isForkPR)
             ) && !isBot;
 
             const o = { isTrusted, isForkPR, isBot };

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,8 +240,6 @@ jobs:
         id: workflow-context
         with:
           script: |
-            console.log('input context:', JSON.stringify(context));
-
             const bots = [
               'dependabot[bot]',
               'renovate[bot]',


### PR DESCRIPTION
Fixes an issue when using Playwright secrets where the secrets are not fetched from Vault when the CI is triggered from CD (via workflow_dispatch).

This was caused because the expression to determine if secrets should be passed was:

```
github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
```

But for CD triggers, the event is NOT a pull_request, but rather a workflow_dispatch, so it always evaluates to false and causes the secrets to be empty.

Example failure in the x-ray-datasource: https://github.com/grafana/x-ray-datasource/actions/runs/16673945572

This PR fixes the issues and refactors the logic to determine if secrets should be fetched or not. Rather than using those complex expressions, it adds a new `workflow-context` step to the `test-and-build` job, which uses a small node js snippet to export some useful information about the workflow run (is fork, is trusted, is bot, etc). Those can then be used to more easily trigger bits of the workflow depending on whether the PR comes from a trusted source or not.

**Keep in mind WIF will still prevent accessing Vault in case the PR comes from outside Grafana Labs. This logic that skips/omits some secrets is only to allow the workflow to pass. Otherwise it would fail when trying fetch secrets from Vault (it fails with a 403).**