### PR TITLE
fix(ci): allow-unsigned package creation on 'none' environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,7 +379,7 @@ jobs:
           dist-folder: dist
           output-folder: dist-artifacts
           access-policy-token: ${{ fromJson(steps.workflow-context.outputs.result).isTrusted && fromJSON(steps.get-secrets.outputs.secrets).SIGN_PLUGIN_ACCESS_POLICY_TOKEN || '' }}
-          allow-unsigned: ${{ ((inputs.environment == 'dev' || inputs.environment == '') && !(fromJson(steps.workflow-context.outputs.result).isTrusted)) || inputs.allow-unsigned }}
+          allow-unsigned: ${{ ((inputs.environment == 'dev' || inputs.environment == '' || inputs.environment == 'none') && !(fromJson(steps.workflow-context.outputs.result).isTrusted)) || inputs.allow-unsigned }}
 
       - name: Package os/arch ZIPs
         id: os-arch-zips
@@ -389,7 +389,7 @@ jobs:
           dist-folder: dist
           output-folder: dist-artifacts
           access-policy-token: ${{ fromJson(steps.workflow-context.outputs.result).isTrusted && fromJSON(steps.get-secrets.outputs.secrets).SIGN_PLUGIN_ACCESS_POLICY_TOKEN || '' }}
-          allow-unsigned: ${{ ((inputs.environment == 'dev' || inputs.environment == '') && !(fromJson(steps.workflow-context.outputs.result).isTrusted)) || inputs.allow-unsigned }}
+          allow-unsigned: ${{ ((inputs.environment == 'dev' || inputs.environment == '' || inputs.environment == 'none') && !(fromJson(steps.workflow-context.outputs.result).isTrusted)) || inputs.allow-unsigned }}
 
       - name: Trufflehog secrets scanning
         if: ${{ inputs.run-trufflehog == true }}


### PR DESCRIPTION
The examples use the following logic to decide the environment:

```yaml
      environment: ${{ (github.event_name == 'push' && github.ref_name == 'main') && 'dev' || 'none' }}
```

This results in an `environment` value of `none` which no longer works after PR #300.

This PR fixes the issue by adding 'none' as a valid environment to skip signing for. Alternatively, we can update the examples. This would require updates in the consuming repos as well which is why I fixed it at this level.