### PR TITLE
fix(ci): Fix NPM auth when running Playwright E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -444,7 +444,8 @@ jobs:
 
   playwright:
     name: Playwright E2E tests
-    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@main # zizmor: ignore[unpinned-uses]
+    # TODO: switch after done testing
+    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@giuseppe/private-npm-registry-playwright # zizmor: ignore[unpinned-uses]
     if: ${{ inputs.run-playwright == true }}
     needs:
       - test-and-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -462,6 +462,7 @@ jobs:
       grafana-url: ${{ inputs.playwright-grafana-url }}
       secrets: ${{ (fromJson(needs.test-and-build.outputs.workflow-context).isTrusted && inputs.playwright-secrets != '') && inputs.playwright-secrets || '' }}
       node-version: ${{ inputs.node-version }}
+      npm-registry-auth: ${{ inputs.npm-registry-auth }}
 
   playwright-docker:
     name: Plugins - Dockerized Playwright E2E tests
@@ -480,6 +481,8 @@ jobs:
       report-path: ${{ inputs.playwright-report-path }}
       grafana-url: ${{ inputs.playwright-grafana-url }}
       secrets: ${{ (fromJson(needs.test-and-build.outputs.workflow-context).isTrusted && inputs.playwright-secrets != '') && inputs.playwright-secrets || '' }}
+      # TODO: add support for NPM auth in Dockerized Playwright as well
+      # npm-registry-auth: ${{ inputs.npm-registry-auth }}
 
   upload-to-gcs:
     name: Upload to GCS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -444,8 +444,7 @@ jobs:
 
   playwright:
     name: Playwright E2E tests
-    # TODO: switch after done testing
-    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@giuseppe/private-npm-registry-playwright # zizmor: ignore[unpinned-uses]
+    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@main # zizmor: ignore[unpinned-uses]
     if: ${{ inputs.run-playwright == true }}
     needs:
       - test-and-build

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -117,7 +117,7 @@ jobs:
           node-version-file: ${{ inputs.plugin-directory }}/.nvmrc
 
       - name: Login to Google Cloud
-        if: inputs.npm-registry-auth == 'true'
+        if: inputs.npm-registry-auth == true
         uses: google-github-actions/auth@b7593ed2efd1c1617e1b0254da33b86225adb2a5 # v2.1.12
         with:
           token_format: access_token
@@ -125,7 +125,7 @@ jobs:
           service_account: github-plugin-ci-workflows@grafanalabs-workload-identity.iam.gserviceaccount.com
 
       - name: NPM registry auth
-        if: inputs.npm-registry-auth == 'true'
+        if: inputs.npm-registry-auth == true
         shell: bash
         working-directory: ${{ inputs.plugin-directory }}
         run: GOOGLE_APPLICATION_CREDENTIALS=${{ env.GOOGLE_APPLICATION_CREDENTIALS }} npx google-artifactregistry-auth --credential-config ./.npmrc

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -63,7 +63,13 @@ on:
         description: Node.js version to use
         type: string
         required: false
-
+      npm-registry-auth:
+        description: |
+          Whether to authenticate to the npm registry in Google Artifact Registry.
+          If true, the root of the plugin repository must contain a `.npmrc` file.
+        type: boolean
+        required: false
+        default: false
 permissions:
   contents: read
   id-token: write
@@ -109,6 +115,20 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
           node-version-file: ${{ inputs.plugin-directory }}/.nvmrc
+
+      - name: Login to Google Cloud
+        if: inputs.npm-registry-auth == 'true'
+        uses: google-github-actions/auth@b7593ed2efd1c1617e1b0254da33b86225adb2a5 # v2.1.12
+        with:
+          token_format: access_token
+          workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
+          service_account: github-plugin-ci-workflows@grafanalabs-workload-identity.iam.gserviceaccount.com
+
+      - name: NPM registry auth
+        if: inputs.npm-registry-auth == 'true'
+        shell: bash
+        working-directory: ${{ inputs.plugin-directory }}
+        run: GOOGLE_APPLICATION_CREDENTIALS=${{ env.GOOGLE_APPLICATION_CREDENTIALS }} npx google-artifactregistry-auth --credential-config ./.npmrc
 
       - name: Install npm dependencies
         # TODO: find a better way


### PR DESCRIPTION
Follow-up to #224. Part of #223. Forgot to do the NPM auth in Playwright as well.

Leaving out Docker for now.

Test run: https://github.com/grafana/plugins-drone-to-gha/actions/runs/16910579862/job/47911075942?pr=41 (ignore the tests failing, the important part is the npm auth and that dependenceis can be fetched)