### PR TITLE
fix: only trust renovate and dependabot rather than all bots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,21 +341,20 @@ jobs:
         id: workflow-context
         with:
           script: |
-            const bots = [
+            const trustedBots = [
               'dependabot[bot]',
-              'renovate[bot]',
-              'github-actions[bot]',
               'renovate-sh-app[bot]'
             ].map((s) => s.toLowerCase());
 
             const isPR = context.eventName === 'pull_request';
-            const isBot = bots.includes(context.actor?.toLowerCase());
+            const isBot = context.actor?.toLowerCase().endsWith('[bot]');
+            const isTrustedBot = trustedBots.includes(context.actor?.toLowerCase());
             const isForkPR = isPR && context.payload.pull_request.head.repo.full_name !== context.payload.repository.full_name;
             const isTesting = process.env['INPUT_TESTING'] === 'true';
 
             // Events that are considered trusted because can be run by a trusted user (unless it's a bot)
             const isTrustedEvent = ['push', 'workflow_dispatch'].includes(context.eventName);
-            const isTrusted = (isTrustedEvent || (isPR && !isForkPR)) && !isTesting;
+            const isTrusted = (isTrustedEvent || (isPR && !isForkPR)) && !isTesting && (!isBot || isTrustedBot);
 
             const o = { isTrusted, isForkPR, isBot };
             console.log(JSON.stringify(o));

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,7 +356,7 @@ jobs:
             const isTrustedEvent = ['push', 'workflow_dispatch'].includes(context.eventName);
             const isTrusted = (isTrustedEvent || (isPR && !isForkPR)) && !isTesting && (!isBot || isTrustedBot);
 
-            const o = { isTrusted, isForkPR, isBot };
+            const o = { isTrusted, isForkPR };
             console.log(JSON.stringify(o));
             return o
         env:


### PR DESCRIPTION
Follow up to #381. Only trust self-hosted renovate and dependabot, do not trust any other bot.