### PR TITLE
chore: switch GitHub Actions runners to arm64

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -331,7 +331,7 @@ jobs:
 
   setup:
     name: Check and setup environment
-    runs-on: ubuntu-x64-small
+    runs-on: ubuntu-arm64-small
 
     outputs:
       commit-sha: ${{ steps.checkout-specified-branch.outputs.commit }}
@@ -480,7 +480,7 @@ jobs:
 
   define-variables:
     name: Define variables
-    runs-on: ubuntu-x64-small
+    runs-on: ubuntu-arm64-small
 
     needs:
       - ci
@@ -578,7 +578,7 @@ jobs:
       fail-fast: false
       matrix:
         environment: ${{ fromJson(needs.define-variables.outputs.environments) }}
-    runs-on: ubuntu-x64-small
+    runs-on: ubuntu-arm64-small
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -686,7 +686,7 @@ jobs:
 
   trigger-argo-workflow:
     name: Trigger Argo Workflow for Grafana Cloud deployment
-    runs-on: ubuntu-x64-small
+    runs-on: ubuntu-arm64-small
 
     needs:
       - ci
@@ -754,7 +754,7 @@ jobs:
   # tailored plugins catalog instead of using GCS.
   upload-to-gcs-release:
     name: Upload to GCS (release)
-    runs-on: ubuntu-x64-small
+    runs-on: ubuntu-arm64-small
 
     needs:
       - ci
@@ -982,7 +982,7 @@ jobs:
 
   create-github-release:
     name: Create GitHub Release
-    runs-on: ubuntu-x64-small
+    runs-on: ubuntu-arm64-small
     needs:
       - define-variables
       - ci

--- a/.github/workflows/check-examples-readmes.yml
+++ b/.github/workflows/check-examples-readmes.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   check-readme:
     name: Check if example/base/README.md is up-to-date
-    runs-on: ubuntu-x64-small
+    runs-on: ubuntu-arm64-small
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -623,7 +623,7 @@ jobs:
 
   upload-to-gcs:
     name: Upload to GCS
-    runs-on: ubuntu-x64-small
+    runs-on: ubuntu-arm64-small
 
     # Skip the GCS upload (no access to the bucket) for PRs when run in non-trusted context (forks)
     if: ${{ fromJson(needs.test-and-build.outputs.workflow-context).isTrusted }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   actionlint:
-    runs-on: ubuntu-x64-small
+    runs-on: ubuntu-arm64-small
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:

--- a/.github/workflows/playwright-docker.yml
+++ b/.github/workflows/playwright-docker.yml
@@ -59,7 +59,7 @@ permissions:
 jobs:
   resolve-versions:
     name: Resolve Grafana images
-    runs-on: ubuntu-x64-small
+    runs-on: ubuntu-arm64-small
     timeout-minutes: 3
     outputs:
       matrix: ${{ steps.resolve-versions.outputs.matrix }}
@@ -161,7 +161,7 @@ jobs:
   check-playwright-status:
     needs: playwright-tests
     name: Check Playwright E2E matrix status
-    runs-on: ubuntu-x64-small
+    runs-on: ubuntu-arm64-small
     if: always()
     steps:
       - name: Check matrix job status

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -77,7 +77,7 @@ permissions:
 jobs:
   resolve-versions:
     name: Resolve Grafana images
-    runs-on: ubuntu-x64-small
+    runs-on: ubuntu-arm64-small
     timeout-minutes: 3
     outputs:
       matrix: ${{ steps.resolve-versions.outputs.matrix }}
@@ -245,7 +245,7 @@ jobs:
   check-playwright-status:
     needs: playwright-tests
     name: Check Playwright E2E matrix status
-    runs-on: ubuntu-x64-small
+    runs-on: ubuntu-arm64-small
     if: always()
     steps:
       - name: Check matrix job status

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -15,7 +15,7 @@ jobs:
   check-title:
     permissions:
       pull-requests: read
-    runs-on: ubuntu-x64-small
+    runs-on: ubuntu-arm64-small
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   release-please:
-    runs-on: ubuntu-x64-small
+    runs-on: ubuntu-arm64-small
 
     permissions:
       contents: write # Needed to create releases and tags


### PR DESCRIPTION
Switch to self-hosted arm64 runners whenever possible because they are cheaper to run.