### PR TITLE
fix: allow dependabot and renovate to access Vault

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,7 +334,7 @@ jobs:
 
             // Events that are considered trusted because can be run by a trusted user (unless it's a bot)
             const isTrustedEvent = ['push', 'workflow_dispatch'].includes(context.eventName);
-            const isTrusted = (isTrustedEvent || (isPR && !isForkPR)) && !isBot && !isTesting;
+            const isTrusted = (isTrustedEvent || (isPR && !isForkPR)) && !isTesting;
 
             const o = { isTrusted, isForkPR, isBot };
             console.log(JSON.stringify(o));


### PR DESCRIPTION
Dependabot and renovate can now access vault. This PR treats the bots as trusted, allowing the workflow to fetch secrets from Vault and run the whole CI pipeline for dependabot and renovate PRs.

For testing, I switched the branch of plugin-ci-workflows in plugins-drone-to-gha to this PR's branch, and that seems to work fine.

Example dependabot PR: https://github.com/grafana/plugins-drone-to-gha/pull/56

Example renovate PR: https://github.com/grafana/slo/pull/3908