### PR TITLE
docs(examples): update example references to point to the latest component release

### DIFF
--- a/examples/base/provisioned-plugin-auto-cd/publish.yaml
+++ b/examples/base/provisioned-plugin-auto-cd/publish.yaml
@@ -32,7 +32,7 @@ permissions: {}
 jobs:
   cd:
     name: CD
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@plugins-publish-publish/v1.2.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v3.1.0
     permissions:
       contents: write
       id-token: write

--- a/examples/base/provisioned-plugin-auto-cd/push.yaml
+++ b/examples/base/provisioned-plugin-auto-cd/push.yaml
@@ -17,7 +17,7 @@ permissions: {}
 jobs:
   cd:
     name: CI / CD
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@plugins-publish-publish/v1.2.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v3.1.0
     permissions:
       contents: write
       id-token: write

--- a/examples/base/provisioned-plugin-manual-deployment/publish.yaml
+++ b/examples/base/provisioned-plugin-manual-deployment/publish.yaml
@@ -32,7 +32,7 @@ permissions: {}
 jobs:
   cd:
     name: CD
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@plugins-publish-publish/v1.2.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v3.1.0
     permissions:
       contents: write
       id-token: write

--- a/examples/base/provisioned-plugin-manual-deployment/push.yaml
+++ b/examples/base/provisioned-plugin-manual-deployment/push.yaml
@@ -17,7 +17,7 @@ permissions: {}
 jobs:
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@plugins-publish-publish/v1.2.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v3.1.0
     permissions:
       contents: read
       id-token: write

--- a/examples/base/simple/publish.yaml
+++ b/examples/base/simple/publish.yaml
@@ -32,7 +32,7 @@ permissions: {}
 jobs:
   cd:
     name: CD
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@plugins-publish-publish/v1.2.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v3.1.0
     permissions:
       contents: write
       id-token: write

--- a/examples/base/simple/push.yaml
+++ b/examples/base/simple/push.yaml
@@ -17,7 +17,7 @@ permissions: {}
 jobs:
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@plugins-publish-publish/v1.2.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v3.1.0
     permissions:
       contents: read
       id-token: write

--- a/examples/extra/change-plugin-scope.yml
+++ b/examples/extra/change-plugin-scope.yml
@@ -94,7 +94,7 @@ jobs:
           ENVIRONMENT: ${{ env.ENVIRONMENT }}
 
       - name: Change plugin scope
-        uses: grafana/plugin-ci-workflows/actions/plugins/publish/change-plugin-scope@plugins-publish-publish/v1.2.0
+        uses: grafana/plugin-ci-workflows/actions/plugins/publish/change-plugin-scope@ci-cd-workflows/v3.1.0
         with:
           plugin-id: ${{ env.PLUGIN_ID }}
           plugin-version: ${{ inputs.plugin_version }}

--- a/examples/extra/version-bump-changelog.yml
+++ b/examples/extra/version-bump-changelog.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Version bump
-        uses: grafana/plugin-ci-workflows/actions/plugins/version-bump-changelog@plugins-publish-publish/v1.2.0
+        uses: grafana/plugin-ci-workflows/actions/plugins/version-bump-changelog@plugins-version-bump-changelog/v1.0.0
         with:
           generate-changelog: ${{ inputs.generate-changelog }}
           version: ${{ inputs.version }}


### PR DESCRIPTION
There seems to be a bug in the tag switching workflow where all examples are updated when a new version of a release-please component is released, rather than just the examples that are relevant for that component.

This PR updates all references in examples to point to the latest version of each action/workflow manually. Long-term we will fix the bug.