### PR TITLE
fix: fix DEFAULT_TRUFFLEHOG_VERSION being ignored (latest version was always installed)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,7 +455,7 @@ jobs:
 
       - name: Trufflehog secrets scanning
         if: ${{ inputs.run-trufflehog == true }}
-        uses: grafana/plugin-ci-workflows/actions/internal/plugins/trufflehog@main
+        uses: grafana/plugin-ci-workflows/actions/internal/plugins/trufflehog@giuseppe/fix-trufflehog-version
         with:
           trufflehog-version: ${{ inputs.trufflehog-version || env.DEFAULT_TRUFFLEHOG_VERSION }}
           folder: dist-artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,7 +455,7 @@ jobs:
 
       - name: Trufflehog secrets scanning
         if: ${{ inputs.run-trufflehog == true }}
-        uses: grafana/plugin-ci-workflows/actions/internal/plugins/trufflehog@giuseppe/fix-trufflehog-version
+        uses: grafana/plugin-ci-workflows/actions/internal/plugins/trufflehog@main
         with:
           trufflehog-version: ${{ inputs.trufflehog-version || env.DEFAULT_TRUFFLEHOG_VERSION }}
           folder: dist-artifacts

--- a/actions/internal/plugins/trufflehog/action.yml
+++ b/actions/internal/plugins/trufflehog/action.yml
@@ -33,7 +33,7 @@ runs:
     - name: Install Trufflehog
       shell: bash
       run: |
-        curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/v${TRUFFLEHOG_VERSION}/scripts/install.sh | bash -s -- "${TRUFFLEHOG_VERSION}"
+        curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/v${TRUFFLEHOG_VERSION}/scripts/install.sh | bash -s -- "v${TRUFFLEHOG_VERSION}"
       env:
         TRUFFLEHOG_VERSION: ${{ inputs.trufflehog-version }}
 

--- a/actions/internal/plugins/trufflehog/action.yml
+++ b/actions/internal/plugins/trufflehog/action.yml
@@ -33,7 +33,7 @@ runs:
     - name: Install Trufflehog
       shell: bash
       run: |
-        curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/v${TRUFFLEHOG_VERSION}/scripts/install.sh | sh
+        curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/v${TRUFFLEHOG_VERSION}/scripts/install.sh | bash -s -- "${TRUFFLEHOG_VERSION}"
       env:
         TRUFFLEHOG_VERSION: ${{ inputs.trufflehog-version }}
 


### PR DESCRIPTION
Fixes an issue where the latest version of Trufflehog was always installed rather than the one specified in DEFAULT_TRUFFLEHOG_VERSION

Example run: https://github.com/grafana/plugin-ci-workflows/actions/runs/19329735544/job/55289581942

(the version returned by Trufflehog is now the same as the one specified in the workflow inputs)