### PR TITLE
chore: Add renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,8 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: [
+    "config:best-practices",
+    ":doNotPinPackage(grafana/docs-base)",
+    ":doNotPinPackage(grafana/shared-workflows)",
+  ],
+}


### PR DESCRIPTION
Adds renovate config file. Uses best practices preset and ignores pinning `grafana/docs-base` and `grafana/shared-workflows`.

The two "do not pin" config options should avoid PRs like this from being created:

https://github.com/grafana/plugin-ci-workflows/pull/203

Those PRs aren't needed because:

- We always need the latest version for `grafana/docs-base` Docker image
- We don't need to pin the exact digest for shared actions since they are internally developed