### PR TITLE
feat: add warning message when using rolling releases channel (`@main`)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -303,7 +303,7 @@ env:
 jobs:
   common:
     name: Common checks
-    uses: grafana/plugin-ci-workflows/.github/workflows/common-checks.yml@giuseppe/warn-on-rolling-releases
+    uses: grafana/plugin-ci-workflows/.github/workflows/common-checks.yml@main
 
   setup:
     name: Check and setup environment

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -301,6 +301,10 @@ env:
   GCS_ARTIFACTS_BUCKET: integration-artifacts
 
 jobs:
+  common:
+    name: Common checks
+    uses: grafana/plugin-ci-workflows/.github/workflows/common-checks.yml@giuseppe/warn-on-rolling-releases
+
   setup:
     name: Check and setup environment
     runs-on: ubuntu-x64-small

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,6 +267,10 @@ env:
   VAULT_INSTANCE: ops
 
 jobs:
+  common:
+    name: Common checks
+    uses: grafana/plugin-ci-workflows/.github/workflows/common-checks.yml@giuseppe/warn-on-rolling-releases
+
   test-and-build:
     name: Test and build plugin
     runs-on: ubuntu-x64-large

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,7 +269,7 @@ env:
 jobs:
   common:
     name: Common checks
-    uses: grafana/plugin-ci-workflows/.github/workflows/common-checks.yml@giuseppe/warn-on-rolling-releases
+    uses: grafana/plugin-ci-workflows/.github/workflows/common-checks.yml@main
 
   test-and-build:
     name: Test and build plugin

--- a/.github/workflows/common-checks.yml
+++ b/.github/workflows/common-checks.yml
@@ -13,8 +13,11 @@ jobs:
 
       - name: Check for rolling releases channel
         run: |
-          grep -E 'grafana/plugin-ci-workflows.+@main' -rn .github/workflows/
-          if [ $? -eq 0 ]; then
+          diff=$(grep -E 'grafana/plugin-ci-workflows.+@main' -rn .github/workflows/)
+          if [[ -n "$diff" ]]; then
+            echo "Found usage of rolling releases channel in the following files:"
+            echo "$diff"
+
             title="Rolling release channel detected"
             message="You are using workflows from plugin-ci-workflows rolling releases channel ('@ main' reference). \
           This is discouraged as it may lead to unexpected breaking changes. \

--- a/.github/workflows/common-checks.yml
+++ b/.github/workflows/common-checks.yml
@@ -4,8 +4,8 @@ on:
   workflow_call:
 
 jobs:
-  warn-on-rolling-releases:
-    name: Warn on rolling releases
+  check-for-rolling-releases:
+    name: Check for rolling releases channel
     runs-on: ubuntu-arm64-small
     steps:
       - name: Checkout

--- a/.github/workflows/common-checks.yml
+++ b/.github/workflows/common-checks.yml
@@ -16,10 +16,13 @@ jobs:
           grep -E 'grafana/plugin-ci-workflows.+@main' -rn .github/workflows/
           if [ $? -eq 0 ]; then
             title="Rolling release channel detected"
-            message="You are using workflows from plugin-ci-workflows rolling releases channel (i.e., @main). \
-            This is discouraged as it may lead to unexpected breaking changes. \
-            Please pin to a specific tagged release to ensure better stability.
-            For more information, refer to [the docs](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#versions-and-release-channels)."
+            message=$(cat <<-EOF
+          You are using workflows from plugin-ci-workflows rolling releases channel (i.e., @main).
+          This is discouraged as it may lead to unexpected breaking changes.
+          Please pin to a specific tagged release to ensure better stability.
+          For more information, refer to [the docs](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#versions-and-release-channels).
+          EOF
+          )
 
             echo "::warning title=$title::$message"
             exit 0

--- a/.github/workflows/common-checks.yml
+++ b/.github/workflows/common-checks.yml
@@ -16,13 +16,10 @@ jobs:
           grep -E 'grafana/plugin-ci-workflows.+@main' -rn .github/workflows/
           if [ $? -eq 0 ]; then
             title="Rolling release channel detected"
-            message=$(cat <<-EOF
-          You are using workflows from plugin-ci-workflows rolling releases channel (i.e., @main).
-          This is discouraged as it may lead to unexpected breaking changes.
-          Please pin to a specific tagged release to ensure better stability.
-          For more information, refer to [the docs](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#versions-and-release-channels).
-          EOF
-          )
+            message="You are using workflows from plugin-ci-workflows rolling releases channel (i.e., @main). \
+            This is discouraged as it may lead to unexpected breaking changes. \
+            Please pin to a specific tagged release to ensure better stability.
+            For more information, refer to [the docs](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#versions-and-release-channels)."
 
             echo "::warning title=$title::$message"
             exit 0

--- a/.github/workflows/common-checks.yml
+++ b/.github/workflows/common-checks.yml
@@ -17,9 +17,9 @@ jobs:
           if [ $? -eq 0 ]; then
             title="Rolling release channel detected"
             message="You are using workflows from plugin-ci-workflows rolling releases channel (i.e., @main). \
-            This is discouraged as it may lead to unexpected breaking changes. \
-            Please pin to a specific tagged release to ensure better stability.
-            For more information, refer to [the docs](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#versions-and-release-channels)."
+          This is discouraged as it may lead to unexpected breaking changes. \
+          Please pin to a specific tagged release to ensure better stability.
+          For more information, refer to [the docs](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#versions-and-release-channels)."
 
             echo "::warning title=$title::$message"
             exit 0

--- a/.github/workflows/common-checks.yml
+++ b/.github/workflows/common-checks.yml
@@ -19,7 +19,7 @@ jobs:
             echo "$nntifare"
 
             title="Rolling release channel detected"
-            message="You are using workflows from plugin-ci-workflows rolling releases channel ('@ main' reference). \
+            message="You are using workflows from plugin-ci-workflows rolling releases channel (`@main`). \
           This is discouraged as it may lead to unexpected breaking changes. \
           Please pin to a specific tagged release to ensure better stability. \
           For more information, refer to the docs: https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#versions-and-release-channels"

--- a/.github/workflows/common-checks.yml
+++ b/.github/workflows/common-checks.yml
@@ -19,7 +19,7 @@ jobs:
             message="You are using workflows from plugin-ci-workflows rolling releases channel (i.e., @main). \
           This is discouraged as it may lead to unexpected breaking changes. \
           Please pin to a specific tagged release to ensure better stability. \
-          For more information, refer to [the docs](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#versions-and-release-channels)."
+          For more information, refer to the docs: https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#versions-and-release-channels"
 
             echo "::warning title=$title::$message"
             exit 0

--- a/.github/workflows/common-checks.yml
+++ b/.github/workflows/common-checks.yml
@@ -13,10 +13,10 @@ jobs:
 
       - name: Check for rolling releases channel
         run: |
-          nntifare=$(grep -E 'grafana/plugin-ci-workflows.+@main' -rn .github/workflows/)
-          if [[ -n "$nntifare" ]]; then
+          diff=$(grep -E 'grafana/plugin-ci-workflows.+@main' -rn .github/workflows/)
+          if [[ -n "$diff" ]]; then
             echo "Found usage of rolling releases channel in the following files:"
-            echo "$nntifare"
+            echo "$diff"
 
             title="Rolling release channel detected"
             message="You are using workflows from plugin-ci-workflows rolling releases channel (\`@main\`). \

--- a/.github/workflows/common-checks.yml
+++ b/.github/workflows/common-checks.yml
@@ -19,7 +19,7 @@ jobs:
             echo "$nntifare"
 
             title="Rolling release channel detected"
-            message="You are using workflows from plugin-ci-workflows rolling releases channel (`@main`). \
+            message="You are using workflows from plugin-ci-workflows rolling releases channel (\`@main\`). \
           This is discouraged as it may lead to unexpected breaking changes. \
           Please pin to a specific tagged release to ensure better stability. \
           For more information, refer to the docs: https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#versions-and-release-channels"

--- a/.github/workflows/common-checks.yml
+++ b/.github/workflows/common-checks.yml
@@ -18,7 +18,7 @@ jobs:
             title="Rolling release channel detected"
             message="You are using workflows from plugin-ci-workflows rolling releases channel (i.e., @main). \
           This is discouraged as it may lead to unexpected breaking changes. \
-          Please pin to a specific tagged release to ensure better stability.
+          Please pin to a specific tagged release to ensure better stability. \
           For more information, refer to [the docs](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#versions-and-release-channels)."
 
             echo "::warning title=$title::$message"

--- a/.github/workflows/common-checks.yml
+++ b/.github/workflows/common-checks.yml
@@ -19,7 +19,7 @@ jobs:
             echo "$diff"
 
             title="Rolling release channel detected"
-            message="You are using workflows from plugin-ci-workflows rolling releases channel. \
+            message="You are using workflows from plugin-ci-workflows rolling releases channel (\`@main\`). \
           This is discouraged as it may lead to unexpected breaking changes. \
           Please pin to a specific tagged release to ensure better stability. \
           For more information, refer to the docs: https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#versions-and-release-channels"

--- a/.github/workflows/common-checks.yml
+++ b/.github/workflows/common-checks.yml
@@ -1,0 +1,27 @@
+name: Common checks
+
+on:
+  workflow_call:
+
+jobs:
+  warn-on-rolling-releases:
+    name: Warn on rolling releases
+    runs-on: ubuntu-arm64-small
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Check for rolling releases channel
+        run: |
+          grep -E 'grafana/plugin-ci-workflows.+@main' -rn .github/workflows/
+          if [ $? -eq 0 ]; then
+            title="Rolling release channel detected"
+            message="You are using workflows from plugin-ci-workflows rolling releases channel (i.e., @main). \
+            This is discouraged as it may lead to unexpected breaking changes. \
+            Please pin to a specific tagged release to ensure better stability.
+            For more information, refer to [the docs](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#versions-and-release-channels)."
+
+            echo "::warning title=$title::$message"
+            exit 0
+          fi
+        shell: bash

--- a/.github/workflows/common-checks.yml
+++ b/.github/workflows/common-checks.yml
@@ -13,8 +13,7 @@ jobs:
 
       - name: Check for rolling releases channel
         run: |
-          set -xe
-          diff=$(grep -E 'grafana/plugin-ci-workflows.+@main' -rn .github/workflows/)
+          diff=$(grep -E 'grafana/plugin-ci-workflows.+@main' -rn .github/workflows/ || true)
           if [[ -n "$diff" ]]; then
             echo "Found usage of rolling releases channel in the following files:"
             echo "$diff"

--- a/.github/workflows/common-checks.yml
+++ b/.github/workflows/common-checks.yml
@@ -13,6 +13,7 @@ jobs:
 
       - name: Check for rolling releases channel
         run: |
+          set -xe
           diff=$(grep -E 'grafana/plugin-ci-workflows.+@main' -rn .github/workflows/)
           if [[ -n "$diff" ]]; then
             echo "Found usage of rolling releases channel in the following files:"

--- a/.github/workflows/common-checks.yml
+++ b/.github/workflows/common-checks.yml
@@ -13,10 +13,10 @@ jobs:
 
       - name: Check for rolling releases channel
         run: |
-          diff=$(grep -E 'grafana/plugin-ci-workflows.+@main' -rn .github/workflows/)
-          if [[ -n "$diff" ]]; then
+          nntifare=$(grep -E 'grafana/plugin-ci-workflows.+@main' -rn .github/workflows/)
+          if [[ -n "$nntifare" ]]; then
             echo "Found usage of rolling releases channel in the following files:"
-            echo "$diff"
+            echo "$nntifare"
 
             title="Rolling release channel detected"
             message="You are using workflows from plugin-ci-workflows rolling releases channel ('@ main' reference). \

--- a/.github/workflows/common-checks.yml
+++ b/.github/workflows/common-checks.yml
@@ -16,7 +16,7 @@ jobs:
           grep -E 'grafana/plugin-ci-workflows.+@main' -rn .github/workflows/
           if [ $? -eq 0 ]; then
             title="Rolling release channel detected"
-            message="You are using workflows from plugin-ci-workflows rolling releases channel (i.e., @main). \
+            message="You are using workflows from plugin-ci-workflows rolling releases channel ('@ main' reference). \
           This is discouraged as it may lead to unexpected breaking changes. \
           Please pin to a specific tagged release to ensure better stability. \
           For more information, refer to the docs: https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#versions-and-release-channels"

--- a/.github/workflows/common-checks.yml
+++ b/.github/workflows/common-checks.yml
@@ -19,7 +19,7 @@ jobs:
             echo "$diff"
 
             title="Rolling release channel detected"
-            message="You are using workflows from plugin-ci-workflows rolling releases channel (\`@main\`). \
+            message="You are using workflows from plugin-ci-workflows rolling releases channel. \
           This is discouraged as it may lead to unexpected breaking changes. \
           Please pin to a specific tagged release to ensure better stability. \
           For more information, refer to the docs: https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#versions-and-release-channels"


### PR DESCRIPTION
Encourages using tagged releases instead of the rolling releases channel. Fixes #353.

Example run using rolling releases (warning): https://github.com/grafana/plugins-drone-to-gha/actions/runs/19031442995

Example run using tagged releases (no warning): https://github.com/grafana/plugins-drone-to-gha/actions/runs/19031298151