### PR TITLE
fix(publish): Fix cd-style push events not being considered trusted

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -307,7 +307,7 @@ jobs:
 
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main # zizmor: ignore[unpinned-uses]
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@giuseppe/fix-trusted-context-cd # zizmor: ignore[unpinned-uses]
     needs:
       - setup
     with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -307,7 +307,7 @@ jobs:
 
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@giuseppe/fix-trusted-context-cd # zizmor: ignore[unpinned-uses]
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main # zizmor: ignore[unpinned-uses]
     needs:
       - setup
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,11 +249,11 @@ jobs:
 
             const isPR = context.eventName === 'pull_request';
             const isBot = bots.includes(context.actor?.toLowerCase());
-
             const isForkPR = isPR && context.payload.pull_request.head.repo.full_name !== context.payload.repository.full_name;
-            const isTrusted = (
-              context.eventName === 'workflow_dispatch' || (isPR && !isForkPR)
-            ) && !isBot;
+
+            // Events that are considered trusted because can be run by a trusted user (unless it's a bot)
+            const isTrustedEvent = ['push', 'workflow_dispatch'].includes(context.eventName);
+            const isTrusted = (isTrustedEvent || (isPR && !isForkPR)) && !isBot;
 
             const o = { isTrusted, isForkPR, isBot };
             console.log(JSON.stringify(o));


### PR DESCRIPTION
Fix CD-style push events not being considered trusted (isTrusted: false) after merging #196.

Without the fix, CD runs are considered trusted only when triggered by a "workflow_dispatch" event. When using CD-style (auto) deployments, however, CD is run for each push to main, so the event in those cases is "push" and not "workflow_dispatch". This PR also treats "push" events as trusted (unless they've been triggered by a bot).

Example failure: https://github.com/grafana/grafana-assistant-app/actions/runs/16722440411/job/47329717594

Test run: https://github.com/grafana/grafana-pluginsplatformprovisioned-app/actions/runs/16724627313/job/47336938815