### PR TITLE
fix(change-plugin-scope): fix check_response_error

### DIFF
--- a/actions/plugins/publish/change-plugin-scope/change-plugin-scope.sh
+++ b/actions/plugins/publish/change-plugin-scope/change-plugin-scope.sh
@@ -128,6 +128,8 @@ check_response_error() {
     local response="$1"
     local expected_scopes="$2"
 
+    expected_scopes=$(echo "$expected_scopes" | jq -r 'join(",")')
+
     local response_scopes_count
     response_scopes_count=$(echo "$response" | jq -r '(.scopes // []) | length')
     if [[ "$response_scopes_count" == "0" ]]; then

--- a/examples/extra/change-plugin-scope.yml
+++ b/examples/extra/change-plugin-scope.yml
@@ -40,7 +40,8 @@ env:
   PLUGIN_ID: hugooshiro-dummy-datasource  # TODO: change with your plugin's slug
 
 jobs:
-  promote:
+  change-plugin-scope:
+    name: Change plugin scope
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
check_response_error is failing when checking if the new scopes are present in the plugin after the change request. This PR fixes that
This PR also fixes the data in the workflow example