### PR TITLE
feat: add cd summary step

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -628,6 +628,7 @@ jobs:
           publish-as-pending: ${{ matrix.environment == 'prod-canary' || inputs.publish-to-catalog-as-pending }}
 
       - name: Print publish summary
+        if: ${{ !inputs.trigger-argo }}
         run: |
           echo "## 📦 Published to Catalog (${{ matrix.environment }})
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -627,6 +627,18 @@ jobs:
           ignore-conflicts: ${{ steps.determine-continue.outputs.ignore_conflicts }}
           publish-as-pending: ${{ matrix.environment == 'prod-canary' || inputs.publish-to-catalog-as-pending }}
 
+      - name: Print publish summary
+        run: |
+          echo "## 📦 Published to Catalog (${{ matrix.environment }})
+
+          - **Plugin ID**: \`${PLUGIN_ID}\`
+          - **Version**: \`${PLUGIN_VERSION}\`
+          " >> "$GITHUB_STEP_SUMMARY"
+        env:
+          PLUGIN_ID: ${{ fromJSON(needs.ci.outputs.plugin).id }}
+          PLUGIN_VERSION: ${{ fromJSON(needs.ci.outputs.plugin).version }}
+        shell: bash
+
   trigger-argo-workflow:
     name: Trigger Argo Workflow for Grafana Cloud deployment
     runs-on: ubuntu-x64-small

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -628,7 +628,6 @@ jobs:
           publish-as-pending: ${{ matrix.environment == 'prod-canary' || inputs.publish-to-catalog-as-pending }}
 
       - name: Print publish summary
-        if: ${{ !inputs.trigger-argo }}
         run: |
           echo "## 📦 Published to Catalog (${{ matrix.environment }})
 


### PR DESCRIPTION
Convenient to get the full version if argo is skipped, e.g. want to deploy a one-off version to a single dev stack for testing.