### PR TITLE
ci: use conventional commits title for PR that restores rolling release

### DIFF
--- a/.github/workflows/release-please-restore-rolling-release.yml
+++ b/.github/workflows/release-please-restore-rolling-release.yml
@@ -90,8 +90,8 @@ jobs:
         if: steps.switch-references.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
-          commit-message: "update references to use 'main' branch"
-          title: "update references to use 'main' branch"
+          commit-message: "chore: update references to use 'main' branch"
+          title: "chore: update references to use 'main' branch"
           branch: restore-rolling-release/${{ github.ref_name }}
           base: main
           body: |
@@ -99,5 +99,11 @@ jobs:
             in order to restore the rolling release channel.
 
             _This is an automated PR created by the `${{ github.workflow }}` workflow._
+
+            <!--
+            BEGIN_COMMIT_OVERRIDE
+            no changelog
+            END_COMMIT_OVERRIDE
+            -->
           committer: ${{ steps.get-bot-user.outputs.committer }}
           token: ${{ steps.generate-github-token.outputs.token }}


### PR DESCRIPTION
The conventional commits check will fail for the PR that restores the rolling release tags because it doesn't follow the convention.

This PR fixes the title, and also adds a section to the body that removes the PR from the changelog of the next release-please version.