### PR TITLE
chore: build and package plugin in its directory, better support for artifact prefix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,6 +403,7 @@ jobs:
           INPUT_TESTING: ${{ inputs.testing }}
 
       - name: Setup
+        id: setup
         uses: grafana/plugin-ci-workflows/actions/internal/plugins/setup@main
         with:
           # The priority to setup the node version is:
@@ -476,6 +477,7 @@ jobs:
         working-directory: ${{ inputs.plugin-directory }}
 
       - name: Test and build frontend
+        id: frontend
         uses: grafana/plugin-ci-workflows/actions/internal/plugins/frontend@main
         with:
           package-manager: ${{ inputs.package-manager }}
@@ -484,6 +486,7 @@ jobs:
           npm-registry-auth: ${{ inputs.npm-registry-auth }}
 
       - name: Test and build backend
+        id: backend
         if: ${{ steps.check-for-backend.outputs.has-backend == 'true' }}
         uses: grafana/plugin-ci-workflows/actions/internal/plugins/backend@main
         with:
@@ -496,8 +499,8 @@ jobs:
         uses: grafana/plugin-ci-workflows/actions/internal/plugins/package@main
         with:
           universal: "true"
-          dist-folder: dist
-          output-folder: dist-artifacts
+          dist-folder: ${{ inputs.plugin-directory }}/dist
+          output-folder: ${{ inputs.plugin-directory }}/dist-artifacts
           access-policy-token: ${{ fromJson(steps.workflow-context.outputs.result).isTrusted && fromJSON(steps.get-secrets.outputs.secrets).SIGN_PLUGIN_ACCESS_POLICY_TOKEN || '' }}
           allow-unsigned: ${{ ((inputs.environment == 'dev' || inputs.environment == '' || inputs.environment == 'none') && !(fromJson(steps.workflow-context.outputs.result).isTrusted)) || inputs.allow-unsigned }}
           signature-type: ${{ inputs.signature-type }}
@@ -507,8 +510,8 @@ jobs:
         uses: grafana/plugin-ci-workflows/actions/internal/plugins/package@main
         with:
           universal: "false"
-          dist-folder: dist
-          output-folder: dist-artifacts
+          dist-folder: ${{ inputs.plugin-directory }}/dist
+          output-folder: ${{ inputs.plugin-directory }}/dist-artifacts
           access-policy-token: ${{ fromJson(steps.workflow-context.outputs.result).isTrusted && fromJSON(steps.get-secrets.outputs.secrets).SIGN_PLUGIN_ACCESS_POLICY_TOKEN || '' }}
           allow-unsigned: ${{ ((inputs.environment == 'dev' || inputs.environment == '' || inputs.environment == 'none') && !(fromJson(steps.workflow-context.outputs.result).isTrusted)) || inputs.allow-unsigned }}
           signature-type: ${{ inputs.signature-type }}
@@ -518,7 +521,7 @@ jobs:
         uses: grafana/plugin-ci-workflows/actions/internal/plugins/trufflehog@main
         with:
           trufflehog-version: ${{ inputs.trufflehog-version || env.DEFAULT_TRUFFLEHOG_VERSION }}
-          folder: dist-artifacts
+          folder: ${{ inputs.plugin-directory }}/dist-artifacts
           include-detectors: ${{ inputs.trufflehog-include-detectors }}
           exclude-detectors: ${{ inputs.trufflehog-exclude-detectors }}
 
@@ -557,7 +560,7 @@ jobs:
           # Do not run clamav because it takes too long
           docker run --name=plugin-validator --pull=always \
             -v "$PWD/${PLUGIN_VALIDATOR_CONFIG_PATH}:/workspace/.plugin-validator.yaml:ro" \
-            -v "$PWD/dist-artifacts:/workspace/dist-artifacts:ro" \
+            -v "$PWD/${PLUGIN_DIRECTORY}/dist-artifacts:/workspace/dist-artifacts:ro" \
             -v "$PWD/${PLUGIN_DIRECTORY}:/workspace" \
             -v "/tmp/empty:/workspace/node_modules" \
             -e SKIP_CLAMAV=1 \
@@ -579,10 +582,10 @@ jobs:
         run: |
           {
             echo plugin="$(jq -n -c \
-                --arg id "$(jq -r .id dist/plugin.json)" \
-                --arg version "$(jq -r .info.version dist/plugin.json)" \
+                --arg id "$(jq -r .id ${PLUGIN_DIRECTORY}/dist/plugin.json)" \
+                --arg version "$(jq -r .info.version ${PLUGIN_DIRECTORY}/dist/plugin.json)" \
                 --arg has-backend "${HAS_BACKEND}" \
-                --arg executable "$(jq -r .executable dist/plugin.json)" \
+                --arg executable "$(jq -r .executable ${PLUGIN_DIRECTORY}/dist/plugin.json)" \
                 '$ARGS.named'
               )"
 
@@ -595,6 +598,7 @@ jobs:
           }  >> "$GITHUB_OUTPUT"
           cat "$GITHUB_OUTPUT"
         env:
+          PLUGIN_DIRECTORY: ${{ inputs.plugin-directory }}
           HAS_BACKEND: ${{ steps.check-for-backend.outputs.has-backend }}
           UNIVERSAL_ZIP: ${{ steps.universal-zip.outputs.zip }}
           OS_ARCH_ZIPS: ${{ steps.os-arch-zips.outputs.zip }}
@@ -604,7 +608,7 @@ jobs:
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: ${{ inputs.dist-artifacts-prefix }}dist-artifacts
-          path: dist-artifacts/
+          path: ${{ inputs.plugin-directory }}/dist-artifacts/
           retention-days: 7
 
   docs:
@@ -707,7 +711,7 @@ jobs:
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: ${{ inputs.dist-artifacts-prefix }}dist-artifacts
-          path: /tmp/dist-artifacts
+          path: /tmp/${{ inputs.dist-artifacts-prefix }}dist-artifacts
 
       - name: Login to Google Cloud
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
@@ -734,7 +738,7 @@ jobs:
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main'}}
         uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3.0.0
         with:
-          path: /tmp/dist-artifacts
+          path: /tmp/${{ inputs.dist-artifacts-prefix }}dist-artifacts
           destination: ${{ env.gcs_artifacts_path_latest }}
           parent: false
           process_gcloudignore: false
@@ -743,7 +747,7 @@ jobs:
         id: gcs-upload-commit
         uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3.0.0
         with:
-          path: /tmp/dist-artifacts
+          path: /tmp/${{ inputs.dist-artifacts-prefix }}dist-artifacts
           destination: ${{ env.gcs_artifacts_path_commit }}
           parent: false
           process_gcloudignore: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -581,9 +581,12 @@ jobs:
         id: outputs
         run: |
           {
+            ID=$(jq -r .id "${PLUGIN_DIRECTORY}/dist/plugin.json")
+            VERSION=$(jq -r .info.version "${PLUGIN_DIRECTORY}/dist/plugin.json")
+
             echo plugin="$(jq -n -c \
-                --arg id "$(jq -r .id ${PLUGIN_DIRECTORY}/dist/plugin.json)" \
-                --arg version "$(jq -r .info.version ${PLUGIN_DIRECTORY}/dist/plugin.json)" \
+                --arg id "${ID}" \
+                --arg version "${VERSION}" \
                 --arg has-backend "${HAS_BACKEND}" \
                 --arg executable "$(jq -r .executable ${PLUGIN_DIRECTORY}/dist/plugin.json)" \
                 '$ARGS.named'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -583,12 +583,13 @@ jobs:
           {
             ID=$(jq -r .id "${PLUGIN_DIRECTORY}/dist/plugin.json")
             VERSION=$(jq -r .info.version "${PLUGIN_DIRECTORY}/dist/plugin.json")
+            EXECUTABLE=$(jq -r .executable "${PLUGIN_DIRECTORY}/dist/plugin.json")
 
             echo plugin="$(jq -n -c \
                 --arg id "${ID}" \
                 --arg version "${VERSION}" \
                 --arg has-backend "${HAS_BACKEND}" \
-                --arg executable "$(jq -r .executable ${PLUGIN_DIRECTORY}/dist/plugin.json)" \
+                --arg executable "${EXECUTABLE}" \
                 '$ARGS.named'
               )"
 

--- a/actions/internal/plugins/frontend/action.yml
+++ b/actions/internal/plugins/frontend/action.yml
@@ -79,16 +79,3 @@ runs:
       run: ${{ github.action_path }}/pm.sh build
       env:
         PACKAGE_MANAGER: ${{ inputs.package-manager }}
-
-    # The action should end up with a dist/ folder, but if the working directory is not the root of the repo,
-    # we need to copy the dist/ folder to the root of the repo.
-    - name: Copy dist if needed
-      run: |
-        if [ "$PLUGIN_DIRECTORY" != "." ]; then
-          mkdir -p dist
-          cp -r $PLUGIN_DIRECTORY/dist/* dist/
-        fi
-      shell: bash
-      if: inputs.plugin-directory != '.'
-      env:
-        PLUGIN_DIRECTORY: ${{ inputs.plugin-directory }}

--- a/actions/internal/plugins/package/package.sh
+++ b/actions/internal/plugins/package/package.sh
@@ -110,6 +110,8 @@ for file in $(find "$backend_folder" -type f -name "${exe_basename}_*"); do
     # Copy all files but the executables
     mkdir -p "$plugin_id"
     rsync -a --exclude "${exe_basename}*" "$dist/" "$plugin_id"
+    # TODO: this instead of rsync
+    # find "$dist" -type f ! -name "${exe_basename}*" -exec cp --parents {} "$plugin_id" \;
 
     # Copy only the current executable
     cp "$dist/$file" "$plugin_id/$backend_folder"

--- a/actions/internal/plugins/setup/action.yml
+++ b/actions/internal/plugins/setup/action.yml
@@ -35,7 +35,12 @@ runs:
       if: ${{ env.ACT }}
       shell: bash
       run: |
-        npm install -g yarn
+        # Double-check if yarn is installed, as it may be installed by another test
+        # running in parallel and sharing the same act-toolcache volume.
+        # If try to install yarn twice, we get an "ENOTEMPTY: directory not empty" error.
+        if ! command -v yarn >/dev/null 2>&1; then
+          npm install -g yarn
+        fi
         apt-get update
         apt-get install -y rsync
 


### PR DESCRIPTION
Second part of splitting #401 into smaller PRs.

First part: #417

As part of #397 , this PR:

- Adds ids to all the important steps in ci, to allow mocking them (referencing them by id) in act tests
- Better use of the `plugin-directory` input for act tests, to allow running CI on the testdata plugins via act in parallel on the same GHA runner/VM:
  - Before, the testdata plugin would be built in `/dist` (where `/` is the repo root) and the dist artifacts would always be downloaded to `/tmp/dist-artifacts`, even if the plugin does not live in the root of the repo. This is fine if in the runner we have one repo with one plugin. If we have multiple plugins in the repo and ONE runner building multiple plugins in parallel, all the different plugins would use the same `/dist` and `/tmp/dist-artifacts` directories and files from different test runs/plugins would clash with each other
  - With this PR, the plugin is built and packaged in `/<plugin_directory>/dist` (in other words, next to its `package.json` file), and the artifacts are stored in `/tmp/<dist-artfacts-prefix>dist-artifacts`. This allows building multiple testdata plugins on the same GHA runner (VM). Each testdata plugin uses its own folders and multiple plugins don't clash with each other.
- Other smaller improvements to the ci and plugin actions to better work with act tests  