### PR TITLE
fix(change-plugin-scope): use the right input name

### DIFF
--- a/actions/plugins/publish/change-plugin-scope/action.yml
+++ b/actions/plugins/publish/change-plugin-scope/action.yml
@@ -44,7 +44,7 @@ runs:
           "${PLUGIN_VERSION}"
       env:
         GCLOUD_AUTH_TOKEN: ${{ inputs.gcloud-auth-token }}
-        GCOM_TOKEN: ${{ inputs.gcom-publish-token }}
+        GCOM_TOKEN: ${{ inputs.gcom-token }}
 
         ENVIRONMENT: ${{ inputs.environment }}
         SCOPES: ${{ inputs.scopes }}


### PR DESCRIPTION
The action is using the wrong input name to pass the `GCOM_TOKEN` environment variable to the bash script. This PR fixes it.