### PR TITLE
chore(release-please): introduce plugins-change-plugin-scope component

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -55,6 +55,9 @@
     "actions/plugins/version-bump-changelog": {
       "package-name": "plugins-version-bump-changelog"
     },
+    "actions/plugins/publish/change-pulugin-scope": {
+      "package-name": "plugins-change-plugin-scope"
+    },
     ".github/workflows": {
       "package-name": "ci-cd-workflows"
     }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -55,7 +55,7 @@
     "actions/plugins/version-bump-changelog": {
       "package-name": "plugins-version-bump-changelog"
     },
-    "actions/plugins/publish/change-pulugin-scope": {
+    "actions/plugins/publish/change-plugin-scope": {
       "package-name": "plugins-change-plugin-scope"
     },
     ".github/workflows": {


### PR DESCRIPTION
Introduce a new release-please component for plugins-change-plugin-scope, which allows to version and release the action separate from the rest of the workflows.