### PR TITLE
feat: allow passing of secrets to frontend build steps

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -227,6 +227,11 @@ on:
           Default is 'dev'.
         default: dev
         type: string
+      frontend-secrets:
+        description: The secrets to use within frontend steps
+        type: string
+        required: false
+        default: ""
 
       # Options for deploying PRs. Those values should come from the PR event and should not be set manually.
       branch:
@@ -339,6 +344,7 @@ jobs:
       trufflehog-include-detectors: ${{ inputs.trufflehog-include-detectors }}
       trufflehog-exclude-detectors: ${{ inputs.trufflehog-exclude-detectors }}
       plugin-version-suffix: ${{ needs.setup.outputs.plugin-version-suffix }}
+      frontend-secrets: ${{ inputs.frontend-secrets }}
 
   build-attestation:
     name: Build attestation
@@ -770,7 +776,7 @@ jobs:
             // Create GCS URLs for all zip files, each in its correct platform directory
             for (const zipFile of zipFiles) {
               let targetPlatform;
-              
+
               // Determine platform directory based on filename pattern
               switch (true) {
                 case zipFile.includes('.darwin_'):
@@ -786,7 +792,7 @@ jobs:
                   targetPlatform = 'any';
                   break;
               }
-              
+
               const gcsUrl = `${gcsPrefix}/${gcsPath}/${targetPlatform}/${zipFile}`;
               allUrls.push(gcsUrl);
               console.log(`Generated GCS URL: ${gcsUrl}`);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,11 @@ on:
         type: string
         required: false
         default: ""
+      frontend-secrets:
+        description: The secrets to use within frontend steps
+        type: string
+        required: false
+        default: ""
 
       # Playwright
       run-playwright:
@@ -326,6 +331,7 @@ jobs:
         with:
           package-manager: ${{ inputs.package-manager }}
           plugin-directory: ${{ inputs.plugin-directory }}
+          secrets: ${{ (fromJson(steps.workflow-context.outputs.result).isTrusted && inputs.frontend-secrets != '') && inputs.frontend-secrets || '' }}
 
       - name: Test and build backend
         if: ${{ steps.check-for-backend.outputs.has-backend == 'true' }}

--- a/actions/plugins/frontend/action.yml
+++ b/actions/plugins/frontend/action.yml
@@ -10,10 +10,21 @@ inputs:
     description: The package manager to use.
     required: false
     default: ""
+  secrets:
+    required: false
+    type: string
+    description: The secrets to use within frontend steps
 
 runs:
   using: composite
   steps:
+    - name: Get secrets from Vault
+      if: inputs.secrets != ''
+      id: get-secrets
+      uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1 # zizmor: ignore[unpinned-uses]
+      with:
+        repo_secrets: ${{ inputs.secrets }}
+
     - name: Install dependencies
       shell: bash
       working-directory: ${{ inputs.plugin-directory }}


### PR DESCRIPTION
Some of our apps have custom webpack configs that use secrets from env vars. This PR adds the ability to pass secrets to the frontend steps.

Fixes: #221

