### PR TITLE
feat(publish): Sanity check ZIP files before publishing to catalog

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -527,6 +527,12 @@ jobs:
           gcom-publish-token: ${{ env.GCOM_PUBLISH_TOKEN }}
           gcloud-auth-token: ${{ steps.gcloud.outputs.id_token }}
 
+      - name: Check artifact ZIP(s)
+        uses: grafana/plugin-ci-workflows/actions/plugins/publish/check-artifacts@main # zizmor: ignore[unpinned-uses]
+        with:
+          zips: ${{ needs.upload-to-gcs-release.outputs.gcs-zip-urls }}
+          plugin-id: ${{ fromJSON(needs.ci.outputs.plugin).id }}
+
       - name: Publish to catalog
         uses: grafana/plugin-ci-workflows/actions/plugins/publish/publish@main # zizmor: ignore[unpinned-uses]
         with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -533,7 +533,7 @@ jobs:
           gcloud-auth-token: ${{ steps.gcloud.outputs.id_token }}
 
       - name: Check artifact ZIP(s)
-        uses: grafana/plugin-ci-workflows/actions/plugins/publish/check-artifacts@giuseppe/sanity-check-zips # zizmor: ignore[unpinned-uses]
+        uses: grafana/plugin-ci-workflows/actions/plugins/publish/check-artifacts@main # zizmor: ignore[unpinned-uses]
         with:
           zips: ${{ needs.upload-to-gcs-release.outputs.gcs-zip-urls }}
           plugin-id: ${{ fromJSON(needs.ci.outputs.plugin).id }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -533,7 +533,7 @@ jobs:
           gcloud-auth-token: ${{ steps.gcloud.outputs.id_token }}
 
       - name: Check artifact ZIP(s)
-        uses: grafana/plugin-ci-workflows/actions/plugins/publish/check-artifacts@main # zizmor: ignore[unpinned-uses]
+        uses: grafana/plugin-ci-workflows/actions/plugins/publish/check-artifacts@giuseppe/sanity-check-zips # zizmor: ignore[unpinned-uses]
         with:
           zips: ${{ needs.upload-to-gcs-release.outputs.gcs-zip-urls }}
           plugin-id: ${{ fromJSON(needs.ci.outputs.plugin).id }}

--- a/actions/plugins/publish/check-artifacts/action.yml
+++ b/actions/plugins/publish/check-artifacts/action.yml
@@ -1,0 +1,23 @@
+name: Plugins - Check artifact ZIP(s)
+description: Checks that the plugin ZIP file(s) are valid, signed and can be published.
+
+inputs:
+  zips:
+    description: |
+      A string or JSON array of plugin ZIP file URL(s) to validate.
+    required: true
+  plugin-id:
+    description: |
+      The expected plugin ID for the ZIP file(s).
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Check artifact ZIP(s)
+      run: |
+        ${{ github.action_path }}/check-artifacts.sh "${ZIPS}" "${PLUGIN_ID}"
+      env:
+        ZIPS: ${{ inputs.zips }}
+        PLUGIN_ID: ${{ inputs.plugin-id }}
+      shell: bash

--- a/actions/plugins/publish/check-artifacts/check-artifacts.sh
+++ b/actions/plugins/publish/check-artifacts/check-artifacts.sh
@@ -44,12 +44,12 @@ validate_plugin_zip() {
 }
 
 process_plugin_zips() {
-    local json_array="$1"
+    local urls_array="$1"
     local plugin_id="$2"
     local failed_count=0
 
     # Parse JSON array and process each URL
-    echo "$json_array" | jq -r '.[]' | while read -r zip_url; do
+    echo "$urls_array" | jq -r '.[]' | while read -r zip_url; do
         if ! validate_plugin_zip "$zip_url" "$plugin_id"; then
             ((failed_count++))
         fi
@@ -70,15 +70,15 @@ if [[ $# -ne 2 ]]; then
     echo "Usage: $0 <json_array_of_urls_or_single_url> <plugin_id>"
     exit 1
 fi
-json_array="$1"
+urls_array="$1"
 plugin_id="$2"
 
-# If a string was provided in json_array, convert it to a JSON array with jq
-if [[ "$json_array" != \[* ]]; then
-    json_array=$(echo "$json_array" | jq -Rc '[.]')
+# If a string was provided in urls_array, convert it to a JSON array with jq
+if [[ "$urls_array" != \[* ]]; then
+    urls_array=$(echo "$urls_array" | jq -Rc '[.]')
 fi
 
-if ! process_plugin_zips "$json_array" "$plugin_id"; then
+if ! process_plugin_zips "$urls_array" "$plugin_id"; then
     exit 1
 fi
 exit 0

--- a/actions/plugins/publish/check-artifacts/check-artifacts.sh
+++ b/actions/plugins/publish/check-artifacts/check-artifacts.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+set -euo pipefail
+
+validate_plugin_zip() {
+    local zip_url="$1"
+    local plugin_id="$2"
+    local temp_dir=$(mktemp -d)
+    local zip_file="$temp_dir/plugin.zip"
+
+    echo "Processing: $zip_url"
+
+    # Download the ZIP file
+    if ! curl -L -o "$zip_file" "$zip_url"; then
+        echo "ERROR: Failed to download $zip_url"
+        return 1
+    fi
+
+    # Extract ZIP file
+    if ! unzip -q "$zip_file" -d "$temp_dir"; then
+        echo "ERROR: Failed to extract $zip_url"
+        return 1
+    fi
+
+    # Check if plugin_id folder exists
+    if [[ ! -d "$temp_dir/$plugin_id" ]]; then
+        echo "ERROR: Folder '$plugin_id' not found in $zip_url"
+        return 1
+    fi
+
+    # Check if MANIFEST.txt exists and is non-empty
+    if [[ ! -f "$temp_dir/$plugin_id/MANIFEST.txt" ]] || [[ ! -s "$temp_dir/$plugin_id/MANIFEST.txt" ]]; then
+        echo "ERROR: MANIFEST.txt missing or empty in $zip_url"
+        return 1
+    fi
+
+    # Check if plugin.json exists and is non-empty
+    if [[ ! -f "$temp_dir/$plugin_id/plugin.json" ]] || [[ ! -s "$temp_dir/$plugin_id/plugin.json" ]]; then
+        echo "ERROR: plugin.json missing or empty in $zip_url"
+        return 1
+    fi
+
+    echo "SUCCESS: $zip_url passed all validation checks"
+    return 0
+}
+
+process_plugin_zips() {
+    local json_array="$1"
+    local plugin_id="$2"
+    local failed_count=0
+
+    # Parse JSON array and process each URL
+    echo "$json_array" | jq -r '.[]' | while read -r zip_url; do
+        if ! validate_plugin_zip "$zip_url" "$plugin_id"; then
+            ((failed_count++))
+        fi
+        echo "---"
+    done
+
+    if [[ $failed_count -gt 0 ]]; then
+        echo "Completed with $failed_count failures"
+        return 1
+    else
+        echo "All ZIP files validated successfully"
+        return 0
+    fi
+}
+
+# Main script execution
+if [[ $# -ne 2 ]]; then
+    echo "Usage: $0 <json_array_of_urls_or_single_url> <plugin_id>"
+    exit 1
+fi
+json_array="$1"
+plugin_id="$2"
+
+# If a string was provided in json_array, convert it to a JSON array with jq
+if [[ "$json_array" != \[* ]]; then
+    json_array=$(echo "$json_array" | jq -Rc '[.]')
+fi
+
+if ! process_plugin_zips "$json_array" "$plugin_id"; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Adds a new re-usable action: `plugins/publish/check-artifacts`.

This action runs the following sanity checks on a list of plugin ZIP files:

- Checks that there's a root folder with the plugin's id as its name
- Checks that MANIFEST.txt is present (plugin is signed)
- Checks that plugin.json is present

This action is run before publishing a plugin, to ensure that broken plugins aren't published to the catalog

Example run: https://github.com/grafana/plugins-drone-to-gha/actions/runs/16773289220/job/47493770200