### PR TITLE
chore(release-please): introduce plugins-version-bump-changelog component

### DIFF
--- a/examples/extra/version-bump-changelog.yml
+++ b/examples/extra/version-bump-changelog.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Version bump
-        uses: grafana/plugin-ci-workflows/actions/plugins/version-bump-changelog@ci-cd-workflows/v3.1.0
+        uses: grafana/plugin-ci-workflows/actions/plugins/version-bump-changelog@plugins-version-bump-changelog/v1.0.0
         with:
           generate-changelog: ${{ inputs.generate-changelog }}
           version: ${{ inputs.version }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -52,6 +52,9 @@
     "actions/plugins/publish/publish": {
       "package-name": "plugins-publish-publish"
     },
+    "actions/plugins/version-bump-changelog": {
+      "package-name": "plugins-version-bump-changelog"
+    },
     ".github/workflows": {
       "package-name": "ci-cd-workflows"
     }


### PR DESCRIPTION
Allows the extra `version-bump-changelog` action to be released with its own tags, similar to the publish action. Without this PR, all changes to the `version-bump-changelog` don't trigger release-please, which make impossible to pin the action to a specific tag.

