### PR TITLE
feat: add step to cache playwright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -450,7 +450,7 @@ jobs:
 
   playwright:
     name: Playwright E2E tests
-    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@cache-playwright # zizmor: ignore[unpinned-uses]
+    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@main # zizmor: ignore[unpinned-uses]
     if: ${{ inputs.run-playwright == true }}
     needs:
       - test-and-build
@@ -472,7 +472,7 @@ jobs:
 
   playwright-docker:
     name: Plugins - Dockerized Playwright E2E tests
-    uses: grafana/plugin-ci-workflows/.github/workflows/playwright-docker.yml@cache-playwright # zizmor: ignore[unpinned-uses]
+    uses: grafana/plugin-ci-workflows/.github/workflows/playwright-docker.yml@main # zizmor: ignore[unpinned-uses]
     if: ${{ inputs.run-playwright-docker == true }}
     needs:
       - test-and-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -444,7 +444,7 @@ jobs:
 
   playwright:
     name: Playwright E2E tests
-    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@main # zizmor: ignore[unpinned-uses]
+    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@cache-playwright # zizmor: ignore[unpinned-uses]
     if: ${{ inputs.run-playwright == true }}
     needs:
       - test-and-build
@@ -466,7 +466,7 @@ jobs:
 
   playwright-docker:
     name: Plugins - Dockerized Playwright E2E tests
-    uses: grafana/plugin-ci-workflows/.github/workflows/playwright-docker.yml@main # zizmor: ignore[unpinned-uses]
+    uses: grafana/plugin-ci-workflows/.github/workflows/playwright-docker.yml@cache-playwright # zizmor: ignore[unpinned-uses]
     if: ${{ inputs.run-playwright-docker == true }}
     needs:
       - test-and-build

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -142,7 +142,7 @@ jobs:
         working-directory: ${{ inputs.plugin-directory }}
 
       - name: Get Playwright version
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         id: version
         with:
           script: |

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -158,9 +158,10 @@ jobs:
             }
             console.debug("Version:", version);
             if (version) {
-              core.exportVariable("PLAYWRIGHT_VERSION", version);
               core.setOutput("version", version);
-            } else core.setFailed("Couldn't get Playwright version");
+            } else {
+              core.setFailed("Couldn't get Playwright version");
+            }
         env:
           PLUGIN_DIRECTORY: ${{ inputs.plugin-directory }}
 
@@ -169,7 +170,7 @@ jobs:
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ env.PLAYWRIGHT_VERSION }}
+          key: playwright-${{ steps.version.outputs.version }}
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -142,7 +142,7 @@ jobs:
         working-directory: ${{ inputs.plugin-directory }}
 
       - name: Get Playwright version
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         id: version
         with:
           script: |
@@ -166,7 +166,7 @@ jobs:
 
       - name: Cache Playwright
         id: cache
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ env.PLAYWRIGHT_VERSION }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -141,6 +141,34 @@ jobs:
         shell: bash
         working-directory: ${{ inputs.plugin-directory }}
 
+      - name: Get Playwright version
+        uses: actions/github-script@v7
+        id: version
+        with:
+          script: |
+            const workingDirectory = "${{ inputs.plugin-directory }}";
+            console.debug("Specified working directory:", workingDirectory);
+            if (workingDirectory) process.chdir(workingDirectory);
+            console.debug("Actual working directory:", process.cwd());
+            let version = "";
+            try {
+              version = require("@playwright/test/package.json").version;
+            } catch (error) {
+              console.log(error.message);
+            }
+            console.debug("Version:", version);
+            if (version) {
+              core.exportVariable("PLAYWRIGHT_VERSION", version);
+              core.setOutput("version", version);
+            } else core.setFailed("Couldn't get Playwright version");
+
+      - name: Cache Playwright
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ env.PLAYWRIGHT_VERSION }}
+
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -146,7 +146,7 @@ jobs:
         id: version
         with:
           script: |
-            const workingDirectory = "${{ inputs.plugin-directory }}";
+            const workingDirectory = process.env.PLUGIN_DIRECTORY;
             console.debug("Specified working directory:", workingDirectory);
             if (workingDirectory) process.chdir(workingDirectory);
             console.debug("Actual working directory:", process.cwd());
@@ -161,6 +161,8 @@ jobs:
               core.exportVariable("PLAYWRIGHT_VERSION", version);
               core.setOutput("version", version);
             } else core.setFailed("Couldn't get Playwright version");
+        env:
+          PLUGIN_DIRECTORY: ${{ inputs.plugin-directory }}
 
       - name: Cache Playwright
         id: cache

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -166,7 +166,7 @@ jobs:
 
       - name: Cache Playwright
         id: cache
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ env.PLAYWRIGHT_VERSION }}


### PR DESCRIPTION
### What is the purpose of this PR
Add step to cache playwright and improve playwright setup times.

### Note for reviewers
The cache approach was chosen over the pre-backend image from microsoft because using a specific image brought some complexities to run the plugin environment using `docker compose`. We would have to run docker inside docker and make the plugin environment provided by docker compose be aware of the network where the `pre-backend image` was running, which is only known during the action runtime. This information would have to be added to the plugin `docker-compose.yml` before running `docker compose up`

**Run example**
https://github.com/grafana/grafana-pluginsplatformprovisioned-app/actions/runs/17218721506/job/48849154440

fixes https://github.com/grafana/plugin-ci-workflows/issues/182