### PR TITLE
chore: updating renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,8 +1,0 @@
-{
-  $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  extends: [
-    "config:best-practices",
-    ":doNotPinPackage(grafana/docs-base)",
-    ":doNotPinPackage(grafana/shared-workflows)",
-  ],
-}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,14 @@
+{
+    "ignorePresets": [
+        "github>grafana/grafana-renovate-config//presets/base",
+        "github>grafana/grafana-renovate-config//presets/automerge",
+        "github>grafana/grafana-renovate-config//presets/labels",
+        "github>grafana/grafana-renovate-config//presets/docker"
+    ],    
+    "extends": [
+        "config:best-practices",
+        ":doNotPinPackage(grafana/docs-base)"
+    ],
+    "minimumReleaseAge": "14 days",
+    "prConcurrentLimit": 10    
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "ignorePresets": [
         "github>grafana/grafana-renovate-config//presets/base",
         "github>grafana/grafana-renovate-config//presets/automerge",


### PR DESCRIPTION
- `.github/renovate.json5` is not supported in self hosted renovate runner so it is currently just being ignored
- Adding minimumReleaseAge