### PR TITLE
feat: block workflow if pinned to a commit hash rather than a tag/branch reference

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -312,11 +312,11 @@ on:
         type: string
 
       # Options for testing the workflow itself.
-      allow-pinned-commit-hashes:
+      DO-NOT-USE-allow-pinned-commit-hashes:
         description: |
+          FOR INTERNAL TESTING ONLY, DO NOT USE.
           If `true`, skip hard fail in case the workflow is pinned to a commit hash.
           Vault access may still fail in such cases, depending on the WIF policies in place.
-          This should only be used for testing repositories and should not be changed in most cases.
         type: boolean
         required: false
         default: false
@@ -458,7 +458,7 @@ jobs:
       allow-unsigned: ${{ inputs.allow-unsigned }}
       signature-type: ${{ inputs.signature-type }}
 
-      allow-pinned-commit-hashes: ${{ inputs.allow-pinned-commit-hashes }}
+      DO-NOT-USE-allow-pinned-commit-hashes: ${{ inputs.DO-NOT-USE-allow-pinned-commit-hashes }}
 
   build-attestation:
     name: Build attestation

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -311,6 +311,16 @@ on:
         default: main
         type: string
 
+      # Options for testing the workflow itself.
+      allow-pinned-commit-hashes:
+        description: |
+          If `true`, skip hard fail in case the workflow is pinned to a commit hash.
+          Vault access may still fail in such cases, depending on the WIF policies in place.
+          This should only be used for testing repositories and should not be changed in most cases.
+        type: boolean
+        required: false
+        default: false
+
 concurrency:
   group: cd-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -447,6 +457,8 @@ jobs:
 
       allow-unsigned: ${{ inputs.allow-unsigned }}
       signature-type: ${{ inputs.signature-type }}
+
+      allow-pinned-commit-hashes: ${{ inputs.allow-pinned-commit-hashes }}
 
   build-attestation:
     name: Build attestation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -607,6 +607,9 @@ jobs:
   docs:
     name: Test docs
     runs-on: ubuntu-latest
+    needs:
+      # Not strictly necessary, but makes sure we fail fast if the workflow is misconfigured
+      - check-for-release-channel
     container:
       image: grafana/docs-base:latest # zizmor: ignore[unpinned-images]
       volumes:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,6 +353,10 @@ jobs:
     name: Test and build plugin
     runs-on: ubuntu-x64-large
 
+    needs:
+      # Not strictly necessary, but makes sure we fail fast if the workflow is misconfigured
+      - check-for-release-channel
+
     outputs:
       plugin: ${{ steps.outputs.outputs.plugin }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,11 +235,11 @@ on:
         type: string
         required: false
         default: ""
-      allow-pinned-commit-hashes:
+      DO-NOT-USE-allow-pinned-commit-hashes:
         description: |
+          FOR INTERNAL TESTING ONLY, DO NOT USE.
           If `true`, skip hard fail in case the workflow is pinned to a commit hash.
           Vault access may still fail in such cases, depending on the WIF policies in place.
-          This should only be used for testing repositories and should not be changed in most cases.
         type: boolean
         required: false
         default: false
@@ -346,7 +346,7 @@ jobs:
             fi
           fi
         env:
-          ALLOW_PINNED_COMMIT_HASHES: ${{ inputs.allow-pinned-commit-hashes }}
+          ALLOW_PINNED_COMMIT_HASHES: ${{ inputs.DO-NOT-USE-allow-pinned-commit-hashes }}
         shell: bash
 
   test-and-build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,8 +299,8 @@ env:
   VAULT_INSTANCE: ops
 
 jobs:
-  check-for-rolling-releases:
-    name: Check for rolling releases channel
+  check-for-release-channel:
+    name: Check for release channel
     runs-on: ubuntu-arm64-small
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,7 +337,7 @@ jobs:
           Please pin to a specific tagged release instead. \
           For more information, refer to the docs: https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#versions-and-release-channels"
 
-            echo "::warning title=$title::$message"
+            echo "::error title=$title::$message"
             if [ "${ALLOW_PINNED_COMMIT_HASHES}" != "true" ]; then
               # Hard fail by default
               exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,14 @@ on:
         type: string
         required: false
         default: ""
+      allow-pinned-commit-hashes:
+        description: |
+          If `true`, skip hard fail in case the workflow is pinned to a commit hash.
+          Vault access may still fail in such cases, depending on the WIF policies in place.
+          This should only be used for testing repositories and should not be changed in most cases.
+        type: boolean
+        required: false
+        default: false
 
     outputs:
       plugin:
@@ -305,7 +313,7 @@ jobs:
             echo "Found usage of rolling releases channel in the following files:"
             echo "$diff"
 
-            title="Rolling release channel detected"
+            title="Detected plugin-ci-workflows rolling release channel"
             message="You are using workflows from plugin-ci-workflows rolling releases channel (\`@main\`). \
           This is discouraged as it may lead to unexpected breaking changes. \
           Please pin to a specific tagged release to ensure better stability. \
@@ -314,6 +322,31 @@ jobs:
             echo "::warning title=$title::$message"
             exit 0
           fi
+        shell: bash
+
+      - name: Check for plugin-ci-workflows pinned to commit hash
+        run: |
+          diff=$(grep -E 'grafana/plugin-ci-workflows.+@[0-9a-f]{6,40}' -rn .github/workflows/ || true)
+          if [[ -n "$diff" ]]; then
+            echo "Found plugin-ci-workflows pinned to a commit hash in the following files:"
+            echo "$diff"
+
+            title="Detected plugin-ci-workflows pinned to a commit hash"
+            message="You are pinning plugin-ci-workflows to a commit hash. \
+          To limit the amount of exposure (security reasons), this is not allowed and the workflow will fail. \
+          Please pin to a specific tagged release instead. \
+          For more information, refer to the docs: https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#versions-and-release-channels"
+
+            echo "::warning title=$title::$message"
+            if [ "${ALLOW_PINNED_COMMIT_HASHES}" != "true" ]; then
+              # Hard fail by default
+              exit 1
+            else
+              exit 0
+            fi
+          fi
+        env:
+          ALLOW_PINNED_COMMIT_HASHES: ${{ inputs.allow-pinned-commit-hashes }}
         shell: bash
 
   test-and-build:


### PR DESCRIPTION
Fixes #390

Example run: https://github.com/grafana/plugins-drone-to-gha/actions/runs/19666546818?pr=63

BEGIN_COMMIT_OVERRIDE
feat: add a more user-friendly error when pinning plugin-ci-workflows to a commit hash
feat: block workflow if pinned to a commit hash rather than a tag/branch reference
chore: changed warning message for rolling release channel detection
END_COMMIT_OVERRIDE