### PR TITLE
feat: add release please

### DIFF
--- a/actions/plugins/release-please/action.yml
+++ b/actions/plugins/release-please/action.yml
@@ -1,0 +1,45 @@
+name: Release Please version bump changelog
+description: |
+  Bump version and generate changelog using release-please.
+  Trigger with workflow_dispatch.
+  Commit message prefixes used:
+  - feat: Minor
+  - fix: Patch
+  - BREAKING CHANGE: Major
+  - anything else: No bump
+
+runs:
+  using: composite
+  steps:
+    - name: Get secrets from Vault
+      id: get-secrets
+      uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
+      env:
+        VAULT_INSTANCE: ops
+      with:
+        vault_instance: ${{ env.VAULT_INSTANCE }}
+        common_secrets: |
+          GITHUB_APP_ID=DrilldownBot:app_id
+          GITHUB_APP_PRIVATE_KEY=DrilldownBot:key
+
+    - name: Generate GitHub token
+      id: generate-github-token
+      uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+      with:
+        app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
+        private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        fetch-tags: true
+
+    - name: Run release-please
+      uses: googleapis/release-please-action@c2a5a2bd6a758a0937f1ddb1e8950609867ed15c # v4.3.0
+      with:
+        manifest-file: .release-please-manifest.json
+        config-file: release-please-config.json
+        target-branch: main
+        token: ${{ steps.generate-github-token.outputs.token }}

--- a/actions/plugins/release-please/action.yml
+++ b/actions/plugins/release-please/action.yml
@@ -46,8 +46,10 @@ runs:
         owner: ${{ github.repository_owner }}
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
+        token: ${{ steps.generate-github-token.outputs.token }}
+        persist-credentials: true
         fetch-depth: 0
         fetch-tags: true
 

--- a/actions/plugins/release-please/action.yml
+++ b/actions/plugins/release-please/action.yml
@@ -34,8 +34,8 @@ runs:
       with:
         vault_instance: ${{ env.VAULT_INSTANCE }}
         common_secrets: |
-          GITHUB_APP_ID=DrilldownBot:app_id
-          GITHUB_APP_PRIVATE_KEY=DrilldownBot:key
+          GITHUB_APP_ID=plugins-platform-bot-app:app-id
+          GITHUB_APP_PRIVATE_KEY=plugins-platform-bot-app:private-key
 
     - name: Generate GitHub token
       id: generate-github-token

--- a/actions/plugins/release-please/action.yml
+++ b/actions/plugins/release-please/action.yml
@@ -1,12 +1,27 @@
 name: Release Please version bump changelog
 description: |
   Bump version and generate changelog using release-please.
+
+  **Requirements:**
+  - Must be run on the main branch
+  - The following files must be present in the repository root:
+    - `.release-please-manifest.json` (manifest file)
+    - `release-please-config.json` (config file)
+
+  **Usage:**
   Trigger with workflow_dispatch.
-  Commit message prefixes used:
-  - feat: Minor
-  - fix: Patch
-  - BREAKING CHANGE: Major
-  - anything else: No bump
+
+  **Version Bumping:**
+  Release-please automatically updates the npm version based on commit message prefixes.
+  - feat: Minor version bump
+  - fix: Patch version bump
+  - BREAKING CHANGE: Major version bump
+  - anything else: No version bump
+
+  **⚠️ Warning:**
+  Adding release-please to an existing repository, may pull in old commits the first time it runs.
+  This happens because release-please analyzes all commits since the last release tag to determine what changes to include.
+  Edit the PR to remove old commits.
 
 runs:
   using: composite

--- a/examples/extra/release-please.yml
+++ b/examples/extra/release-please.yml
@@ -13,4 +13,4 @@ jobs:
 
     steps:
       - name: release please version bump changelog
-        uses: grafana/plugin-ci-workflows/actions/plugins/release-please-version-bump-changelog@main # zizmor: ignore[unpinned-uses]
+        uses: grafana/plugin-ci-workflows/actions/plugins/release-please@main # zizmor: ignore[unpinned-uses]

--- a/examples/extra/release-please.yml
+++ b/examples/extra/release-please.yml
@@ -13,4 +13,4 @@ jobs:
 
     steps:
       - name: release please version bump changelog
-        uses: grafana/plugin-ci-workflows/actions/plugins/release-please@main # zizmor: ignore[unpinned-uses]
+        uses: grafana/plugin-ci-workflows/actions/plugins/release-please@plugins-release-please/v1.0.0

--- a/examples/extra/release-please.yml
+++ b/examples/extra/release-please.yml
@@ -1,0 +1,16 @@
+name: release please
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  run-release-please:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: release please version bump changelog
+        uses: grafana/plugin-ci-workflows/actions/plugins/release-please-version-bump-changelog@main # zizmor: ignore[unpinned-uses]

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -58,6 +58,9 @@
     "actions/plugins/publish/change-plugin-scope": {
       "package-name": "plugins-change-plugin-scope"
     },
+    "actions/plugins/release-please": {
+      "package-name": "plugins-release-please"
+    },
     ".github/workflows": {
       "package-name": "ci-cd-workflows"
     }


### PR DESCRIPTION
Allow plugin developer to use googles release-please library without having to request a github app. 

Developers can customize their changelog and setup by using these files in the root of their repo:
- `.release-please-manifest.json` (manifest file)
- `release-please-config.json` (config file)

[Example PR](https://github.com/grafana/test-release-gh-actions/pull/93)
[Example Workflow](https://github.com/grafana/test-release-gh-actions/actions/runs/18176727438)