### PR TITLE
fix(worflows/ci): make .nvmrc be used over the default node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,9 +279,13 @@ jobs:
       - name: Setup
         uses: grafana/plugin-ci-workflows/actions/plugins/setup@main
         with:
-          go-version: ${{ inputs.go-version || env.DEFAULT_GO_VERSION }}
+          # The priority to setup the node version is:
+          # 1. inputs.node-version
+          # 2. inputs.plugin-directory/.nvmrc
+          # 3. workflow-level DEFAULT_NODE_VERSION
           node-version: ${{ inputs.node-version || (hashFiles(format('{0}/.nvmrc', inputs.plugin-directory)) == '' && env.DEFAULT_NODE_VERSION || '') }}
           node-version-file: ${{ inputs.plugin-directory }}/.nvmrc
+          go-version: ${{ inputs.go-version || env.DEFAULT_GO_VERSION }}
           golangci-lint-version: ${{ inputs.golangci-lint-version || env.DEFAULT_GOLANGCI_LINT_VERSION }}
           go-setup-caching: ${{ inputs.go-setup-caching }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,12 +285,6 @@ jobs:
           golangci-lint-version: ${{ inputs.golangci-lint-version || env.DEFAULT_GOLANGCI_LINT_VERSION }}
           go-setup-caching: ${{ inputs.go-setup-caching }}
 
-      - name: Check Node version
-        run: |
-          node --version
-        shell: bash
-        working-directory: ${{ inputs.plugin-directory }}
-
       - name: Get secrets from Vault
         id: get-secrets
         if: ${{ fromJson(steps.workflow-context.outputs.result).isTrusted }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,6 +285,12 @@ jobs:
           golangci-lint-version: ${{ inputs.golangci-lint-version || env.DEFAULT_GOLANGCI_LINT_VERSION }}
           go-setup-caching: ${{ inputs.go-setup-caching }}
 
+      - name: Check Node version
+        run: |
+          node --version
+        shell: bash
+        working-directory: ${{ inputs.plugin-directory }}
+
       - name: Get secrets from Vault
         id: get-secrets
         if: ${{ fromJson(steps.workflow-context.outputs.result).isTrusted }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,7 +280,7 @@ jobs:
         uses: grafana/plugin-ci-workflows/actions/plugins/setup@main
         with:
           go-version: ${{ inputs.go-version || env.DEFAULT_GO_VERSION }}
-          node-version: ${{ inputs.node-version || env.DEFAULT_NODE_VERSION }}
+          node-version: ${{ inputs.node-version || (hashFiles(format('{0}/.nvmrc', inputs.plugin-directory)) == '' && env.DEFAULT_NODE_VERSION || '') }}
           node-version-file: ${{ inputs.plugin-directory }}/.nvmrc
           golangci-lint-version: ${{ inputs.golangci-lint-version || env.DEFAULT_GOLANGCI_LINT_VERSION }}
           go-setup-caching: ${{ inputs.go-setup-caching }}


### PR DESCRIPTION
This PR fixes the usage of `grafana/plugin-ci-workflows/actions/plugins/setup`.
It only uses the default node version when both the `node-version` and the `.nvmrc` file are not provided. The order of priority is as fallows:
1. `node-version`
2. `.nvmrc`
3. `default node version`

All scenarios were tested:

node-version
https://github.com/grafana/grafana-pluginsplatformprovisioned-app/actions/runs/17742474942/job/50419969833

nvmrc file
https://github.com/grafana/grafana-pluginsplatformprovisioned-app/actions/runs/17741573563/job/50416610722

default node
https://github.com/grafana/grafana-pluginsplatformprovisioned-app/actions/runs/17743518205/job/50423130788

Fixes https://github.com/grafana/plugin-ci-workflows/issues/279