### PR TITLE
test(act): fix main branch of plugin-ci-workflows not mapped to local repo

### DIFF
--- a/tests/act/internal/act/act.go
+++ b/tests/act/internal/act/act.go
@@ -98,7 +98,7 @@ func (r *Runner) args(workflowFile string, payloadFile string) ([]string, error)
 
 // localRepositoryArgs returns act CLI arguments to map local references of plugin-ci-workflows
 // to the local repository based on release-please configuration and manifest.
-// It adds a CLI flag for each release-please component.
+// It adds a CLI flag for each release-please component and the main branch.
 func (r *Runner) localRepositoryArgs() ([]string, error) {
 	var args []string
 

--- a/tests/act/internal/act/act.go
+++ b/tests/act/internal/act/act.go
@@ -143,6 +143,7 @@ func (r *Runner) localRepositoryArgs() ([]string, error) {
 		tag := releasePleasePackage.PackageName + "/v" + tag
 		args = append(args, "--local-repository=grafana/plugin-ci-workflows@"+tag+"="+pciwfRoot)
 	}
+	args = append(args, "--local-repository=grafana/plugin-ci-workflows@main="+pciwfRoot)
 	return args, nil
 }
 


### PR DESCRIPTION
Small fix for act tests, so the `@main` reference is mapped to the local repo when running act tests on pull requests