### PR TITLE
fix: bump e2e-versions to get plugin.json lookup fix 

### DIFF
--- a/.github/workflows/playwright-docker.yml
+++ b/.github/workflows/playwright-docker.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Resolve Grafana E2E versions
         id: resolve-versions
-        uses: grafana/plugin-actions/e2e-version@e2e-version/v1.1.1
+        uses: grafana/plugin-actions/e2e-version@e2e-version/v1.1.2
         with:
           skip-grafana-dev-image: ${{ inputs.skip-grafana-dev-image }}
           version-resolver-type: ${{ inputs.version-resolver-type }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -89,12 +89,11 @@ jobs:
 
       - name: Resolve Grafana E2E versions
         id: resolve-versions
-        uses: grafana/plugin-actions/e2e-version@e2e-version/v1.1.1
+        uses: grafana/plugin-actions/e2e-version@e2e-version/v1.1.2
         with:
           skip-grafana-dev-image: ${{ inputs.skip-grafana-dev-image }}
           version-resolver-type: ${{ inputs.version-resolver-type }}
           grafana-dependency: ${{ inputs.grafana-dependency }}
-          plugin-directory: ${{ inputs.plugin-directory }}
 
   playwright-tests:
     needs: resolve-versions


### PR DESCRIPTION
Bump e2e-versions. The new version reverts the introduction of plugin-directory support. See https://github.com/grafana/plugin-actions/pull/121