### PR TITLE
feat(playwright): env for GRAFANA_VERSION to allow the playwright config access

### DIFF
--- a/.github/workflows/playwright-docker.yml
+++ b/.github/workflows/playwright-docker.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Set secrets
         if: inputs.secrets != ''
         run: |
-          echo '${{ steps.get-secrets.outputs.secrets }}' | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> .env          
+          echo '${{ steps.get-secrets.outputs.secrets }}' | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> .env
         # No support for subdirectories when running with Docker
         # working-directory: ${{ inputs.plugin-directory }}
 
@@ -147,6 +147,8 @@ jobs:
           docker compose --profile playwright ${DOCKER_COMPOSE_FILE:+-f "$DOCKER_COMPOSE_FILE"} up playwright --exit-code-from playwright
         env:
           DOCKER_COMPOSE_FILE: ${{ inputs.grafana-compose-file }}
+          GRAFANA_VERSION: ${{ matrix.GRAFANA_IMAGE.VERSION }}
+          GRAFANA_IMAGE: ${{ matrix.GRAFANA_IMAGE.NAME }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -154,7 +154,7 @@ jobs:
       - name: Set secrets
         if: inputs.secrets != ''
         run: |
-          echo '${{ steps.get-secrets.outputs.secrets }}' | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> .env          
+          echo '${{ steps.get-secrets.outputs.secrets }}' | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> .env
         working-directory: ${{ inputs.plugin-directory }}
 
       - name: Start Grafana
@@ -169,12 +169,14 @@ jobs:
         uses: grafana/plugin-actions/wait-for-grafana@main # zizmor: ignore[unpinned-uses]
         with:
           url: "${{ inputs.grafana-url }}"
-      
+
       - name: Run Playwright tests
         id: run-tests
         run: npx playwright test --config "${PLAYWRIGHT_CONFIG}"
         env:
           PLAYWRIGHT_CONFIG: ${{ inputs.playwright-config }}
+          GRAFANA_VERSION: ${{ matrix.GRAFANA_IMAGE.VERSION }}
+          GRAFANA_IMAGE: ${{ matrix.GRAFANA_IMAGE.NAME }}
         working-directory: ${{ inputs.plugin-directory }}
 
       - name: Upload artifacts


### PR DESCRIPTION
Pass the `GRAFANA_VERSION: ${{ matrix.GRAFANA_IMAGE.VERSION }}` and `GRAFANA_IMAGE: ${{ matrix.GRAFANA_IMAGE.NAME }}` to playwright so that people can access it in the playwright config with `process.env.GRAFANA_VERSION` . The goal is to run different tests for different grafana versions. [example PR ](https://github.com/grafana/logs-drilldown/pull/1479). Right now `process.env.GRAFANA_VERSION` is undefined 
<img width="674" height="149" alt="Screenshot 2025-08-05 at 9 55 11 AM" src="https://github.com/user-attachments/assets/2cfc2991-4251-42ce-b74b-1ffeb8025637" />. 
