### PR TITLE
feat: run plugin-validator as part of CI (opt-in)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -191,7 +191,7 @@ on:
         type: boolean
         required: false
         default: false
-      plugin-validator-config-file:
+      plugin-validator-config:
         description: |
           Content of the plugin validator configuration file (yaml) to use.
           If not provided, the action will look for the file specified in `plugin-validator-config-path` input instead.
@@ -422,7 +422,7 @@ jobs:
       golangci-lint-version: ${{ inputs.golangci-lint-version }}
 
       run-plugin-validator: ${{ inputs.run-plugin-validator }}
-      plugin-validator-config-file: ${{ inputs.plugin-validator-config-file }}
+      plugin-validator-config: ${{ inputs.plugin-validator-config }}
       plugin-validator-config-path: ${{ inputs.plugin-validator-config-path }}
 
       run-playwright: ${{ inputs.run-playwright }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -194,18 +194,20 @@ on:
       plugin-validator-config:
         description: |
           Content of the plugin validator configuration file (yaml) to use.
+          It has higher priority than `plugin-validator-config-path` input.
           If not provided, the action will look for the file specified in `plugin-validator-config-path` input instead.
+          If neither is provided, a default configuration will be used.
         type: string
         required: false
         default: ""
       plugin-validator-config-path:
         description: |
           Path to the plugin validator configuration file (yaml) to use.
-          Defaults to `.plugin-validator.yaml`.
-          If the file is not present, the action will use a default configuration instead.
+          It will be used only if `plugin-validator-config` input is not provided.
+          If not provided, a default configuration will be used.
         type: string
         required: false
-        default: .plugin-validator.yaml
+        default: ""
 
       # Feature toggle: Artifacts attestation for build provenance
       attestation:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -185,7 +185,14 @@ on:
         type: string
         required: false
 
-      # Artifacts attestation for build provenance
+      # Feature toggle: plugin-validator
+      run-plugin-validator:
+        description: Whether to run plugin-validator.
+        type: boolean
+        required: false
+        default: false
+
+      # Feature toggle: Artifacts attestation for build provenance
       attestation:
         description: Create a verifiable attestation for the plugin using Github OIDC.
         type: boolean
@@ -391,6 +398,7 @@ jobs:
       go-setup-caching: ${{ inputs.go-setup-caching }}
       node-version: ${{ inputs.node-version }}
       golangci-lint-version: ${{ inputs.golangci-lint-version }}
+      run-plugin-validator: ${{ inputs.run-plugin-validator }}
       run-playwright: ${{ inputs.run-playwright }}
       run-playwright-docker: ${{ inputs.run-playwright-docker }}
       run-playwright-with-grafana-dependency: ${{ inputs.run-playwright-with-grafana-dependency }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -191,6 +191,21 @@ on:
         type: boolean
         required: false
         default: false
+      plugin-validator-config-file:
+        description: |
+          Content of the plugin validator configuration file (yaml) to use.
+          If not provided, the action will look for the file specified in `plugin-validator-config-path` input instead.
+        type: string
+        required: false
+        default: ""
+      plugin-validator-config-path:
+        description: |
+          Path to the plugin validator configuration file (yaml) to use.
+          Defaults to `.plugin-validator.yaml`.
+          If the file is not present, the action will use a default configuration instead.
+        type: string
+        required: false
+        default: .plugin-validator.yaml
 
       # Feature toggle: Artifacts attestation for build provenance
       attestation:
@@ -396,13 +411,20 @@ jobs:
     with:
       branch: ${{ inputs.branch }}
       plugin-directory: ${{ inputs.plugin-directory }}
+      plugin-version-suffix: ${{ needs.setup.outputs.plugin-version-suffix }}
+
       package-manager: ${{ inputs.package-manager }}
       npm-registry-auth: ${{ inputs.npm-registry-auth }}
+
       go-version: ${{ inputs.go-version }}
       go-setup-caching: ${{ inputs.go-setup-caching }}
       node-version: ${{ inputs.node-version }}
       golangci-lint-version: ${{ inputs.golangci-lint-version }}
+
       run-plugin-validator: ${{ inputs.run-plugin-validator }}
+      plugin-validator-config-file: ${{ inputs.plugin-validator-config-file }}
+      plugin-validator-config-path: ${{ inputs.plugin-validator-config-path }}
+
       run-playwright: ${{ inputs.run-playwright }}
       run-playwright-docker: ${{ inputs.run-playwright-docker }}
       run-playwright-with-grafana-dependency: ${{ inputs.run-playwright-with-grafana-dependency }}
@@ -414,14 +436,17 @@ jobs:
       playwright-config: ${{ inputs.playwright-config }}
       playwright-grafana-url: ${{ inputs.playwright-grafana-url }}
       playwright-secrets: ${{ inputs.playwright-secrets }}
+
       run-trufflehog: ${{ inputs.run-trufflehog }}
       trufflehog-version: ${{ inputs.trufflehog-version }}
       trufflehog-include-detectors: ${{ inputs.trufflehog-include-detectors }}
       trufflehog-exclude-detectors: ${{ inputs.trufflehog-exclude-detectors }}
-      plugin-version-suffix: ${{ needs.setup.outputs.plugin-version-suffix }}
+
       frontend-secrets: ${{ inputs.frontend-secrets }}
       backend-secrets: ${{ inputs.backend-secrets }}
+
       environment: ${{ inputs.environment }}
+
       allow-unsigned: ${{ inputs.allow-unsigned }}
       signature-type: ${{ inputs.signature-type }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -469,7 +469,7 @@ jobs:
             -config=/workspace/.plugin-validator.yaml \
             -sourceCodeUri=file:///workspace \
             "/workspace/dist-artifacts/${UNIVERSAL_ZIP}"
-          exit $(docker inspect plugin-validator --format='{{.State.ExitCode}}')
+          exit "$(docker inspect plugin-validator --format='{{.State.ExitCode}}')"
         env:
           UNIVERSAL_ZIP: ${{ steps.universal-zip.outputs.zip }}
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -464,6 +464,7 @@ jobs:
             -v "$PWD/dist-artifacts:/workspace/dist-artifacts:ro" \
             -v "$PWD:/workspace:ro" \
             -e SKIP_CLAMAV=1 \
+            -e DEBUG=1 \
             grafana/plugin-validator-cli \
             -config=/workspace/.plugin-validator.yaml \
             -sourceCodeUri=file:///workspace \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,13 @@ on:
         type: string
         required: false
 
+      # Feature toggle: plugin-validator
+      run-plugin-validator:
+        description: Whether to run plugin-validator.
+        type: boolean
+        required: false
+        default: false
+
       # Options for building PRs. Those values should come from the PR event and should not be set manually.
       plugin-version-suffix:
         description: |
@@ -426,6 +433,17 @@ jobs:
           folder: dist-artifacts
           include-detectors: ${{ inputs.trufflehog-include-detectors }}
           exclude-detectors: ${{ inputs.trufflehog-exclude-detectors }}
+
+      - name: plugin-validator
+        if: ${{ inputs.run-plugin-validator == true }}
+        run: |
+          cd dist-artifacts
+          docker run --pull=always \
+            -v $PWD/dist-artifacts:/dist-artifacts \
+            grafana/plugin-validator-cli -analyzer=metadatavalid "/dist-artifacts/${UNIVERSAL_ZIP}"
+        env:
+          UNIVERSAL_ZIP: ${{ steps.universal-zip.outputs.zip }}
+        shell: bash
 
       - name: Define outputs
         id: outputs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -437,7 +437,6 @@ jobs:
       - name: plugin-validator
         if: ${{ inputs.run-plugin-validator == true }}
         run: |
-          cd dist-artifacts
           docker run --pull=always \
             -v $PWD/dist-artifacts:/dist-artifacts \
             grafana/plugin-validator-cli -analyzer=metadatavalid "/dist-artifacts/${UNIVERSAL_ZIP}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,11 +486,14 @@ jobs:
           echo "Using configuration:"
           cat "${PLUGIN_VALIDATOR_CONFIG_PATH}"
 
+          mkdir -p /tmp/empty
+
           # Do not run clamav because it takes too long (and because it would scan node_modules as well)
           docker run --name=plugin-validator --pull=always \
             -v "$PWD/${PLUGIN_VALIDATOR_CONFIG_PATH}:/workspace/.plugin-validator.yaml:ro" \
             -v "$PWD/dist-artifacts:/workspace/dist-artifacts:ro" \
             -v "$PWD/${PLUGIN_DIRECTORY}:/workspace" \
+            -v "/tmp/empty:/workspace/node_modules" \
             -e SKIP_CLAMAV=1 \
             grafana/plugin-validator-cli \
             -ghaOutput \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ on:
         type: boolean
         required: false
         default: false
-      plugin-validator-config-file:
+      plugin-validator-config:
         description: |
           Content of the plugin validator configuration file (yaml) to use.
           If not provided, the action will look for the file specified in `plugin-validator-config-path` input instead.
@@ -463,9 +463,9 @@ jobs:
       - name: plugin-validator
         if: ${{ inputs.run-plugin-validator == true }}
         run: |
-          if [ -n "${PLUGIN_VALIDATOR_CONFIG_FILE}" ]; then
+          if [ -n "${PLUGIN_VALIDATOR_CONFIG}" ]; then
             echo "Using provided plugin-validator configuration content."
-            echo "${PLUGIN_VALIDATOR_CONFIG_FILE}" > .plugin-validator.yaml
+            echo "${PLUGIN_VALIDATOR_CONFIG}" > .plugin-validator.yaml
             PLUGIN_VALIDATOR_CONFIG_PATH=.plugin-validator.yaml
             cat ${PLUGIN_VALIDATOR_CONFIG_PATH}
           elif [ -f "${PLUGIN_VALIDATOR_CONFIG_PATH}" ]; then
@@ -505,7 +505,7 @@ jobs:
           exit "$(docker inspect plugin-validator --format='{{.State.ExitCode}}')"
         env:
           UNIVERSAL_ZIP: ${{ steps.universal-zip.outputs.zip }}
-          PLUGIN_VALIDATOR_CONFIG_FILE: ${{ inputs.plugin-validator-config-file }}
+          PLUGIN_VALIDATOR_CONFIG: ${{ inputs.plugin-validator-config }}
           PLUGIN_VALIDATOR_CONFIG_PATH: ${{ inputs.plugin-validator-config-path }}
           PLUGIN_DIRECTORY: ${{ inputs.plugin-directory }}
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -457,9 +457,9 @@ jobs:
             reportAll: false
           EOF
           fi
-          if [ -f validator-output.txt ]; then
-            cat >&2 validator-output.txt
-          fi
+          #if [ -f validator-output.txt ]; then
+          #  cat >&2 validator-output.txt
+          #fi
           docker run --name=plugin-validator --pull=always \
             -v "$PWD/dist-artifacts:/workspace/dist-artifacts:ro" \
             -v "$PWD/.plugin-validator.yaml:/workspace/.plugin-validator.yaml:ro" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,9 +486,11 @@ jobs:
           echo "Using configuration:"
           cat "${PLUGIN_VALIDATOR_CONFIG_PATH}"
 
+          # Create an empty dir for mounting it instead of node_modules, otherwise some validator analyzers
+          # will recurse into the plugin's directory (including node_modules).
           mkdir -p /tmp/empty
 
-          # Do not run clamav because it takes too long (and because it would scan node_modules as well)
+          # Do not run clamav because it takes too long
           docker run --name=plugin-validator --pull=always \
             -v "$PWD/${PLUGIN_VALIDATOR_CONFIG_PATH}:/workspace/.plugin-validator.yaml:ro" \
             -v "$PWD/dist-artifacts:/workspace/dist-artifacts:ro" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -458,8 +458,8 @@ jobs:
           EOF
           fi
           docker run --rm --pull=always \
-            -v $PWD/dist-artifacts:/workspace/dist-artifacts:ro \
-            -v $PWD/.plugin-validator.yaml:/workspace/.plugin-validator.yaml:ro \
+            -v "$PWD/dist-artifacts:/workspace/dist-artifacts:ro" \
+            -v "$PWD/.plugin-validator.yaml:/workspace/.plugin-validator.yaml:ro" \
             grafana/plugin-validator-cli -config=/workspace/.plugin-validator.yaml "/workspace/dist-artifacts/${UNIVERSAL_ZIP}"
         env:
           UNIVERSAL_ZIP: ${{ steps.universal-zip.outputs.zip }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,10 +233,6 @@ on:
         type: string
         required: false
         default: ""
-      concurrency-prefix:
-        type: string
-        required: false
-        default: ""
 
     outputs:
       plugin:
@@ -275,7 +271,7 @@ on:
         value: ${{ jobs.upload-to-gcs.outputs.universal-zip-url-commit }}
 
 concurrency:
-  group: ${{ inputs.concurrency-prefix }}ci-${{ inputs.plugin-directory }}-${{ github.head_ref || github.run_id }}
+  group: ci-${{ inputs.plugin-directory }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -437,9 +437,19 @@ jobs:
       - name: plugin-validator
         if: ${{ inputs.run-plugin-validator == true }}
         run: |
-          docker run --pull=always \
-            -v $PWD/dist-artifacts:/dist-artifacts \
-            grafana/plugin-validator-cli -analyzer=metadatavalid "/dist-artifacts/${UNIVERSAL_ZIP}"
+          if [ ! -f ".plugin-validator.yaml" ]; then
+            echo "⚠️ .plugin-validator.yaml configuration file is missing. Providing a default one as fallback."
+            cat <<EOF > .plugin-validator.yaml
+          global:
+            enabled: true
+            severity: warning
+            reportAll: false
+          EOF
+          fi
+          docker run --rm --pull=always \
+            -v $PWD/dist-artifacts:/workspace/dist-artifacts:ro \
+            -v $PWD/.plugin-validator.yaml:/workspace/.plugin-validator.yaml:ro \
+            grafana/plugin-validator-cli -config=/workspace/.plugin-validator.yaml "/workspace/dist-artifacts/${UNIVERSAL_ZIP}"
         env:
           UNIVERSAL_ZIP: ${{ steps.universal-zip.outputs.zip }}
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,6 +466,7 @@ jobs:
             -e SKIP_CLAMAV=1 \
             -e DEBUG=1 \
             grafana/plugin-validator-cli \
+            -ghaOutput \
             -config=/workspace/.plugin-validator.yaml \
             -sourceCodeUri=file:///workspace \
             "/workspace/dist-artifacts/${UNIVERSAL_ZIP}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,10 +477,6 @@ jobs:
               echo "::error title=plugin-validator: missing config file::${PLUGIN_VALIDATOR_CONFIG_PATH} configuration file is missing."
               exit 1
             fi
-            if [[ -d "${PLUGIN_VALIDATOR_CONFIG_PATH}" ]]; then
-              echo "::error title=plugin-validator: invalid config file::${PLUGIN_VALIDATOR_CONFIG_PATH} is a directory, expected a file."
-              exit 1
-            fi
           else
             # Default hardcoded configuration
             PLUGIN_VALIDATOR_CONFIG_PATH=".plugin-validator.yaml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,18 +170,20 @@ on:
       plugin-validator-config:
         description: |
           Content of the plugin validator configuration file (yaml) to use.
+          It has higher priority than `plugin-validator-config-path` input.
           If not provided, the action will look for the file specified in `plugin-validator-config-path` input instead.
+          If neither is provided, a default configuration will be used.
         type: string
         required: false
         default: ""
       plugin-validator-config-path:
         description: |
           Path to the plugin validator configuration file (yaml) to use.
-          Defaults to `.plugin-validator.yaml`.
-          If the file is not present, the action will use a default configuration instead.
+          It will be used only if `plugin-validator-config` input is not provided.
+          If not provided, a default configuration will be used.
         type: string
         required: false
-        default: .plugin-validator.yaml
+        default: ""
 
       # Options for building PRs. Those values should come from the PR event and should not be set manually.
       plugin-version-suffix:
@@ -464,15 +466,19 @@ jobs:
         if: ${{ inputs.run-plugin-validator == true }}
         run: |
           if [ -n "${PLUGIN_VALIDATOR_CONFIG}" ]; then
+            # User-provided configuration content
             echo "Using provided plugin-validator configuration content."
-            echo "${PLUGIN_VALIDATOR_CONFIG}" > .plugin-validator.yaml
-            PLUGIN_VALIDATOR_CONFIG_PATH=.plugin-validator.yaml
-            cat ${PLUGIN_VALIDATOR_CONFIG_PATH}
-          elif [ -f "${PLUGIN_VALIDATOR_CONFIG_PATH}" ]; then
+            PLUGIN_VALIDATOR_CONFIG_PATH=".plugin-validator.yaml"
+            echo "${PLUGIN_VALIDATOR_CONFIG}" > ${PLUGIN_VALIDATOR_CONFIG_PATH}
+          elif [ -n "${PLUGIN_VALIDATOR_CONFIG_PATH}" ]; then
+            # User-provided configuration file path
             echo "Using plugin-validator configuration file at path: ${PLUGIN_VALIDATOR_CONFIG_PATH}"
-          fi
-
-          if [ ! -f "${PLUGIN_VALIDATOR_CONFIG_PATH}" ]; then
+            if [ ! -f "${PLUGIN_VALIDATOR_CONFIG_PATH}" ]; then
+              echo "::error title=plugin-validator: missing config file::${PLUGIN_VALIDATOR_CONFIG_PATH} configuration file is missing."
+              exit 1
+            fi
+          else
+            # Default hardcoded configuration
             PLUGIN_VALIDATOR_CONFIG_PATH=".plugin-validator.yaml"
             echo "${PLUGIN_VALIDATOR_CONFIG_PATH} configuration file is missing. Providing a default one as fallback."
             cat <<EOF > "${PLUGIN_VALIDATOR_CONFIG_PATH}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -474,12 +474,10 @@ jobs:
 
           if [ ! -f "${PLUGIN_VALIDATOR_CONFIG_PATH}" ]; then
             PLUGIN_VALIDATOR_CONFIG_PATH=".plugin-validator.yaml"
-            echo "⚠️ ${PLUGIN_VALIDATOR_CONFIG_PATH} configuration file is missing. Providing a default one as fallback."
+            echo "${PLUGIN_VALIDATOR_CONFIG_PATH} configuration file is missing. Providing a default one as fallback."
             cat <<EOF > "${PLUGIN_VALIDATOR_CONFIG_PATH}"
           global:
             enabled: true
-            severity: warning
-            reportAll: true
           EOF
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -494,7 +494,7 @@ jobs:
           docker run --name=plugin-validator --pull=always \
             -v "$PWD/${PLUGIN_VALIDATOR_CONFIG_PATH}:/workspace/.plugin-validator.yaml:ro" \
             -v "$PWD/dist-artifacts:/workspace/dist-artifacts:ro" \
-            -v "$PWD/${PLUGIN_DIRECTORY}:/workspace:ro" \
+            -v "$PWD/${PLUGIN_DIRECTORY}:/workspace" \
             -e SKIP_CLAMAV=1 \
             grafana/plugin-validator-cli \
             -ghaOutput \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -457,6 +457,9 @@ jobs:
             reportAll: false
           EOF
           fi
+          if [ -f validator-output.txt ]; then
+            cat >&2 validator-output.txt
+          fi
           docker run --rm --pull=always \
             -v "$PWD/dist-artifacts:/workspace/dist-artifacts:ro" \
             -v "$PWD/.plugin-validator.yaml:/workspace/.plugin-validator.yaml:ro" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -462,8 +462,11 @@ jobs:
           #fi
           docker run --name=plugin-validator --pull=always \
             -v "$PWD/dist-artifacts:/workspace/dist-artifacts:ro" \
-            -v "$PWD/.plugin-validator.yaml:/workspace/.plugin-validator.yaml:ro" \
-            grafana/plugin-validator-cli -config=/workspace/.plugin-validator.yaml "/workspace/dist-artifacts/${UNIVERSAL_ZIP}"
+            -v "$PWD:/workspace:ro" \
+            grafana/plugin-validator-cli \
+            -config=/workspace/.plugin-validator.yaml \
+            -sourceCodeUri=file:///workspace \
+            "/workspace/dist-artifacts/${UNIVERSAL_ZIP}"
           exit $(docker inspect plugin-validator --format='{{.State.ExitCode}}')
         env:
           UNIVERSAL_ZIP: ${{ steps.universal-zip.outputs.zip }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,10 @@ on:
         type: string
         required: false
         default: ""
+      concurrency-prefix:
+        type: string
+        required: false
+        default: ""
 
     outputs:
       plugin:
@@ -271,7 +275,7 @@ on:
         value: ${{ jobs.upload-to-gcs.outputs.universal-zip-url-commit }}
 
 concurrency:
-  group: ci-${{ inputs.plugin-directory }}-${{ github.head_ref || github.run_id }}
+  group: ${{ inputs.concurrency-prefix }}ci-${{ inputs.plugin-directory }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,21 @@ on:
         type: boolean
         required: false
         default: false
+      plugin-validator-config-file:
+        description: |
+          Content of the plugin validator configuration file (yaml) to use.
+          If not provided, the action will look for the file specified in `plugin-validator-config-path` input instead.
+        type: string
+        required: false
+        default: ""
+      plugin-validator-config-path:
+        description: |
+          Path to the plugin validator configuration file (yaml) to use.
+          Defaults to `.plugin-validator.yaml`.
+          If the file is not present, the action will use a default configuration instead.
+        type: string
+        required: false
+        default: .plugin-validator.yaml
 
       # Options for building PRs. Those values should come from the PR event and should not be set manually.
       plugin-version-suffix:
@@ -448,23 +463,35 @@ jobs:
       - name: plugin-validator
         if: ${{ inputs.run-plugin-validator == true }}
         run: |
-          if [ ! -f ".plugin-validator.yaml" ]; then
-            echo "⚠️ .plugin-validator.yaml configuration file is missing. Providing a default one as fallback."
-            cat <<EOF > .plugin-validator.yaml
+          if [ ! -z "${PLUGIN_VALIDATOR_CONFIG_FILE}" ]; then
+            echo "Using provided plugin-validator configuration content."
+            echo "${PLUGIN_VALIDATOR_CONFIG_FILE}" > .plugin-validator.yaml
+            PLUGIN_VALIDATOR_CONFIG_PATH=.plugin-validator.yaml
+            cat ${PLUGIN_VALIDATOR_CONFIG_PATH}
+          elif [ -f "${PLUGIN_VALIDATOR_CONFIG_PATH}" ]; then
+            echo "Using plugin-validator configuration file at path: ${PLUGIN_VALIDATOR_CONFIG_PATH}"
+          fi
+
+          if [ ! -f "${PLUGIN_VALIDATOR_CONFIG_PATH}" ]; then
+            PLUGIN_VALIDATOR_CONFIG_PATH=".plugin-validator.yaml"
+            echo "⚠️ ${PLUGIN_VALIDATOR_CONFIG_PATH} configuration file is missing. Providing a default one as fallback."
+            cat <<EOF > "${PLUGIN_VALIDATOR_CONFIG_PATH}"
           global:
             enabled: true
             severity: warning
             reportAll: true
           EOF
           fi
-          #if [ -f validator-output.txt ]; then
-          #  cat >&2 validator-output.txt
-          #fi
+
+          echo "Using configuration:"
+          cat "${PLUGIN_VALIDATOR_CONFIG_PATH}"
+
+          # Do not run clamav because it takes too long (and because it would scan node_modules as well)
           docker run --name=plugin-validator --pull=always \
+            -v "$PWD/${PLUGIN_VALIDATOR_CONFIG_PATH}:/workspace/.plugin-validator.yaml:ro" \
             -v "$PWD/dist-artifacts:/workspace/dist-artifacts:ro" \
             -v "$PWD:/workspace:ro" \
             -e SKIP_CLAMAV=1 \
-            -e DEBUG=1 \
             grafana/plugin-validator-cli \
             -ghaOutput \
             -config=/workspace/.plugin-validator.yaml \
@@ -473,6 +500,8 @@ jobs:
           exit "$(docker inspect plugin-validator --format='{{.State.ExitCode}}')"
         env:
           UNIVERSAL_ZIP: ${{ steps.universal-zip.outputs.zip }}
+          PLUGIN_VALIDATOR_CONFIG_FILE: ${{ inputs.plugin-validator-config-file }}
+          PLUGIN_VALIDATOR_CONFIG_PATH: ${{ inputs.plugin-validator-config-path }}
         shell: bash
 
       - name: Define outputs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,6 +477,10 @@ jobs:
               echo "::error title=plugin-validator: missing config file::${PLUGIN_VALIDATOR_CONFIG_PATH} configuration file is missing."
               exit 1
             fi
+            if [[ -d "${PLUGIN_VALIDATOR_CONFIG_PATH}" ]]; then
+              echo "::error title=plugin-validator: invalid config file::${PLUGIN_VALIDATOR_CONFIG_PATH} is a directory, expected a file."
+              exit 1
+            fi
           else
             # Default hardcoded configuration
             PLUGIN_VALIDATOR_CONFIG_PATH=".plugin-validator.yaml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -454,7 +454,7 @@ jobs:
           global:
             enabled: true
             severity: warning
-            reportAll: false
+            reportAll: true
           EOF
           fi
           #if [ -f validator-output.txt ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -463,7 +463,7 @@ jobs:
       - name: plugin-validator
         if: ${{ inputs.run-plugin-validator == true }}
         run: |
-          if [ ! -z "${PLUGIN_VALIDATOR_CONFIG_FILE}" ]; then
+          if [ -n "${PLUGIN_VALIDATOR_CONFIG_FILE}" ]; then
             echo "Using provided plugin-validator configuration content."
             echo "${PLUGIN_VALIDATOR_CONFIG_FILE}" > .plugin-validator.yaml
             PLUGIN_VALIDATOR_CONFIG_PATH=.plugin-validator.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -494,7 +494,7 @@ jobs:
           docker run --name=plugin-validator --pull=always \
             -v "$PWD/${PLUGIN_VALIDATOR_CONFIG_PATH}:/workspace/.plugin-validator.yaml:ro" \
             -v "$PWD/dist-artifacts:/workspace/dist-artifacts:ro" \
-            -v "$PWD:/workspace:ro" \
+            -v "$PWD/${PLUGIN_DIRECTORY}:/workspace:ro" \
             -e SKIP_CLAMAV=1 \
             grafana/plugin-validator-cli \
             -ghaOutput \
@@ -506,6 +506,7 @@ jobs:
           UNIVERSAL_ZIP: ${{ steps.universal-zip.outputs.zip }}
           PLUGIN_VALIDATOR_CONFIG_FILE: ${{ inputs.plugin-validator-config-file }}
           PLUGIN_VALIDATOR_CONFIG_PATH: ${{ inputs.plugin-validator-config-path }}
+          PLUGIN_DIRECTORY: ${{ inputs.plugin-directory }}
         shell: bash
 
       - name: Define outputs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -463,6 +463,7 @@ jobs:
           docker run --name=plugin-validator --pull=always \
             -v "$PWD/dist-artifacts:/workspace/dist-artifacts:ro" \
             -v "$PWD:/workspace:ro" \
+            -e SKIP_CLAMAV=1 \
             grafana/plugin-validator-cli \
             -config=/workspace/.plugin-validator.yaml \
             -sourceCodeUri=file:///workspace \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -460,10 +460,11 @@ jobs:
           if [ -f validator-output.txt ]; then
             cat >&2 validator-output.txt
           fi
-          docker run --rm --pull=always \
+          docker run --name=plugin-validator --pull=always \
             -v "$PWD/dist-artifacts:/workspace/dist-artifacts:ro" \
             -v "$PWD/.plugin-validator.yaml:/workspace/.plugin-validator.yaml:ro" \
             grafana/plugin-validator-cli -config=/workspace/.plugin-validator.yaml "/workspace/dist-artifacts/${UNIVERSAL_ZIP}"
+          exit $(docker inspect plugin-validator --format='{{.State.ExitCode}}')
         env:
           UNIVERSAL_ZIP: ${{ steps.universal-zip.outputs.zip }}
         shell: bash

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -79,7 +79,7 @@ jobs:
       testing: true
       concurrency-prefix: plugin-validator-${{ matrix.plugin-validator-config-file }}
       plugin-directory: tests/simple-backend
-      dist-artifacts-prefix: custom-inputs
+      dist-artifacts-prefix: plugin-validator-${{ matrix.plugin-validator-config-file }}
       plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
       run-playwright: false
 

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -33,7 +33,7 @@ jobs:
           plugins=$(find . -maxdepth 1 -type d ! -name '.' -printf '%f\n' | jq -R . | jq -cs .)
           echo "plugin-directories=$plugins" >> "$GITHUB_OUTPUT"
 
-  simple-ci:
+  ci:
     name: CI
     needs: find-tests
     strategy:

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -68,6 +68,7 @@ jobs:
     uses: ./.github/workflows/ci.yml
     with:
       testing: true
+      concurrency-prefix: plugin-validator-
       plugin-directory: tests/simple-backend
       dist-artifacts-prefix: custom-inputs
       plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -62,18 +62,28 @@ jobs:
   
   ci-plugin-validator:
     name: CI plugin-validator
+    strategy:
+      matrix:
+        plugin-validator-config-file:
+          - ""
+          - |
+            global:
+              enabled: true
+              severity: warning
+              reportAll: false
     permissions:
       contents: read
       id-token: write
     uses: ./.github/workflows/ci.yml
     with:
       testing: true
-      concurrency-prefix: plugin-validator-
+      concurrency-prefix: plugin-validator-${{ matrix.plugin-validator-config-file }}
       plugin-directory: tests/simple-backend
       dist-artifacts-prefix: custom-inputs
       plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
       run-playwright: false
 
       run-plugin-validator: true
+      plugin-validator-config-file: ${{ matrix.plugin-validator-config-file }}
 
 

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -59,31 +59,5 @@ jobs:
 
       # TODO: enable in a follow-up PR
       run-playwright: false
-  
-  ci-plugin-validator:
-    name: CI plugin-validator
-    strategy:
-      matrix:
-        plugin-validator-config-file:
-          - ""
-          - |
-            global:
-              enabled: true
-              severity: warning
-              reportAll: false
-    permissions:
-      contents: read
-      id-token: write
-    uses: ./.github/workflows/ci.yml
-    with:
-      testing: true
-      concurrency-prefix: plugin-validator-${{ matrix.plugin-validator-config-file }}
-      plugin-directory: tests/simple-backend
-      dist-artifacts-prefix: plugin-validator-${{ matrix.plugin-validator-config-file }}
-      plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
-      run-playwright: false
 
       run-plugin-validator: true
-      plugin-validator-config-file: ${{ matrix.plugin-validator-config-file }}
-
-

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -33,7 +33,7 @@ jobs:
           plugins=$(find . -maxdepth 1 -type d ! -name '.' -printf '%f\n' | jq -R . | jq -cs .)
           echo "plugin-directories=$plugins" >> "$GITHUB_OUTPUT"
 
-  ci:
+  simple-ci:
     name: CI
     needs: find-tests
     strategy:
@@ -59,3 +59,20 @@ jobs:
 
       # TODO: enable in a follow-up PR
       run-playwright: false
+  
+  ci-plugin-validator:
+    name: CI plugin-validator
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/ci.yml
+    with:
+      testing: true
+      plugin-directory: tests/simple-backend
+      dist-artifacts-prefix: custom-inputs
+      plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
+      run-playwright: false
+
+      run-plugin-validator: true
+
+


### PR DESCRIPTION
Adds support for running plugin-validator as part of CI when input `run-plugin-validator: true` is passed to the workflow.

Part of #354.

Example runs can be found in the smoke tests for this PR, which have been updated to run the validator.

For example: https://github.com/grafana/plugin-ci-workflows/actions/runs/19139877974/job/54701694400?pr=366

(see the annotations at the top)