### PR TITLE
ci: Switch runners for internal workflows to self-hosted ones

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,0 +1,25 @@
+self-hosted-runner:
+  labels:
+    - ubuntu-x64-small
+    - ubuntu-x64
+    - ubuntu-x64-large
+    - ubuntu-x64-xlarge
+    - ubuntu-x64-2xlarge
+
+    - ubuntu-x64-small-io
+    - ubuntu-x64-io
+    - ubuntu-x64-large-io
+    - ubuntu-x64-xlarge-io
+    - ubuntu-x64-2xlarge-io
+
+    - ubuntu-arm64-small
+    - ubuntu-arm64
+    - ubuntu-arm64-large
+    - ubuntu-arm64-xlarge
+    - ubuntu-arm64-2xlarge
+
+    - ubuntu-arm64-small-io
+    - ubuntu-arm64-io
+    - ubuntu-arm64-large-io
+    - ubuntu-arm64-xlarge-io
+    - ubuntu-arm64-2xlarge-io

--- a/.github/workflows/check-examples-readmes.yml
+++ b/.github/workflows/check-examples-readmes.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   check-readme:
     name: Check if example/base/README.md is up-to-date
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64-small
 
     steps:
       - name: Checkout code

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   actionlint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64-small
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -10,12 +10,12 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-  
+
 jobs:
   check-title:
-    permissions: 
+    permissions:
       pull-requests: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64-small
     steps:
       - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
         env:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,10 +11,9 @@ permissions:
 env:
   IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
 
-
 jobs:
   release-please:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64-small
 
     permissions:
       contents: write # Needed to create releases and tags


### PR DESCRIPTION
Switches the runners used for internal workflows used by plugin-ci-workflows itself to the self-hosted ones.

Part of #213 
