### PR TITLE
chore: add debug flag to Trufflehog run command

### DIFF
--- a/actions/internal/plugins/trufflehog/action.yml
+++ b/actions/internal/plugins/trufflehog/action.yml
@@ -40,7 +40,7 @@ runs:
     - name: Run Trufflehog
       shell: bash
       run: |
-        ./bin/trufflehog filesystem "${FOLDER}" \
+        ./bin/trufflehog filesystem "${FOLDER}" --debug \
         --no-update --fail --github-actions \
         --results=verified,unknown \
         --include-detectors="${INCLUDE_DETECTORS}" \


### PR DESCRIPTION
Recently, we had a [problem](https://github.com/grafana/grafana-csp-app/actions/runs/19228228083/job/54962202132) in the csp plugin with trufflehog returning an error in CI, but not giving us any more information.

Let's run the command with `--debug` so that we get more information about the errors.