### PR TITLE
feat: allow all workflows to set both node-version-file and node-version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,7 @@ jobs:
         with:
           go-version: ${{ inputs.go-version || env.DEFAULT_GO_VERSION }}
           node-version: ${{ inputs.node-version || env.DEFAULT_NODE_VERSION }}
+          node-version-file: ${{ inputs.plugin-directory }}/.nvmrc
           golangci-lint-version: ${{ inputs.golangci-lint-version || env.DEFAULT_GOLANGCI_LINT_VERSION }}
           go-setup-caching: ${{ inputs.go-setup-caching }}
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -59,10 +59,17 @@ on:
         type: string
         required: false
         default: http://localhost:3000/
+      node-version:
+        description: Node.js version to use
+        type: string
+        required: false
 
 permissions:
   contents: read
   id-token: write
+
+env:
+  DEFAULT_NODE_VERSION: "20"
 
 jobs:
   resolve-versions:
@@ -103,6 +110,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
+          node-version: ${{ inputs.node-version || env.DEFAULT_NODE_VERSION }}
           node-version-file: ${{ inputs.plugin-directory }}/.nvmrc
 
       - name: Install npm dependencies
@@ -154,7 +162,7 @@ jobs:
       - name: Set secrets
         if: inputs.secrets != ''
         run: |
-          echo '${{ steps.get-secrets.outputs.secrets }}' | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> .env          
+          echo '${{ steps.get-secrets.outputs.secrets }}' | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> .env
         working-directory: ${{ inputs.plugin-directory }}
 
       - name: Start Grafana
@@ -169,7 +177,7 @@ jobs:
         uses: grafana/plugin-actions/wait-for-grafana@main # zizmor: ignore[unpinned-uses]
         with:
           url: "${{ inputs.grafana-url }}"
-      
+
       - name: Run Playwright tests
         id: run-tests
         run: npx playwright test --config "${PLAYWRIGHT_CONFIG}"

--- a/actions/plugins/setup/action.yml
+++ b/actions/plugins/setup/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: Defines if setup-go action should have caching enabled (https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs)
     required: false
     default: "true"
+  node-version-file:
+    description: Node.js version file to use.
+    required: true
+    default: ".nvmrc"
 
 runs:
   using: composite
@@ -23,6 +27,7 @@ runs:
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: "${{ inputs.node-version }}"
+        node-version-file: "${{ inputs.node-version-file }}"
 
     - name: Go
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0

--- a/actions/plugins/setup/action.yml
+++ b/actions/plugins/setup/action.yml
@@ -17,8 +17,8 @@ inputs:
     default: "true"
   node-version-file:
     description: Node.js version file to use.
-    required: true
-    default: ".nvmrc"
+    required: false
+    default: ""
 
 runs:
   using: composite


### PR DESCRIPTION
Allow all workflows that use `actions/setup-node` to use both `node-version-file` and `node-version`.

The `node-version-file` will be taken from the plugins-directory/.nvmrc path always, while `node-version` can be optionally provided and it will default to 20 in `playwright.yml` for consistency with `ci.yml`

Fixes https://github.com/grafana/plugin-ci-workflows/issues/195