### PR TITLE
chore(cd): make CD workflow fail if Argo step fails

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -628,10 +628,6 @@ jobs:
 
     if: ${{ inputs.grafana-cloud-deployment-type != '' }}
 
-    # Allow the job to fail because this is opt-in and experimental.
-    # TODO: remove once the workflow is stable.
-    continue-on-error: true
-
     steps:
       - name: Check deployment type
         # Right now we only support provisioned plugins.


### PR DESCRIPTION
`continue-on-error: true` was added to the Argo step to avoid blocking deployments while it was in development/testing. This PR removes it since it's been adopted and works correctly.