### PR TITLE
Add package lock drift check to frontend action

### DIFF
--- a/actions/plugins/frontend/pm.sh
+++ b/actions/plugins/frontend/pm.sh
@@ -33,7 +33,21 @@ fi
 # Run the provided command with the detected package manager
 echo "Running '$1' with $pm..."
 if [ "$1" = "install" ]; then
-	"$pm" install
+	# Use CI-appropriate commands that fail if lock files are out of sync
+	case "$pm" in
+		npm)
+			npm ci
+			;;
+		pnpm)
+			pnpm install --frozen-lockfile
+			;;
+		yarn)
+			yarn install --frozen-lockfile
+			;;
+		*)
+			"$pm" install
+			;;
+	esac
 else
 	"$pm" run "$1"
 fi


### PR DESCRIPTION
## What this PR does

This PR adds a drift check after package installation in the frontend action to ensure lock files (, , or ) stay in sync with .

## Why this is needed

Currently, CI runs `npm install` (or equivalent) but doesn't verify if the lock file would be modified. This can allow out-of-sync lock files to slip through, causing:
- Inconsistent builds across environments
- Silent dependency changes that weren't reviewed
- Surprises when developers run `npm install` locally

## What this changes

Adds a new step after "Install dependencies" that checks if any lock files were modified by the install. If so, it fails CI with a clear error message asking developers to run install locally and commit the changes.

The check uses `git diff --exit-code` on all three common lock files and suppresses errors (2>/dev/null) so it works regardless of which package manager is in use.