### PR TITLE
docs(examples): add trigger-argo input to provisioned plugins examples

### DIFF
--- a/examples/base/provisioned-plugin-auto-cd/publish.yaml
+++ b/examples/base/provisioned-plugin-auto-cd/publish.yaml
@@ -48,6 +48,8 @@ jobs:
       scopes: grafana_cloud # TODO: Choose the appropriate scope for your plugin.
       # This will trigger the Argo Workflow to update your plugin version in Grafana Cloud via deployment_tools
       grafana-cloud-deployment-type: provisioned
+      # Trigger Argo Workflow only when deploying from main branch (do not deploy PRs to the whole cluster)
+      trigger-argo: ${{ github.event.inputs.branch == 'main' }}
       argo-workflow-slack-channel: "#grafana-plugins-platform-ci" # TODO: Change with your own Slack channel
 
 

--- a/examples/base/provisioned-plugin-manual-deployment/publish.yaml
+++ b/examples/base/provisioned-plugin-manual-deployment/publish.yaml
@@ -48,6 +48,8 @@ jobs:
       scopes: grafana_cloud # TODO: Choose the appropriate scope for your plugin.
       # This will trigger the Argo Workflow to update your plugin version in Grafana Cloud via deployment_tools
       grafana-cloud-deployment-type: provisioned
+      # Trigger Argo Workflow only when deploying from main branch (do not deploy PRs to the whole cluster)
+      trigger-argo: ${{ github.event.inputs.branch == 'main' }}
       argo-workflow-slack-channel: "#grafana-plugins-platform-ci" # TODO: Change with your own Slack channel
 
 


### PR DESCRIPTION
Follow-up to #311. Add `trigger-argo` to the `provisioned-plugins-*` examples, so that Argo (cluster-wide Grafana Cloud deployment) is triggered only when targeting the `main` branch, and skipped when targeting PR branches.

The version will only be published to the catalog, and can still be installed on selected stacks following the instructions in the docs: https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#provisioned-plugins

**Follow-up:** These docs will also have to be updated as deploying PRs to dev is not the default behaviour anymore: https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/040-plugins-cd/#testing