### PR TITLE
feat: adding a non-required input called signature-type

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -93,6 +93,11 @@ on:
         type: boolean
         required: false
         default: false
+      signature-type:
+        description: Specify signature type to use when signing the plugin
+        type: string
+        required: false
+        default: "grafana"
 
       # Playwright
       run-playwright:
@@ -406,6 +411,7 @@ jobs:
       backend-secrets: ${{ inputs.backend-secrets }}
       environment: ${{ inputs.environment }}
       allow-unsigned: ${{ inputs.allow-unsigned }}
+      signature-type: ${{ inputs.signature-type }}
 
   build-attestation:
     name: Build attestation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,11 @@ on:
         type: boolean
         required: false
         default: false
+      signature-type:
+        description: Specify signature type to use when signing the plugin
+        type: string
+        required: false
+        default: "grafana"
 
       # Options for testing the workflow itself.
       testing:
@@ -400,6 +405,7 @@ jobs:
           output-folder: dist-artifacts
           access-policy-token: ${{ fromJson(steps.workflow-context.outputs.result).isTrusted && fromJSON(steps.get-secrets.outputs.secrets).SIGN_PLUGIN_ACCESS_POLICY_TOKEN || '' }}
           allow-unsigned: ${{ ((inputs.environment == 'dev' || inputs.environment == '' || inputs.environment == 'none') && !(fromJson(steps.workflow-context.outputs.result).isTrusted)) || inputs.allow-unsigned }}
+          signature-type: ${{ inputs.signature-type }}
 
       - name: Package os/arch ZIPs
         id: os-arch-zips
@@ -410,6 +416,7 @@ jobs:
           output-folder: dist-artifacts
           access-policy-token: ${{ fromJson(steps.workflow-context.outputs.result).isTrusted && fromJSON(steps.get-secrets.outputs.secrets).SIGN_PLUGIN_ACCESS_POLICY_TOKEN || '' }}
           allow-unsigned: ${{ ((inputs.environment == 'dev' || inputs.environment == '' || inputs.environment == 'none') && !(fromJson(steps.workflow-context.outputs.result).isTrusted)) || inputs.allow-unsigned }}
+          signature-type: ${{ inputs.signature-type }}
 
       - name: Trufflehog secrets scanning
         if: ${{ inputs.run-trufflehog == true }}

--- a/actions/internal/plugins/package/action.yml
+++ b/actions/internal/plugins/package/action.yml
@@ -27,6 +27,10 @@ inputs:
       If false, only allow packaging signed plugins (fail the action if the plugin could not be signed).
     required: false
     default: "false"
+  signature-type:
+    description: Specify signature type to use when signing the plugin
+    required: false
+    default: "grafana"
 
 outputs:
   zip:
@@ -64,6 +68,7 @@ runs:
         ${DIST_FOLDER} ${OUTPUT_FOLDER}
       env:
         GRAFANA_ACCESS_POLICY_TOKEN: ${{ inputs.access-policy-token }}
+        SIGNATURE_TYPE: ${{ inputs.signature-type }}
         DIST_FOLDER: ${{ inputs.dist-folder }}
         OUTPUT_FOLDER: ${{ inputs.output-folder }}
 
@@ -75,6 +80,7 @@ runs:
         ${DIST_FOLDER} ${OUTPUT_FOLDER}
       env:
         GRAFANA_ACCESS_POLICY_TOKEN: ${{ inputs.access-policy-token }}
+        SIGNATURE_TYPE: ${{ inputs.signature-type }}
         DIST_FOLDER: ${{ inputs.dist-folder }}
         OUTPUT_FOLDER: ${{ inputs.output-folder }}
 

--- a/actions/internal/plugins/package/package.sh
+++ b/actions/internal/plugins/package/package.sh
@@ -4,10 +4,13 @@ set -e
 # package creates a zip file and its corresponding sha256 file
 # $1 is the destination zip file name
 # $2 is the source directory
+# $3 is the signature type (optional, defaults to "grafana")
 package() {
+    local signature_type=${3:-grafana}
+    
     # Sign the plugin
     if [ ! -z $GRAFANA_ACCESS_POLICY_TOKEN ]; then
-        npx -y @grafana/sign-plugin@latest --distDir $2
+        npx -y @grafana/sign-plugin@latest --signatureType=$signature_type --distDir $2
     else
         echo "WARNING: Plugin won't be signed, GRAFANA_ACCESS_POLICY_TOKEN not set"
     fi
@@ -70,7 +73,7 @@ if [ "$universal" = true ]; then
 
     cp -r . "$tmp/$plugin_id"
     cd "$tmp"
-    package "$out/$universal_zip_fn" "$plugin_id"
+    package "$out/$universal_zip_fn" "$plugin_id" "$SIGNATURE_TYPE"
     exit 0
 fi
 
@@ -114,7 +117,7 @@ for file in $(find "$backend_folder" -type f -name "${exe_basename}_*"); do
     echo "Creating package: $os_arch_zip_fn"
 
     # Create the zip+sha256 files
-    package "$out/$os_arch_zip_fn" "$plugin_id"
+    package "$out/$os_arch_zip_fn" "$plugin_id" "$SIGNATURE_TYPE"
 
     # Cleanup temporary folder
     popd > /dev/null


### PR DESCRIPTION
Adding a new input called `signature-type` which will be passed down to the `@grafana/sign-plugin` call. 
This input should be used when using this workflows but signing a plugin with a different signature type than `grafana` - for example:`community`