### PR TITLE
fix(cd): github draft optional, omit commits

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,7 +25,7 @@ on:
           Comma-separated list of scopes for the plugin version in the catalog.
           Default is 'universal'.
           Can also be set to 'grafana_cloud' or a list of grafana_cloud_org's or grafana_cloud_instance's like "grafana_cloud_org_{slug},grafana_cloud_org_{slug}" or "grafan_cloud_instance_{slug},grafan_cloud_instance_{slug}"
-          More information about available scopes can be found here https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/grafana-com/gcom-cli-cheat-sheet/#scoping 
+          More information about available scopes can be found here https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/grafana-com/gcom-cli-cheat-sheet/#scoping
         required: false
         default: universal
         type: string
@@ -61,8 +61,8 @@ on:
         type: string
         required: false
       go-setup-caching:
-        description: Defines if setup-go action should have caching enabled (https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs) 
-        type: 'boolean'
+        description: Defines if setup-go action should have caching enabled (https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs)
+        type: "boolean"
         required: false
       trufflehog-version:
         description: Trufflehog version to use
@@ -206,6 +206,11 @@ on:
         description: |
           Only publish docs to the website, do not publish the plugin.
         default: false
+        type: boolean
+      github-draft-release:
+        description: |
+          Publish a draft release on GitHub.
+        default: true
         type: boolean
       argo-workflow-slack-channel:
         description: |
@@ -900,7 +905,7 @@ jobs:
       - name: Create Github release
         uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2.3.2
         with:
-          draft: true
+          draft: ${{ inputs.github-draft-release }}
           name: ${{ fromJSON(needs.ci.outputs.plugin).id }} v${{ fromJSON(needs.ci.outputs.plugin).version }}
           tag_name: v${{ fromJSON(needs.ci.outputs.plugin).version }}
           files: |

--- a/actions/plugins/version-bump-changelog/action.yml
+++ b/actions/plugins/version-bump-changelog/action.yml
@@ -1,6 +1,6 @@
-name: Bump npm version and release
+name: Generate changelog version bump changelog
 description: |
-  Bump npm version, create a git tag and optionally generate a changelog on main.
+  Bump npm version, create a git tag and optionally generate a changelog on main using the generate-changelog npm package.
 
 inputs:
   version:
@@ -78,10 +78,10 @@ runs:
         if [[ "${{ steps.previous-tag.outputs.previous-tag }}" == "v0.0.0" ]]; then
           echo "No previous tag found ${{ steps.previous-tag.outputs.previous-tag }}, generating changelog for initial version only: v${{ steps.bump.outputs.new-version }}"
           # For initial version, get all commits up to HEAD
-          npx generate-changelog -t HEAD
+          npx generate-changelog -t HEAD --exclude skip,no-changelog
         else
           echo "Generating changelog from ${{ steps.previous-tag.outputs.previous-tag }} to HEAD"
-          npx generate-changelog -t ${{ steps.previous-tag.outputs.previous-tag }}...HEAD
+          npx generate-changelog -t ${{ steps.previous-tag.outputs.previous-tag }}...HEAD --exclude skip,no-changelog
         fi
 
         # Remove existing "Changelog" header anywhere in the file


### PR DESCRIPTION
- Update cd.yml with an optional configuration for github-draft-release. It's set to true by default for backwards compatibility. This flexibility will be nice because some of the other changelog libraries do the draft release for you (ex: release please). 
- Allow generate-changelog to omit commits