### PR TITLE
fix: pass node-version down from ci to playwright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,6 +447,7 @@ jobs:
       report-path: ${{ inputs.playwright-report-path }}
       grafana-url: ${{ inputs.playwright-grafana-url }}
       secrets: ${{ (fromJson(needs.test-and-build.outputs.workflow-context).isTrusted && inputs.playwright-secrets != '') && inputs.playwright-secrets || '' }}
+      node-version: ${{ inputs.node-version }}
 
   playwright-docker:
     name: Plugins - Dockerized Playwright E2E tests

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -68,9 +68,6 @@ permissions:
   contents: read
   id-token: write
 
-env:
-  DEFAULT_NODE_VERSION: "20"
-
 jobs:
   resolve-versions:
     name: Resolve Grafana images
@@ -110,7 +107,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: ${{ inputs.node-version || env.DEFAULT_NODE_VERSION }}
+          node-version: ${{ inputs.node-version }}
           node-version-file: ${{ inputs.plugin-directory }}/.nvmrc
 
       - name: Install npm dependencies


### PR DESCRIPTION
- Pass node-version down from ci.yml to playwright.yml
- Remove the default node version and let the node version fallback for the nvmrc when as it was before.