### PR TITLE
fix: trust grafana-plugins-platform-bot[bot]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,7 +380,9 @@ jobs:
           script: |
             const trustedBots = [
               'dependabot[bot]',
-              'renovate-sh-app[bot]'
+              'renovate-sh-app[bot]',
+              // Used by other shared workflows such as the version bump workflow
+              'grafana-plugins-platform-bot[bot]'
             ].map((s) => s.toLowerCase());
 
             const isPR = context.eventName === 'pull_request';


### PR DESCRIPTION
Trusts grafana-plugins-platform-bot[bot], which is used by other workflows such as the version bump changelog:

https://github.com/grafana/plugin-ci-workflows/blob/f2c945af2f13d37c5ebfa544b549f09fd01c56c1/actions/plugins/version-bump-changelog/action.yml#L40-L46

Example failure: https://github.com/grafana/metrics-drilldown/actions/runs/19678653226/job/56367465845