### PR TITLE
chore: pinning e2e-versions and wait-for-grafana

### DIFF
--- a/.github/workflows/playwright-docker.yml
+++ b/.github/workflows/playwright-docker.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Resolve Grafana E2E versions
         id: resolve-versions
-        uses: grafana/plugin-actions/e2e-version@main
+        uses: grafana/plugin-actions/e2e-version@e2e-version/v1.0.2
         with:
           skip-grafana-dev-image: ${{ inputs.skip-grafana-dev-image }}
           version-resolver-type: ${{ inputs.version-resolver-type }}
@@ -136,7 +136,7 @@ jobs:
           DOCKER_COMPOSE_FILE: ${{ inputs.grafana-compose-file }}
 
       - name: Wait for Grafana to start
-        uses: grafana/plugin-actions/wait-for-grafana@main
+        uses: grafana/plugin-actions/wait-for-grafana@wait-for-grafana/v1.0.2
         with:
           url: "${{ inputs.grafana-url }}"
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Resolve Grafana E2E versions
         id: resolve-versions
-        uses: grafana/plugin-actions/e2e-version@main
+        uses: grafana/plugin-actions/e2e-version@e2e-version/v1.0.2
         with:
           skip-grafana-dev-image: ${{ inputs.skip-grafana-dev-image }}
           version-resolver-type: ${{ inputs.version-resolver-type }}
@@ -222,7 +222,7 @@ jobs:
           DOCKER_COMPOSE_FILE: ${{ inputs.docker-compose-file }}
 
       - name: Wait for Grafana to start
-        uses: grafana/plugin-actions/wait-for-grafana@main
+        uses: grafana/plugin-actions/wait-for-grafana@wait-for-grafana/v1.0.2
         with:
           url: "${{ inputs.grafana-url }}"
 


### PR DESCRIPTION
Pinning the downstream actions to their latest available tags:
- e2e-versions
- wait-for-grafana