### PR TITLE
fix: Fix "Test docs" and "Publish docs" steps failing

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -312,7 +312,7 @@ jobs:
 
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@giuseppe/docs-docker # zizmor: ignore[unpinned-uses]
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main # zizmor: ignore[unpinned-uses]
     needs:
       - setup
     with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -811,7 +811,7 @@ jobs:
         && (needs.define-variables.outputs.publish-docs == 'true')
         && !(failure() || cancelled())
       }}
-    runs-on: ubuntu-x64-small
+    runs-on: ubuntu-latest
     container:
       image: grafana/docs-base:latest # zizmor: ignore[unpinned-images]
       volumes:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -312,7 +312,7 @@ jobs:
 
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main # zizmor: ignore[unpinned-uses]
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@giuseppe/docs-docker # zizmor: ignore[unpinned-uses]
     needs:
       - setup
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,7 +398,7 @@ jobs:
 
   docs:
     name: Test docs
-    runs-on: ubuntu-x64-small
+    runs-on: ubuntu-latest
     container:
       image: grafana/docs-base:latest # zizmor: ignore[unpinned-images]
       volumes:


### PR DESCRIPTION
Fixes test-docs and publish-docs steps failing for example here https://github.com/grafana/profiles-drilldown/actions/runs/16832835476/job/47684694460

```
/__w/_temp/a3180bbd-dc45-40c8-aeb9-37d23750b236.sh: line 2: /opt/actions-runner/_work/_actions/grafana/plugin-ci-workflows/main/actions/plugins/docs/test/script.sh: No such file or directory
```

Switches back to github-hosted runners for those steps until we can find a proper fix

Test run: https://github.com/grafana/profiles-drilldown/actions/runs/16833635923/job/47688740979