### PR TITLE
feat: add support for backend secrets

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -249,6 +249,11 @@ on:
         type: string
         required: false
         default: ""
+      backend-secrets:
+        description: The secrets to use within backend steps
+        type: string
+        required: false
+        default: ""
       publish-to-catalog-as-pending:
         description: |
           If true, the plugin will be published as pending in the plugins catalog.
@@ -370,6 +375,7 @@ jobs:
       trufflehog-exclude-detectors: ${{ inputs.trufflehog-exclude-detectors }}
       plugin-version-suffix: ${{ needs.setup.outputs.plugin-version-suffix }}
       frontend-secrets: ${{ inputs.frontend-secrets }}
+      backend-secrets: ${{ inputs.backend-secrets }}
 
   build-attestation:
     name: Build attestation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,11 @@ on:
         type: string
         required: false
         default: ""
+      backend-secrets:
+        description: The secrets to use within frontend steps
+        type: string
+        required: false
+        default: ""
       npm-registry-auth:
         description: |
           Whether to authenticate to the npm registry in Google Artifact Registry.
@@ -347,6 +352,7 @@ jobs:
         with:
           github-token: ${{ steps.generate-github-token.outputs.token }}
           plugin-directory: ${{ inputs.plugin-directory }}
+          secrets: ${{ (fromJson(steps.workflow-context.outputs.result).isTrusted && inputs.backend-secrets != '') && inputs.backend-secrets || '' }}
 
       - name: Package universal ZIP
         id: universal-zip

--- a/actions/plugins/backend/action.yml
+++ b/actions/plugins/backend/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: Directory of the plugin, if not in the root of the repository. If provided, package-manager must also be provided.
     required: false
     default: .
+  secrets:
+    required: false
+    type: string
+    description: The secrets to use within frontend steps
 
 runs:
   using: composite
@@ -18,6 +22,13 @@ runs:
       env:
         INPUT_GITHUB_TOKEN: ${{ inputs.github-token }}
       shell: bash
+
+    - name: Get secrets from Vault
+      if: inputs.secrets != ''
+      id: get-secrets
+      uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
+      with:
+        repo_secrets: ${{ inputs.secrets }}
 
     - name: Install dependencies
       run: go mod download


### PR DESCRIPTION
this works the same as with `frontend-secrets`, just for the backend build step