### PR TITLE
chore(publish)!: Remove deprecated `local-md5` input

### DIFF
--- a/actions/plugins/publish/publish/action.yml
+++ b/actions/plugins/publish/publish/action.yml
@@ -10,16 +10,6 @@ inputs:
       - a combination of both.
     required: true
 
-  local-md5:
-    description: |
-      DEPRECATED: This input is no longer used - we only calculate MD5 hashes on the gcom.
-      If true, download the ZIP files and calculate their MD5 hashes locally.
-      Otherwise, get them from the URLs, by appending ".md5" to each URL.
-      Default is false. It's recommended to keep it set to false if possible,
-      unless you are not uploading to the "integration-artifacts" bucket.
-    required: false
-    default: "false"
-
   environment:
     description: |
       Environment to publish to.


### PR DESCRIPTION
Fixes deprecated `local-md5` input in `actions/plugins/publish/publish`.

Fixes #327.