### PR TITLE
chore: add ACTIONLINT_VERSION to simplify actionlint version bumps

### DIFF
--- a/.github/workflows/pr-checks-lint.yml
+++ b/.github/workflows/pr-checks-lint.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Download actionlint
         id: get_actionlint
         run: |
-          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/v${ACTIONLINT_VERSION}/scripts/download-actionlint.bash) "${ACTIONLINT_VERSION}" /usr/bin
+          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/v${ACTIONLINT_VERSION}/scripts/download-actionlint.bash) "${ACTIONLINT_VERSION}" /usr/local/bin
         shell: bash
         env:
           ACTIONLINT_VERSION: ${{ env.ACTIONLINT_VERSION }}

--- a/.github/workflows/pr-checks-lint.yml
+++ b/.github/workflows/pr-checks-lint.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/pr-checks-lint.yml
+++ b/.github/workflows/pr-checks-lint.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Download actionlint
         id: get_actionlint
         run: |
-          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/v${ACTIONLINT_VERSION}/scripts/download-actionlint.bash) "${ACTIONLINT_VERSION}" /usr/local/bin
+          bash <(curl "https://raw.githubusercontent.com/rhysd/actionlint/v${ACTIONLINT_VERSION}/scripts/download-actionlint.bash") "${ACTIONLINT_VERSION}" "/usr/local/bin"
         shell: bash
         env:
           ACTIONLINT_VERSION: ${{ env.ACTIONLINT_VERSION }}

--- a/.github/workflows/pr-checks-lint.yml
+++ b/.github/workflows/pr-checks-lint.yml
@@ -10,6 +10,9 @@ on:
 permissions:
   contents: read
 
+env:
+  ACTIONLINT_VERSION: v1.7.3
+
 jobs:
   actionlint:
     runs-on: ubuntu-arm64-small
@@ -21,12 +24,12 @@ jobs:
         run: echo "::add-matcher::.github/actionlint-matcher.json"
       - name: Download actionlint
         id: get_actionlint
-        # v1.7.3
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/5db9d9cde2f3deb5035dea3e45f0a9fff2f29448/scripts/download-actionlint.bash)
+        run: |
+          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/${ACTIONLINT_VERSION}/scripts/download-actionlint.bash) "${ACTIONLINT_VERSION}" /usr/bin
         shell: bash
+        env:
+          ACTIONLINT_VERSION: ${{ env.ACTIONLINT_VERSION }}
       - name: Check workflow files
-        # This workflow comes from the testing instructions of the actionlint project.
-        # This templated run be safe because the install script is pinned and the output is pretty much fixed.
-        # zizmor: ignore[template-injection]
-        run: ${{ steps.get_actionlint.outputs.executable }} -color
+        run: |
+          actionlint -color
         shell: bash

--- a/.github/workflows/pr-checks-lint.yml
+++ b/.github/workflows/pr-checks-lint.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 env:
-  ACTIONLINT_VERSION: v1.7.3
+  ACTIONLINT_VERSION: "1.7.3"
 
 jobs:
   actionlint:
@@ -25,7 +25,7 @@ jobs:
       - name: Download actionlint
         id: get_actionlint
         run: |
-          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/${ACTIONLINT_VERSION}/scripts/download-actionlint.bash) "${ACTIONLINT_VERSION}" /usr/bin
+          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/v${ACTIONLINT_VERSION}/scripts/download-actionlint.bash) "${ACTIONLINT_VERSION}" /usr/bin
         shell: bash
         env:
           ACTIONLINT_VERSION: ${{ env.ACTIONLINT_VERSION }}


### PR DESCRIPTION
As per title. This makes it easier to bump with renovate. Related to #385 

BEGIN_COMMIT_OVERRIDE
chore: add ACTIONLINT_VERSION to simplify actionlint version bumps
chore: add concurrency to actionlint job
END_COMMIT_OVERRIDE