### PR TITLE
fix: use local exec for playwright test

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -236,7 +236,7 @@ jobs:
 
       - name: Run Playwright tests
         id: run-tests
-        run: ${{ steps.package-manager.outputs.execCmd }} playwright test --config "${PLAYWRIGHT_CONFIG}"
+        run: ${{ steps.package-manager.outputs.execLocalCmd }} playwright test --config "${PLAYWRIGHT_CONFIG}"
         env:
           PLAYWRIGHT_CONFIG: ${{ inputs.playwright-config }}
           GRAFANA_VERSION: ${{ matrix.GRAFANA_IMAGE.VERSION }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -180,7 +180,7 @@ jobs:
           key: playwright-${{ steps.version.outputs.version }}
 
       - name: Install Playwright Browsers
-        run: ${{ steps.package-manager.outputs.execCmd }} playwright install --with-deps chromium
+        run: ${{ steps.package-manager.outputs.execLocalCmd }} playwright install --with-deps chromium
         shell: bash
 
       - name: Download GitHub artifact


### PR DESCRIPTION
`Yarn dlx` creates a temp env which breaks playwright test.