### PR TITLE
fix(release-please): update only relevant examples when releasing new versions

### DIFF
--- a/.github/workflows/release-please-pr-update-tagged-references.yml
+++ b/.github/workflows/release-please-pr-update-tagged-references.yml
@@ -119,7 +119,9 @@ jobs:
         env:
           COMPONENT_NAME: ${{ steps.component-name.outputs.component }}
 
-      - name: Switch references
+      # **All** references in the actions or workflows are updated, even those that aren't strictly needed by the component.
+      # This is to ensure that the tag is completely hermetic.
+      - name: Switch references (actions and workflows)
         id: switch-references
         uses: grafana/plugin-ci-workflows/actions/internal/switch-references@main
         with:
@@ -131,11 +133,23 @@ jobs:
             .github/workflows/playwright.yml
             .github/workflows/playwright-docker.yml
             actions/plugins/**
+
+      # For examples we update filtering with an additional prefix,
+      # this way we only update only the relevant examples
+      - name: Switch references (examples)
+        id: switch-references-examples
+        uses: grafana/plugin-ci-workflows/actions/internal/switch-references@main
+        with:
+          repository: grafana/plugin-ci-workflows
+          # Prefix to update only the relevant examples
+          tag-prefix: ${{ steps.component-name.outputs.component }}
+          ref: ${{ steps.component-name.outputs.component }}/v${{ steps.get-version.outputs.version }}
+          paths: |
             examples/**
 
       - name: Get bot user info
         id: get-bot-user
-        if: steps.switch-references.outputs.changed == 'true'
+        if: steps.switch-references.outputs.changed == 'true' || steps.switch-references-examples.outputs.changed == 'true'
         uses: grafana/plugin-ci-workflows/actions/internal/get-bot-user@main
         with:
           app-slug: ${{ steps.generate-github-token.outputs.app-slug }}
@@ -143,7 +157,7 @@ jobs:
 
       # Commit and push all changes to the PR
       - name: Update PR
-        if: steps.switch-references.outputs.changed == 'true'
+        if: steps.switch-references.outputs.changed == 'true' || steps.switch-references-examples.outputs.changed == 'true'
         uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6.0.1
         with:
           commit_message: "chore(main): update tagged references"

--- a/.github/workflows/release-please-pr-update-tagged-references.yml
+++ b/.github/workflows/release-please-pr-update-tagged-references.yml
@@ -134,8 +134,8 @@ jobs:
             .github/workflows/playwright-docker.yml
             actions/plugins/**
 
-      # For examples we update filtering with an additional prefix,
-      # this way we only update only the relevant examples
+      # For "examples", update references by filtering for an additional prefix.
+      # This way we update only the examples relevant to the new component being released.
       - name: Switch references (examples)
         id: switch-references-examples
         uses: grafana/plugin-ci-workflows/actions/internal/switch-references@main

--- a/actions/internal/switch-references/action.yml
+++ b/actions/internal/switch-references/action.yml
@@ -11,6 +11,11 @@ inputs:
     description: |
       The repository containing the actions that have to be switched, e.g. `grafana/plugin-ci-workflows`
     required: true
+  tag-prefix:
+    description: |
+      An optional prefix to match for, after the "@" symbol (e.g. `ci-cd-workflows` to match `@ci-cd-workflows`)
+    required: false
+    default: ""
   paths:
     description: |
       The paths to the files or folders to modify, one per line.
@@ -33,11 +38,18 @@ runs:
   using: composite
   steps:
     - name: Switch references
-      run: ${{ github.action_path }}/switch-references.sh "${REPO}" "${REF}" ${PATHS}
+      run: |
+        args=()
+        if [ -n "${PREFIX}" ]; then
+          args+=("--tag-prefix" "${PREFIX}")
+        fi
+        args+=("${REPO}" "${REF}" ${PATHS})
+        ${{ github.action_path }}/switch-references.sh "${args[@]}"
       env:
         REF: ${{ inputs.ref }}
         REPO: ${{ inputs.repository }}
         PATHS: ${{ inputs.paths }}
+        PREFIX: ${{ inputs.tag-prefix }}
       shell: bash
 
     - name: Determine if anything changed


### PR DESCRIPTION
Fix a bug in the `.github/workflows/release-please-pr-update-tagged-references.yml` workflow for hermetic tags.

Before, the workflow would update pinned references for **all** workflows/actions and examples. This is okay for workflows/actions, but not for examples.

For example, if we release a new version for `plugins-publish-publish`, it would update **all** the tags in the examples, including those for unrelated components. For example it would update references for `@ci-cd-workflows/vx.y.z` to `@plugins-publish/vx.y.z`, when it should only update the examples that reference `@plugins-publish/vx.y.z` (the new component being released).

See this PR for an example of this bug in action: https://github.com/grafana/plugin-ci-workflows/pull/329/files#diff-941863291da298183b673484c0d211354c1f3fc0bceecb911a597b66d3ac2741

The example above was fixed manually in this PR: https://github.com/grafana/plugin-ci-workflows/pull/332

This PR changes the action so it updates only the examples that are relevant to the component being released. For example, if we release a new version of `plugins-publish-publish`, it will update only the examples referencing `@plugins-publish-publish/vx.y.z`, and ignore all other examples that reference other components (e.g.: `@ci-cd-workflows/vx.y.z`).

Tested here:

- https://github.com/grafana/plugin-ci-workflows-test/pull/84: this PR releases a new version of `plugins-version-bump-changelog`, notice how only the relevant example is updated
- https://github.com/grafana/plugin-ci-workflows-test/pull/85: this PR releases a new version of `ci-cd-workflows`, notice how only the relevant examples are updated (`examples/extra/version-bump-changelog.yml` is not updated)