### PR TITLE
ci!: Add support for tagged releases

### DIFF
--- a/.github/workflows/release-please-pr-update-tagged-references.yml
+++ b/.github/workflows/release-please-pr-update-tagged-references.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Switch references
         id: switch-references
-        uses: grafana/plugin-ci-workflows-test/actions/internal/switch-references@main # zizmor: ignore[unpinned-uses]
+        uses: grafana/plugin-ci-workflows/actions/internal/switch-references@main # zizmor: ignore[unpinned-uses]
         with:
           repository: grafana/plugin-ci-workflows
           ref: ${{ steps.component-name.outputs.component }}/v${{ steps.get-version.outputs.version }}
@@ -136,7 +136,7 @@ jobs:
       - name: Get bot user info
         id: get-bot-user
         if: steps.switch-references.outputs.changed == 'true'
-        uses: grafana/plugin-ci-workflows-test/actions/internal/get-bot-user@main # zizmor: ignore[unpinned-uses]
+        uses: grafana/plugin-ci-workflows/actions/internal/get-bot-user@main # zizmor: ignore[unpinned-uses]
         with:
           app-slug: ${{ steps.generate-github-token.outputs.app-slug }}
           token: ${{ steps.generate-github-token.outputs.token }}

--- a/.github/workflows/release-please-pr-update-tagged-references.yml
+++ b/.github/workflows/release-please-pr-update-tagged-references.yml
@@ -49,7 +49,7 @@ jobs:
     name: Update tagged references
     needs: automated-commit-check
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
       id-token: write
     # Only run if the PR is from the same repo (not a fork), is a release-please PR,
@@ -77,7 +77,7 @@ jobs:
         with:
           app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
           private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
-          permission-contents: read
+          permission-contents: write
           permission-pull-requests: write
 
       - name: Checkout PR branch

--- a/.github/workflows/release-please-pr-update-tagged-references.yml
+++ b/.github/workflows/release-please-pr-update-tagged-references.yml
@@ -49,7 +49,7 @@ jobs:
     name: Update tagged references
     needs: automated-commit-check
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
       id-token: write
     # Only run if the PR is from the same repo (not a fork), is a release-please PR,
@@ -77,6 +77,7 @@ jobs:
         with:
           app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
           private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
+          permission-contents: read
           permission-pull-requests: write
 
       - name: Checkout PR branch

--- a/.github/workflows/release-please-pr-update-tagged-references.yml
+++ b/.github/workflows/release-please-pr-update-tagged-references.yml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Switch references
         id: switch-references
-        uses: grafana/plugin-ci-workflows/actions/internal/switch-references@main # zizmor: ignore[unpinned-uses]
+        uses: grafana/plugin-ci-workflows-test/actions/internal/switch-references@main # zizmor: ignore[unpinned-uses]
         with:
           repository: grafana/plugin-ci-workflows
           ref: ${{ steps.component-name.outputs.component }}/v${{ steps.get-version.outputs.version }}
@@ -132,7 +132,7 @@ jobs:
       - name: Get bot user info
         id: get-bot-user
         if: steps.switch-references.outputs.changed == 'true'
-        uses: grafana/plugin-ci-workflows/actions/internal/get-bot-user@main # zizmor: ignore[unpinned-uses]
+        uses: grafana/plugin-ci-workflows-test/actions/internal/get-bot-user@main # zizmor: ignore[unpinned-uses]
         with:
           app-slug: ${{ steps.generate-github-token.outputs.app-slug }}
           token: ${{ steps.generate-github-token.outputs.token }}

--- a/.github/workflows/release-please-pr-update-tagged-references.yml
+++ b/.github/workflows/release-please-pr-update-tagged-references.yml
@@ -15,6 +15,11 @@ on:
 permissions:
   contents: read
 
+# Only one instance of this workflow should run at a time for each PR.
+concurrency:
+  group: ${{ github.workflow_ref }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   # Checks if the PR's latest commit was made by this workflow to prevent recursion.
   automated-commit-check:

--- a/.github/workflows/release-please-pr-update-tagged-references.yml
+++ b/.github/workflows/release-please-pr-update-tagged-references.yml
@@ -79,6 +79,9 @@ jobs:
           private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
+          # Required or the following error is returned when trying to push:
+          # "refusing to allow a GitHub App to create or update workflow XYZ without `workflows` permission"
+          permission-workflows: write
 
       - name: Checkout PR branch
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0

--- a/.github/workflows/release-please-pr-update-tagged-references.yml
+++ b/.github/workflows/release-please-pr-update-tagged-references.yml
@@ -1,0 +1,142 @@
+# Creates an automated commit whenever a release-please PR is created or updated.
+# The commit updates the references for all actions used in all workflows, actions
+# and examples in the repository to point to the new version tag, which will be
+# created when the PR is merged.
+name: "release-please PR: Update tagged references"
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    paths: .release-please-manifest.json
+
+permissions:
+  contents: read
+
+jobs:
+  # Checks if the PR's latest commit was made by this workflow to prevent recursion.
+  automated-commit-check:
+    name: Automated commit check
+    runs-on: ubuntu-arm64-small
+    outputs:
+      automated-commit: ${{ steps.check.outputs.automated-commit }}
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          ref: ${{ github.head_ref }}
+          persist-credentials: false
+      - name: Automated commit check
+        id: check
+        run: |
+          if git log -1 --pretty=%B | grep -q "update tagged references"; then
+            echo "Automated commit"
+            echo "automated-commit=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Not an automated commit"
+            echo "automated-commit=false" >> "$GITHUB_OUTPUT"
+          fi
+        shell: bash
+
+  update-tagged-references:
+    name: Update tagged references
+    needs: automated-commit-check
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    # Only run if the PR is from the same repo (not a fork), is a release-please PR,
+    # and the last commit was not made by this workflow (to prevent recursion).
+    if: >-
+      ${{
+        github.event.pull_request.head.repo.full_name == github.repository
+        && startsWith(github.head_ref, 'release-please--')
+        && needs.automated-commit-check.outputs.automated-commit == 'false'
+      }}
+    runs-on: ubuntu-arm64-small
+    steps:
+      - name: Get secrets from Vault
+        id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
+        with:
+          common_secrets: |
+            GITHUB_APP_ID=plugins-platform-bot-app:app-id
+            GITHUB_APP_PRIVATE_KEY=plugins-platform-bot-app:private-key
+          export_env: false
+
+      - name: Generate GitHub token
+        id: generate-github-token
+        uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2.1.1
+        with:
+          app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
+          private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Checkout PR branch
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ steps.generate-github-token.outputs.token }}
+          # This is needed or GitHub will return a
+          # "remote rejected - cannot lock ref" error when trying to push
+          fetch-depth: 0
+          # Needed for the git-auto-commit-action to push changes
+          persist-credentials: true
+
+      - name: Determine component name
+        id: component-name
+        run: |
+          # Extract component name from branch name pattern: release-please--branches--main--components--<component-name>
+          component_name="${BRANCH_NAME##*--components--}"
+          echo "component=$component_name" >> "$GITHUB_OUTPUT"
+        shell: bash
+        env:
+          BRANCH_NAME: ${{ github.head_ref }}
+
+      - name: Get new version
+        id: get-version
+        run: |
+          # Extract path from component name (`package-name` key)
+          key=$(jq -r --arg component "$COMPONENT_NAME" '.packages | to_entries[] | select(.value["package-name"] == $component) | .key' release-please-config.json)
+          if [ -z "$key" ]; then
+            echo "Error: No package found with package-name '$COMPONENT_NAME'" >&2
+            exit 1
+          fi
+          version=$(jq -r --arg key "$key" '.[$key]' .release-please-manifest.json)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+        shell: bash
+        env:
+          COMPONENT_NAME: ${{ steps.component-name.outputs.component }}
+
+      - name: Switch references
+        id: switch-references
+        uses: grafana/plugin-ci-workflows/actions/internal/switch-references@main # zizmor: ignore[unpinned-uses]
+        with:
+          repository: grafana/plugin-ci-workflows
+          ref: ${{ steps.component-name.outputs.component }}/v${{ steps.get-version.outputs.version }}
+          paths: |
+            .github/workflows/ci.yml
+            .github/workflows/cd.yml
+            .github/workflows/playwright.yml
+            .github/workflows/playwright-docker.yml
+            actions/plugins/**
+            examples/**
+
+      - name: Get bot user info
+        id: get-bot-user
+        if: steps.switch-references.outputs.changed == 'true'
+        uses: grafana/plugin-ci-workflows/actions/internal/get-bot-user@main # zizmor: ignore[unpinned-uses]
+        with:
+          app-slug: ${{ steps.generate-github-token.outputs.app-slug }}
+          token: ${{ steps.generate-github-token.outputs.token }}
+
+      # Commit and push all changes to the PR
+      - name: Update PR
+        if: steps.switch-references.outputs.changed == 'true'
+        uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6.0.1
+        with:
+          commit_message: "chore(main): update tagged references"
+          commit_user_name: ${{ steps.get-bot-user.outputs.name }}
+          commit_user_email: ${{ steps.get-bot-user.outputs.email }}

--- a/.github/workflows/release-please-pr-update-tagged-references.yml
+++ b/.github/workflows/release-please-pr-update-tagged-references.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
           private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
+          permission-pull-requests: write
 
       - name: Checkout PR branch
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0

--- a/.github/workflows/release-please-restore-rolling-release.yml
+++ b/.github/workflows/release-please-restore-rolling-release.yml
@@ -67,7 +67,7 @@ jobs:
       # (we want to encourage using tagged releases in docs)
       - name: Switch references
         id: switch-references
-        uses: grafana/plugin-ci-workflows-test/actions/internal/switch-references@main # zizmor: ignore[unpinned-uses]
+        uses: grafana/plugin-ci-workflows/actions/internal/switch-references@main # zizmor: ignore[unpinned-uses]
         with:
           repository: grafana/plugin-ci-workflows
           ref: main
@@ -81,7 +81,7 @@ jobs:
       - name: Get bot user info
         id: get-bot-user
         if: steps.switch-references.outputs.changed == 'true'
-        uses: grafana/plugin-ci-workflows-test/actions/internal/get-bot-user@main # zizmor: ignore[unpinned-uses]
+        uses: grafana/plugin-ci-workflows/actions/internal/get-bot-user@main # zizmor: ignore[unpinned-uses]
         with:
           app-slug: ${{ steps.generate-github-token.outputs.app-slug }}
           token: ${{ steps.generate-github-token.outputs.token }}

--- a/.github/workflows/release-please-restore-rolling-release.yml
+++ b/.github/workflows/release-please-restore-rolling-release.yml
@@ -1,0 +1,94 @@
+# Creates an automated PR to restore the rolling release channel by switching
+# all tagged references in workflows and configuration files to point to the
+# `main` branch instead of a specific version tag. This is complementary to the
+# `release-please PR: Update tagged references` workflow, which updates the
+# references to point to specific version tags when a new release is created.
+name: "release-please: Restore rolling release"
+
+on:
+  push:
+    tags:
+      # Trigger tags matching the most specific tags created by release-please.
+      # When publishing a new release, release-please creates multiple tags like these:
+      # - `component/v1.2.3`
+      # - `component/v1.2`
+      # - `component/v1`
+      # We trigger only for the most specific one, otherwise we trigger this workflow multiple times.
+      # (we only need one PR for each release, even if multiple tags are updated for the same release)
+      - "*/v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: read
+
+jobs:
+  update-tagged-references:
+    name: Update tagged references
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    runs-on: ubuntu-arm64-small
+    steps:
+      - name: Get secrets from Vault
+        id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
+        with:
+          common_secrets: |
+            GITHUB_APP_ID=plugins-platform-bot-app:app-id
+            GITHUB_APP_PRIVATE_KEY=plugins-platform-bot-app:private-key
+          export_env: false
+
+      - name: Generate GitHub token
+        id: generate-github-token
+        uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2.1.1
+        with:
+          app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
+          private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Checkout main branch
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          ref: main
+          token: ${{ steps.generate-github-token.outputs.token }}
+          # fetch-depth: 0
+          persist-credentials: false
+
+      # Update everything except for the "examples" folder
+      # (we want to encourage using tagged releases in docs)
+      - name: Switch references
+        id: switch-references
+        uses: grafana/plugin-ci-workflows/actions/internal/switch-references@main # zizmor: ignore[unpinned-uses]
+        with:
+          repository: grafana/plugin-ci-workflows
+          ref: main
+          paths: |
+            .github/workflows/ci.yml
+            .github/workflows/cd.yml
+            .github/workflows/playwright.yml
+            .github/workflows/playwright-docker.yml
+            actions/plugins/**
+
+      - name: Get bot user info
+        id: get-bot-user
+        if: steps.switch-references.outputs.changed == 'true'
+        uses: grafana/plugin-ci-workflows/actions/internal/get-bot-user@main # zizmor: ignore[unpinned-uses]
+        with:
+          app-slug: ${{ steps.generate-github-token.outputs.app-slug }}
+          token: ${{ steps.generate-github-token.outputs.token }}
+
+      - name: Create PR
+        if: steps.switch-references.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        with:
+          commit-message: "update references to use 'main' branch"
+          title: "update references to use 'main' branch"
+          branch: restore-rolling-release/${{ github.ref_name }}
+          base: main
+          body: |
+            This PR updates tagged references in workflow and configuration files to point to the `main` branch
+            in order to restore the rolling release channel.
+
+            _This is an automated PR created by the `${{ github.workflow }}` workflow._
+          committer: ${{ steps.get-bot-user.outputs.committer }}
+          token: ${{ steps.generate-github-token.outputs.token }}

--- a/.github/workflows/release-please-restore-rolling-release.yml
+++ b/.github/workflows/release-please-restore-rolling-release.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
           private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
+          permission-pull-requests: write
 
       - name: Checkout main branch
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0

--- a/.github/workflows/release-please-restore-rolling-release.yml
+++ b/.github/workflows/release-please-restore-rolling-release.yml
@@ -20,6 +20,11 @@ on:
 permissions:
   contents: read
 
+# Only one instance of this workflow should run at a time.
+concurrency:
+  group: ${{ github.workflow_ref }}
+  cancel-in-progress: true
+
 jobs:
   update-tagged-references:
     name: Update tagged references

--- a/.github/workflows/release-please-restore-rolling-release.yml
+++ b/.github/workflows/release-please-restore-rolling-release.yml
@@ -51,6 +51,9 @@ jobs:
           private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
+          # Required or the following error is returned when trying to push:
+          # "refusing to allow a GitHub App to create or update workflow XYZ without `workflows` permission"
+          permission-workflows: write
 
       - name: Checkout main branch
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0

--- a/.github/workflows/release-please-restore-rolling-release.yml
+++ b/.github/workflows/release-please-restore-rolling-release.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
           private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
+          permission-contents: write
           permission-pull-requests: write
 
       - name: Checkout main branch

--- a/.github/workflows/release-please-restore-rolling-release.yml
+++ b/.github/workflows/release-please-restore-rolling-release.yml
@@ -63,7 +63,7 @@ jobs:
       # (we want to encourage using tagged releases in docs)
       - name: Switch references
         id: switch-references
-        uses: grafana/plugin-ci-workflows/actions/internal/switch-references@main # zizmor: ignore[unpinned-uses]
+        uses: grafana/plugin-ci-workflows-test/actions/internal/switch-references@main # zizmor: ignore[unpinned-uses]
         with:
           repository: grafana/plugin-ci-workflows
           ref: main
@@ -77,7 +77,7 @@ jobs:
       - name: Get bot user info
         id: get-bot-user
         if: steps.switch-references.outputs.changed == 'true'
-        uses: grafana/plugin-ci-workflows/actions/internal/get-bot-user@main # zizmor: ignore[unpinned-uses]
+        uses: grafana/plugin-ci-workflows-test/actions/internal/get-bot-user@main # zizmor: ignore[unpinned-uses]
         with:
           app-slug: ${{ steps.generate-github-token.outputs.app-slug }}
           token: ${{ steps.generate-github-token.outputs.token }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,3 +1,4 @@
+# Creates releases and tags for the plugin-ci-workflows repository using release-please.
 name: Release plugin-ci-workflows
 
 on:

--- a/actions/internal/get-bot-user/action.yml
+++ b/actions/internal/get-bot-user/action.yml
@@ -1,0 +1,51 @@
+name: Get Bot user
+description: Get information about the GitHub App bot user (such as ID, email, name) for use in commits and PRs.
+
+inputs:
+  app-slug:
+    description: |
+      The GitHub App slug.
+      This is usually set from the output of the `create-github-app-token` action.
+    required: true
+    type: string
+  token:
+    description: |
+      A GitHub token with permissions to call the GitHub API.
+      This is usually set from the output of the `create-github-app-token` action.
+    required: true
+    type: string
+
+outputs:
+  id:
+    description: The user ID of the GitHub App bot user.
+    value: ${{ steps.get-bot-user.outputs.id }}
+  email:
+    description: The email of the GitHub App bot user.
+    value: ${{ steps.get-bot-user.outputs.email }}
+  name:
+    description: The name of the GitHub App bot user.
+    value: ${{ steps.get-bot-user.outputs.name }}
+  committer:
+    description: The committer string to use in git commits in format "name <email>".
+    value: ${{ steps.get-bot-user.outputs.committer }}
+
+runs:
+  using: composite
+  steps:
+    - name: Get bot user info
+      id: get-bot-user
+      run: |
+        user_id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)
+        name=${APP_SLUG}[bot]
+        email="${user_id}+${APP_SLUG}[bot]@users.noreply.github.com"
+        {
+          echo "id=${user_id}"
+          echo "email=${email}"
+          echo "name=${name}"
+          echo "committer=${name} <${email}>"
+        } >> "$GITHUB_OUTPUT"
+      shell: bash
+      env:
+        APP_SLUG: ${{ inputs.app-slug }}
+        # Needed for gh cli to work
+        GH_TOKEN: ${{ inputs.token }}

--- a/actions/internal/switch-references/action.yml
+++ b/actions/internal/switch-references/action.yml
@@ -1,0 +1,53 @@
+name: Switch GHA references
+description: |
+  Switches all GitHub Actions "uses" references for the specified repository to the specified ref
+  for all workflows and actions in the specified paths.
+
+inputs:
+  ref:
+    description: The new reference (tag or branch) used in the workflows
+    required: true
+  repository:
+    description: |
+      The repository containing the actions that have to be switched, e.g. `grafana/plugin-ci-workflows`
+    required: true
+  paths:
+    description: |
+      The paths to the files or folders to modify, one per line.
+      Folders have to be suffixed with `/**`.
+
+      Example for a file: `.github/workflows/ci.yml`
+      Example for a folder: `actions/plugins/**`
+    required: true
+
+outputs:
+  changed:
+    description: Whether any files were changed
+    value: ${{ steps.determine-changes.outputs.changed }}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+runs:
+  using: composite
+  steps:
+    - name: Switch references
+      run: ${{ github.action_path }}/switch-references.sh "${REPO}" "${REF}" ${PATHS}
+      env:
+        REF: ${{ inputs.ref }}
+        REPO: ${{ inputs.repository }}
+        PATHS: ${{ inputs.paths }}
+      shell: bash
+
+    - name: Determine if anything changed
+      id: determine-changes
+      run: |
+        if git diff --quiet; then
+          echo "No changes detected"
+          echo "changed=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "Changes detected"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+        fi
+      shell: bash

--- a/actions/internal/switch-references/switch-references.sh
+++ b/actions/internal/switch-references/switch-references.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echov() {
+    if [ "$VERBOSE" == true ]; then
+        echo "$@"
+    fi
+}
+
+show_help() {
+    echo "Usage: $0 [-v|--verbose] <repository_name> <replacement_string> <paths...>"
+    echo ""
+    echo "Replaces all 'uses' references for the specified repository"
+    echo "from @<current_version> to @<replacement_string> into each of the"
+    echo "specified paths."
+    echo ""
+    echo "If a path is a directory, all .yml/.yaml files will be processed"
+    echo "recursively. If a path is a file, only that file will be processed."
+    echo ""
+    echo "Arguments"
+    echo "  -v: verbose"
+    echo ""
+    echo "Examples:"
+    echo "  $0 grafana/plugin-ci-workflows main .github/workflows          # Process directory recursively"
+    echo "  $0 grafana/plugin-ci-workflows v2.0.0 .github/workflows/ci.yml # Process single file"
+    echo "  $0 grafana/plugin-ci-workflows main examples actions/plugins   # Process multiple directories"
+}
+
+
+# Function to process a single file
+process_file() {
+    local file="$1"
+    
+    echov "Processing: $file"
+
+    # Check if file contains the pattern before modifying
+    if grep -q "uses: $REPO_NAME.*@" "$file"; then
+        # Use sed to replace the pattern in-place while preserving comments
+        # Pattern explanation:
+        # - \(uses: $REPO_NAME[^@]*\) - Capture everything up to @
+        # - @[^ ]* - Match @ and everything up to the first space (or end of line)
+        # - \(.*\) - Capture everything after the version (including comments)
+        # Replace with: captured prefix + @REPLACEMENT + captured suffix
+        sed -i "s|\(uses: $REPO_NAME[^@]*\)@[^ ]*\(.*\)|\1@$REPLACEMENT\2|g" "$file"
+        echo "  ✓ Updated $file"
+    else
+        echo "  - No matching pattern found in $file"
+    fi
+}
+
+# Function to process YAML files
+process() {
+    local path="$1"
+
+    # Check if path is a directory (treat as recursive search)
+    if [[ -d "$path" ]]; then
+        echov "Processing directory: $path"
+        
+        # Find all .yml and .yaml files in the directory and subdirectories
+        find "$path" -type f \( -name "*.yml" -o -name "*.yaml" \) -print0 | while IFS= read -r -d '' file; do
+            process_file "$file"
+        done
+    elif [[ -f "$path" ]]; then
+        # Check if it's a YAML file
+        if [[ "$path" == *.yml || "$path" == *.yaml ]]; then
+            process_file "$path"
+        else
+            echov "File $path is not a YAML file, skipping..."
+        fi
+    else
+        echo "Path $path does not exist, skipping..."
+    fi
+}
+
+# Arguments parsing
+VERBOSE=false
+paths=()
+for arg in "$@"; do
+    case $arg in
+        -h|--help) show_help; exit 0 ;;
+        -v|--verbose) VERBOSE=true; shift ;;
+        *)
+            if [ -z "${REPO_NAME:-}" ]; then
+                REPO_NAME="$arg"
+            elif [ -z "${REPLACEMENT:-}" ]; then
+                REPLACEMENT="$arg"
+            else
+                paths+=("$arg")
+            fi
+            shift ;;
+    esac
+done
+
+if [ -z "${REPO_NAME:-}" ] || [ -z "${REPLACEMENT:-}" ] || [ ${#paths[@]} -eq 0 ]; then
+    # Not enough arguments
+    echo "Error: Missing required arguments."
+    show_help
+    exit 1
+fi
+
+# Main script
+echo "Starting YAML file processing..."
+echo "Searching for repository: $REPO_NAME"
+echo "Replacing its references with: @$REPLACEMENT"
+echo "================================"
+
+# Process each path provided as argument
+for path in "${paths[@]}"; do
+    process "$path"
+done
+
+echo "================================"
+echo "Processing complete!"

--- a/actions/internal/switch-references/switch-references.sh
+++ b/actions/internal/switch-references/switch-references.sh
@@ -79,7 +79,7 @@ paths=()
 for arg in "$@"; do
     case $arg in
         -h|--help) show_help; exit 0 ;;
-        -v|--verbose) VERBOSE=true; shift ;;
+        -v|--verbose) VERBOSE=true;;
         *)
             if [ -z "${REPO_NAME:-}" ]; then
                 REPO_NAME="$arg"
@@ -88,7 +88,6 @@ for arg in "$@"; do
             else
                 paths+=("$arg")
             fi
-            shift ;;
     esac
 done
 

--- a/actions/internal/switch-references/switch-references.sh
+++ b/actions/internal/switch-references/switch-references.sh
@@ -100,6 +100,13 @@ if [ -z "${REPO_NAME:-}" ] || [ -z "${REPLACEMENT:-}" ] || [ ${#paths[@]} -eq 0 
 fi
 
 # Main script
+if [[ ! "$REPO_NAME" =~ ^[a-zA-Z0-9._/-]+$ ]]; then
+    echo "Error: Invalid repository name" >&2
+    exit 1
+fi
+# Escape special characters in REPO_NAME for use in sed
+REPO_NAME=$(printf '%s\n' "$REPO_NAME" | sed 's/[[\.*^$()+?{|]/\\&/g')
+
 echo "Starting YAML file processing..."
 echo "Searching for repository: $REPO_NAME"
 echo "Replacing its references with: @$REPLACEMENT"


### PR DESCRIPTION
Rework of #270. Part of #158. Part of https://github.com/grafana/grafana-community-team/issues/426.

Adds some GHA workflows for making hermetic tags.

**Some documentation on why this is needed and how is works is in this docs PR for EngHub: https://github.com/grafana/grafana-community-team/pull/557**

Example release-please PR with automated commit created by the workflow introduced in this PR: https://github.com/grafana/plugin-ci-workflows-test/pull/57 (this commit: https://github.com/grafana/plugin-ci-workflows-test/pull/57/commits/0ff33e760f3ac1de8f635b8506c4ced7ea088773)

Example PR that restores to the rolling-release channel after merging the PR: https://github.com/grafana/plugin-ci-workflows-test/pull/59