### PR TITLE
chore: keep the renovate PR branches up to date automatically

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,5 +22,6 @@
         }
     ],
     "minimumReleaseAge": "14 days",
-    "prConcurrentLimit": 10    
+    "prConcurrentLimit": 10,
+    "rebaseWhen": "behind-base-branch"
 }


### PR DESCRIPTION
Should update the branch automatically when it's behind main

Docz: https://docs.renovatebot.com/updating-rebasing/#rebasing-out-of-date-branches