### PR TITLE
feat(workflows): fail ci for failed signs on ops and prod

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -367,7 +367,7 @@ jobs:
 
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@fail-ci-for-failed-signs-on-ops-and-prod
     needs:
       - setup
     with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -87,9 +87,9 @@ on:
         type: boolean
         required: false
         default: false
-      force-allow-unsigned:
+      allow-unsigned:
         description: |
-          Force allow unsigned plugins to be packaged.
+          Allow to publish unsigned plugins.
         type: boolean
         required: false
         default: false
@@ -398,7 +398,7 @@ jobs:
       frontend-secrets: ${{ inputs.frontend-secrets }}
       backend-secrets: ${{ inputs.backend-secrets }}
       environment: ${{ inputs.environment }}
-      force-allow-unsigned: ${{ inputs.force-allow-unsigned }}
+      allow-unsigned: ${{ inputs.allow-unsigned }}
 
   build-attestation:
     name: Build attestation

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -367,7 +367,7 @@ jobs:
 
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@fail-ci-for-failed-signs-on-ops-and-prod
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main
     needs:
       - setup
     with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -87,6 +87,12 @@ on:
         type: boolean
         required: false
         default: false
+      force-allow-unsigned:
+        description: |
+          Force allow unsigned plugins to be packaged.
+        type: boolean
+        required: false
+        default: false
 
       # Playwright
       run-playwright:
@@ -391,6 +397,8 @@ jobs:
       plugin-version-suffix: ${{ needs.setup.outputs.plugin-version-suffix }}
       frontend-secrets: ${{ inputs.frontend-secrets }}
       backend-secrets: ${{ inputs.backend-secrets }}
+      environment: ${{ inputs.environment }}
+      force-allow-unsigned: ${{ inputs.force-allow-unsigned }}
 
   build-attestation:
     name: Build attestation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,7 +378,7 @@ jobs:
           dist-folder: dist
           output-folder: dist-artifacts
           access-policy-token: ${{ fromJson(steps.workflow-context.outputs.result).isTrusted && fromJSON(steps.get-secrets.outputs.secrets).SIGN_PLUGIN_ACCESS_POLICY_TOKEN || '' }}
-          allow-unsigned: ${{ (inputs.environment == 'dev' && !(fromJson(steps.workflow-context.outputs.result).isTrusted)) || inputs.force-allow-unsigned }}
+          allow-unsigned: ${{ ((inputs.environment == 'dev' || inputs.environment == '') && !(fromJson(steps.workflow-context.outputs.result).isTrusted)) || inputs.force-allow-unsigned }}
 
       - name: Package os/arch ZIPs
         id: os-arch-zips
@@ -388,7 +388,7 @@ jobs:
           dist-folder: dist
           output-folder: dist-artifacts
           access-policy-token: ${{ fromJson(steps.workflow-context.outputs.result).isTrusted && fromJSON(steps.get-secrets.outputs.secrets).SIGN_PLUGIN_ACCESS_POLICY_TOKEN || '' }}
-          allow-unsigned: ${{ (inputs.environment == 'dev' && !(fromJson(steps.workflow-context.outputs.result).isTrusted)) || inputs.force-allow-unsigned }}
+          allow-unsigned: ${{ ((inputs.environment == 'dev' || inputs.environment == '') && !(fromJson(steps.workflow-context.outputs.result).isTrusted)) || inputs.force-allow-unsigned }}
 
       - name: Trufflehog secrets scanning
         if: ${{ inputs.run-trufflehog == true }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,18 @@ on:
         type: string
         required: false
         default: ${{ github.ref || github.ref_name }}
+      environment:
+        description: |
+          Environment(s) to publish to, in case the CI workflow is part of a CD workflow.
+          If present this will be used to control some aspects of the CI workflow.
+        type: string
+        required: false
+      force-allow-unsigned:
+        description: |
+          Force allow unsigned plugins to be built.
+        type: boolean
+        required: false
+        default: false
 
     outputs:
       plugin:
@@ -366,7 +378,7 @@ jobs:
           dist-folder: dist
           output-folder: dist-artifacts
           access-policy-token: ${{ fromJson(steps.workflow-context.outputs.result).isTrusted && fromJSON(steps.get-secrets.outputs.secrets).SIGN_PLUGIN_ACCESS_POLICY_TOKEN || '' }}
-          allow-unsigned: ${{ !(fromJson(steps.workflow-context.outputs.result).isTrusted) }}
+          allow-unsigned: ${{ (inputs.environment == 'dev' && !(fromJson(steps.workflow-context.outputs.result).isTrusted)) || inputs.force-allow-unsigned }}
 
       - name: Package os/arch ZIPs
         id: os-arch-zips
@@ -376,7 +388,7 @@ jobs:
           dist-folder: dist
           output-folder: dist-artifacts
           access-policy-token: ${{ fromJson(steps.workflow-context.outputs.result).isTrusted && fromJSON(steps.get-secrets.outputs.secrets).SIGN_PLUGIN_ACCESS_POLICY_TOKEN || '' }}
-          allow-unsigned: ${{ !(fromJson(steps.workflow-context.outputs.result).isTrusted) }}
+          allow-unsigned: ${{ (inputs.environment == 'dev' && !(fromJson(steps.workflow-context.outputs.result).isTrusted)) || inputs.force-allow-unsigned }}
 
       - name: Trufflehog secrets scanning
         if: ${{ inputs.run-trufflehog == true }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,7 +372,7 @@ jobs:
 
       - name: Package universal ZIP
         id: universal-zip
-        uses: grafana/plugin-ci-workflows/actions/plugins/package@fail-ci-for-failed-signs-on-ops-and-prod
+        uses: grafana/plugin-ci-workflows/actions/plugins/package@main
         with:
           universal: "true"
           dist-folder: dist
@@ -382,7 +382,7 @@ jobs:
 
       - name: Package os/arch ZIPs
         id: os-arch-zips
-        uses: grafana/plugin-ci-workflows/actions/plugins/package@fail-ci-for-failed-signs-on-ops-and-prod
+        uses: grafana/plugin-ci-workflows/actions/plugins/package@main
         with:
           universal: "false"
           dist-folder: dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,9 +182,9 @@ on:
           If present this will be used to control some aspects of the CI workflow.
         type: string
         required: false
-      force-allow-unsigned:
+      allow-unsigned:
         description: |
-          Force allow unsigned plugins to be built.
+          Allow unsigned plugins to be built.
         type: boolean
         required: false
         default: false
@@ -378,7 +378,7 @@ jobs:
           dist-folder: dist
           output-folder: dist-artifacts
           access-policy-token: ${{ fromJson(steps.workflow-context.outputs.result).isTrusted && fromJSON(steps.get-secrets.outputs.secrets).SIGN_PLUGIN_ACCESS_POLICY_TOKEN || '' }}
-          allow-unsigned: ${{ ((inputs.environment == 'dev' || inputs.environment == '') && !(fromJson(steps.workflow-context.outputs.result).isTrusted)) || inputs.force-allow-unsigned }}
+          allow-unsigned: ${{ ((inputs.environment == 'dev' || inputs.environment == '') && !(fromJson(steps.workflow-context.outputs.result).isTrusted)) || inputs.allow-unsigned }}
 
       - name: Package os/arch ZIPs
         id: os-arch-zips
@@ -388,7 +388,7 @@ jobs:
           dist-folder: dist
           output-folder: dist-artifacts
           access-policy-token: ${{ fromJson(steps.workflow-context.outputs.result).isTrusted && fromJSON(steps.get-secrets.outputs.secrets).SIGN_PLUGIN_ACCESS_POLICY_TOKEN || '' }}
-          allow-unsigned: ${{ ((inputs.environment == 'dev' || inputs.environment == '') && !(fromJson(steps.workflow-context.outputs.result).isTrusted)) || inputs.force-allow-unsigned }}
+          allow-unsigned: ${{ ((inputs.environment == 'dev' || inputs.environment == '') && !(fromJson(steps.workflow-context.outputs.result).isTrusted)) || inputs.allow-unsigned }}
 
       - name: Trufflehog secrets scanning
         if: ${{ inputs.run-trufflehog == true }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,7 +372,7 @@ jobs:
 
       - name: Package universal ZIP
         id: universal-zip
-        uses: grafana/plugin-ci-workflows/actions/plugins/package@main
+        uses: grafana/plugin-ci-workflows/actions/plugins/package@fail-ci-for-failed-signs-on-ops-and-prod
         with:
           universal: "true"
           dist-folder: dist
@@ -382,7 +382,7 @@ jobs:
 
       - name: Package os/arch ZIPs
         id: os-arch-zips
-        uses: grafana/plugin-ci-workflows/actions/plugins/package@main
+        uses: grafana/plugin-ci-workflows/actions/plugins/package@fail-ci-for-failed-signs-on-ops-and-prod
         with:
           universal: "false"
           dist-folder: dist

--- a/actions/plugins/package/package.sh
+++ b/actions/plugins/package/package.sh
@@ -7,8 +7,7 @@ set -e
 package() {
     # Sign the plugin
     if [ ! -z $GRAFANA_ACCESS_POLICY_TOKEN ]; then
-        # npx -y @grafana/sign-plugin@latest --distDir $2
-        mockSignError
+        npx -y @grafana/sign-plugin@latest --distDir $2
     else
         echo "WARNING: Plugin won't be signed, GRAFANA_ACCESS_POLICY_TOKEN not set"
     fi
@@ -16,11 +15,6 @@ package() {
     zip -r $1 $2
     sha1sum $1 | cut -f1 -d' ' | tr -d '\n' > $1.sha1
     md5sum $1 | cut -f1 -d' ' | tr -d '\n' > $1.md5
-}
-
-mockSignError() {
-    echo "Mock sign error"
-    exit 1
 }
 
 universal=false

--- a/actions/plugins/package/package.sh
+++ b/actions/plugins/package/package.sh
@@ -7,7 +7,8 @@ set -e
 package() {
     # Sign the plugin
     if [ ! -z $GRAFANA_ACCESS_POLICY_TOKEN ]; then
-        npx -y @grafana/sign-plugin@latest --distDir $2
+        # npx -y @grafana/sign-plugin@latest --distDir $2
+        mockSignError
     else
         echo "WARNING: Plugin won't be signed, GRAFANA_ACCESS_POLICY_TOKEN not set"
     fi
@@ -15,6 +16,11 @@ package() {
     zip -r $1 $2
     sha1sum $1 | cut -f1 -d' ' | tr -d '\n' > $1.sha1
     md5sum $1 | cut -f1 -d' ' | tr -d '\n' > $1.md5
+}
+
+mockSignError() {
+    echo "Mock sign error"
+    exit 1
 }
 
 universal=false
@@ -64,7 +70,7 @@ fi
 if [ "$universal" = true ]; then
     universal_zip_fn=$plugin_id-$plugin_version.zip
     echo "Creating universal package: $universal_zip_fn"
-    
+
     tmp=$(mktemp -d)
     mkdir -p "$tmp/$plugin_id"
 
@@ -86,7 +92,7 @@ if [ "$ptype" == "app" ] && [ -d "datasource" ]; then
         backend_folder="datasource"
         exe="$backend_folder/$nested_exe"
     fi
-    cd .. 
+    cd ..
 fi
 
 if [ "$exe" == "null" ]; then
@@ -107,7 +113,7 @@ for file in $(find "$backend_folder" -type f -name "${exe_basename}_*"); do
     # Copy all files but the executables
     mkdir -p "$plugin_id"
     rsync -a --exclude "${exe_basename}*" "$dist/" "$plugin_id"
-    
+
     # Copy only the current executable
     cp "$dist/$file" "$plugin_id/$backend_folder"
     os_arch_zip_fn="$plugin_id-$plugin_version.$os_arch.zip"


### PR DESCRIPTION
## What does this PR do?
Add the following inputs to CD:
- `force-allow-unsigned`

Add the following inputs to CI:
- `environment` - it will be passed down from CD, and if present, if will not allow unsigned plugins to be packaged if the environment is not `dev`. If it's `dev` or if it's not used it will keep following the same logic as before which is controlled by `isTrusted`
- `force-allow-unsigned` - it will be passed down from CD, and it will force allow unsigned plugins to be package, regardless of the environment or the value of `isTrusted`

## Note for reviewers:
It also worth to mention the currently the CI already fails when there is an error in the plugin sign up command:
https://github.com/grafana/plugin-ci-workflows/blob/main/actions/plugins/package/package.sh#L10
if this step returns 1, the CI will fail.

But currently it's possible to skip this step for any environment as long as `isTrusted` is false:
https://github.com/grafana/plugin-ci-workflows/blob/main/.github/workflows/ci.yml#L273


closes https://github.com/grafana/plugin-ci-workflows/issues/298
