### PR TITLE
feat(cd): add "staging" as an alias for "ops" for plugins publishing and Argo workflow trigger

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -208,7 +208,7 @@ on:
           Allowed values:
           - `none` (or empty string): Skip deployment (run only CI)
           - `dev`: Deploy to dev catalog
-          - `ops`: Deploy to ops catalog
+          - `ops` or `staging`: Deploy to ops catalog
           - `prod-canary`: Deploy to subset of prod instances - free and on instant wave
           - `prod`: Deploy to dev AND ops AND prod-canary AND prod
           - A comma separated combination of the values above. E.g.: `dev,ops`
@@ -246,7 +246,7 @@ on:
       auto-merge-environments:
         description: |
           Comma separated list of environments to auto-merge when deploying to Grafana Cloud via Argo.
-          Supported values are 'dev' and 'ops'.
+          Supported values are 'dev' and 'ops' (or 'staging').
           'prod-canary' and 'prod' will never be auto-merged.
           Default is 'dev'.
         default: dev
@@ -482,10 +482,11 @@ jobs:
             }
 
             // Parse and filter environments
-            const allowedEnvironments = ['dev', 'ops', 'prod-canary', 'prod'];
+            const allowedEnvironments = ['dev', 'ops', 'staging', 'prod-canary', 'prod'];
             let environments = [];
             environments = ENVIRONMENT.split(',')
               .map(e => e.trim())
+              .map(e => e === 'staging' ? 'ops' : e) // normalize 'staging' to 'ops'
               .filter(e => allowedEnvironments.includes(e));
 
             // Special case: 'prod' means we deploy to all environments

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -482,11 +482,12 @@ jobs:
             }
 
             // Parse and filter environments
-            const allowedEnvironments = ['dev', 'ops', 'staging', 'prod-canary', 'prod'];
+            const allowedEnvironments = ['dev', 'ops', 'prod-canary', 'prod'];
+            const aliases = {staging: 'ops'};
             let environments = [];
             environments = ENVIRONMENT.split(',')
               .map(e => e.trim())
-              .map(e => e === 'staging' ? 'ops' : e) // normalize 'staging' to 'ops'
+              .map(e => aliases[e] || e) // resolve aliases
               .filter(e => allowedEnvironments.includes(e));
 
             // Special case: 'prod' means we deploy to all environments

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,7 @@ on:
         description: |
           Environment(s) to publish to, in case the CI workflow is part of a CD workflow.
           If present this will be used to control some aspects of the CI workflow.
+          Can be 'dev', 'ops' (or 'staging'), 'prod-canary' or 'prod'.
         type: string
         required: false
       allow-unsigned:

--- a/actions/plugins/publish/change-plugin-scope/action.yml
+++ b/actions/plugins/publish/change-plugin-scope/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: |
       Environment where the plugin is published and where the scope will be changed.
       Trying to change the scope in an environment where the plugin is not published will result in an error.
-      Can be 'dev', 'ops', or 'prod'.
+      Can be 'dev', 'ops' (or `staging`), or 'prod'.
     required: true
   scopes:
     description: |

--- a/actions/plugins/publish/change-plugin-scope/change-plugin-scope.sh
+++ b/actions/plugins/publish/change-plugin-scope/change-plugin-scope.sh
@@ -5,7 +5,7 @@ if [[ "$RUNNER_DEBUG" == "1" ]]; then
 fi
 
 usage() {
-    echo "Usage: $0 --environment <dev|ops|prod> --scopes <universal|grafana_cloud|a,b,c|...> [--dry-run] <plugin-id> <plugin-version>"
+    echo "Usage: $0 --environment <dev|ops|staging|prod> --scopes <universal|grafana_cloud|a,b,c|...> [--dry-run] <plugin-id> <plugin-version>"
 }
 
 json_obj() {
@@ -69,7 +69,7 @@ case $gcom_env in
         gcom_api_url=https://grafana-dev.com/api
         has_iap=true
         ;;
-    ops)
+    ops|staging)
         gcom_api_url=https://grafana-ops.com/api
         has_iap=true
         ;;
@@ -77,7 +77,7 @@ case $gcom_env in
         gcom_api_url=https://grafana.com/api
         ;;
     *)
-        echo "Invalid environment: $gcom_env (supported values: 'dev', 'ops', 'prod')"
+        echo "Invalid environment: $gcom_env (supported values: 'dev', 'ops', 'staging', 'prod')"
         usage
         exit 1
         ;;

--- a/actions/plugins/publish/check-and-create-stub/action.yml
+++ b/actions/plugins/publish/check-and-create-stub/action.yml
@@ -5,7 +5,6 @@ description: |
   The signature type is taken from the production catalog.
   If the plugin stub doesn't exist in prod, the action returns an error.
 
-
 inputs:
   plugin-id:
     description: |
@@ -14,7 +13,7 @@ inputs:
   environment:
     description: |
       Environment where the stub should be created.
-      Can be 'dev' or 'ops'.
+      Can be 'dev' or 'ops' (or 'staging').
       Cannot be 'prod'.
     required: true
 

--- a/actions/plugins/publish/check-and-create-stub/check-and-create-stub.sh
+++ b/actions/plugins/publish/check-and-create-stub/check-and-create-stub.sh
@@ -2,7 +2,7 @@
 set -e
 
 usage() {
-    echo "Usage: $0 --environment <dev|ops> --plugin-id <plugin_id>"
+    echo "Usage: $0 --environment <dev|ops|staging> --plugin-id <plugin_id>"
 }
 
 while [[ "$#" -gt 0 ]]; do
@@ -38,7 +38,7 @@ case $gcom_env in
     dev)
         gcom_api_url=https://grafana-dev.com/api
         ;;
-    ops)
+    ops|staging)
         gcom_api_url=https://grafana-ops.com/api
         ;;
     *)

--- a/actions/plugins/publish/publish/action.yml
+++ b/actions/plugins/publish/publish/action.yml
@@ -23,7 +23,7 @@ inputs:
   environment:
     description: |
       Environment to publish to.
-      Can be 'dev', 'ops', or 'prod'.
+      Can be 'dev', 'ops' (or 'staging'), or 'prod'.
     required: true
 
   scopes:
@@ -74,11 +74,11 @@ runs:
           --environment "${ENVIRONMENT}"
           --scopes "${SCOPES}"
         )
-        
+
         if [ "${PUBLISH_AS_PENDING}" = "true" ]; then
           publish_args+=(--publish-as-pending)
         fi
-        
+
         ${{ github.action_path }}/publish.sh \
           "${publish_args[@]}" \
           "${args[@]}"

--- a/actions/plugins/publish/publish/publish.sh
+++ b/actions/plugins/publish/publish/publish.sh
@@ -5,7 +5,7 @@ if [[ "$RUNNER_DEBUG" == "1" ]]; then
 fi
 
 usage() {
-    echo "Usage: $0 --environment <dev|ops|prod> [--scopes <comma_separated_scopes>] [--publish-as-pending] [--dry-run]  <plugin_zip_urls...>"
+    echo "Usage: $0 --environment <dev|ops|staging|prod> [--scopes <comma_separated_scopes>] [--publish-as-pending] [--dry-run]  <plugin_zip_urls...>"
 }
 
 json_obj() {
@@ -60,7 +60,7 @@ case $gcom_env in
         gcom_api_url=https://grafana-dev.com/api
         has_iap=true
         ;;
-    ops)
+    ops|staging)
         gcom_api_url=https://grafana-ops.com/api
         has_iap=true
         ;;
@@ -68,7 +68,7 @@ case $gcom_env in
         gcom_api_url=https://grafana.com/api
         ;;
     *)
-        echo "Invalid environment: $gcom_env (supported values: 'dev', 'ops', 'prod')"
+        echo "Invalid environment: $gcom_env (supported values: 'dev', 'ops', 'staging', 'prod')"
         usage
         exit 1
         ;;


### PR DESCRIPTION
Adds "staging" as an alias for "ops".

Requires Argo changes in https://github.com/grafana/deployment_tools/pull/358629

 Fixes #212
