### PR TITLE
chore(deps)!: revert actions/setup-node action to v4.4.0

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -111,7 +111,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ inputs.node-version }}
           node-version-file: ${{ inputs.plugin-directory }}/.nvmrc

--- a/actions/plugins/setup/action.yml
+++ b/actions/plugins/setup/action.yml
@@ -24,7 +24,7 @@ runs:
   using: composite
   steps:
     - name: Node
-      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: "${{ inputs.node-version }}"
         node-version-file: "${{ inputs.node-version-file }}"


### PR DESCRIPTION
Reverts 286770aade561f57089dd8d098fc37159719d730. (#273) for now due to breaking changes

See https://raintank-corp.slack.com/archives/C01C4K8DETW/p1757350792483449