### PR TITLE
Use CI-appropriate package manager commands (npm ci, etc.)

### DIFF
--- a/actions/internal/plugins/frontend/pm.sh
+++ b/actions/internal/plugins/frontend/pm.sh
@@ -33,7 +33,21 @@ fi
 # Run the provided command with the detected package manager
 echo "Running '$1' with $pm..."
 if [ "$1" = "install" ]; then
-	"$pm" install
+	# Use CI-appropriate commands that fail if lock files are out of sync
+	case "$pm" in
+		npm)
+			npm ci
+			;;
+		pnpm)
+			pnpm install --frozen-lockfile
+			;;
+		yarn)
+			yarn install --frozen-lockfile
+			;;
+		*)
+			"$pm" install
+			;;
+	esac
 else
 	"$pm" run "$1"
 fi


### PR DESCRIPTION
## Warning ⚠️ - developed by a GenAI agent

I (Sam) didn't write this code, nor this PR description! But I did get here from experiencing the issue myself, on a datasource I've been working on where Renovate has been making PRs. Each of those PRs was passing CI when I merged them, and yet I found drift on my `package-lock.json` file today.

## What this PR does

This PR updates the frontend action to use CI-appropriate package manager commands that automatically enforce lock file consistency.

## Changes

Updates `actions/internal/plugins/frontend/pm.sh` to use CI-optimized install commands:
- **npm**: `npm ci` instead of `npm install`
- **pnpm**: `pnpm install --frozen-lockfile`
- **yarn**: `yarn install --frozen-lockfile`

## Why this is needed

Currently, CI runs standard install commands (`npm install`, etc.) which don't fail if lock files are out of sync with `package.json`. This can allow drift to slip through, causing:
- Inconsistent builds across environments
- Silent dependency changes that weren't reviewed
- Surprises when developers run install locally and see unexpected changes

## Benefits of this approach

1. **Faster installs**: CI commands skip dependency resolution since lock files should already be resolved
2. **Automatic drift detection**: These commands fail if lock files don't match `package.json`
3. **Cleaner installs**: `npm ci` removes `node_modules` first for a fresh install
4. **CI best practice**: Using commands explicitly designed for CI environments
5. **No separate drift check needed**: The install itself enforces consistency

## Testing

The CI-appropriate commands are well-established best practices:
- `npm ci` has been the recommended CI command since npm 5.7.0 (2018)
- `--frozen-lockfile` is the standard flag for pnpm and yarn in CI

This change should be backward compatible - existing plugins will see faster, stricter installs.

## Draft Status

Opening as draft to gather feedback on this approach before merging.
