### PR TITLE
chore(deps): update shared-workflows/actions/trigger-argo-workflow to v1.2.0

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -632,7 +632,7 @@ jobs:
 
       - name: Trigger Argo Workflow
         id: trigger-argo-workflow
-        uses: grafana/shared-workflows/actions/trigger-argo-workflow@trigger-argo-workflow/v1.1.2
+        uses: grafana/shared-workflows/actions/trigger-argo-workflow@2b6ace8fb54a9a0e4c4a28760b10c4f9ab073537 # trigger-argo-workflow/v1.2.0
         with:
           namespace: grafana-plugins-cd
           workflow_template: grafana-plugins-deploy


### PR DESCRIPTION
Renovate seems to always pin to exact digest. This PR pins trigger-argo-workflows to the exact commit as well