### PR TITLE
fix(ci)!: small fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -789,8 +789,8 @@ jobs:
 
           universal_zip_file_name=$(basename "${UNIVERSAL_ZIP}")
           if [ -n "$universal_zip_file_name" ]; then
-            echo universal_zip_url_latest="$gcs_artifacts_path_latest/$universal_zip_file_name" >> "$GITHUB_OUTPUT"
-            echo universal_zip_url_commit="$gcs_artifacts_path_commit/$universal_zip_file_name" >> "$GITHUB_OUTPUT"
+            echo universal_zip_url_latest="https://storage.googleapis.com/$gcs_artifacts_path_latest/$universal_zip_file_name" >> "$GITHUB_OUTPUT"
+            echo universal_zip_url_commit="https://storage.googleapis.com/$gcs_artifacts_path_commit/$universal_zip_file_name" >> "$GITHUB_OUTPUT"
           fi
         env:
           GCS_UPLOADED_FILES_LATEST: ${{ steps.gcs-upload-latest.outputs.uploaded }}

--- a/actions/internal/plugins/backend/action.yml
+++ b/actions/internal/plugins/backend/action.yml
@@ -62,15 +62,3 @@ runs:
       working-directory: ${{ inputs.plugin-directory }}
       shell: bash
 
-    # The action should end up with a dist/ folder, but if the working directory is not the root of the repo,
-    # we need to copy the dist/ folder to the root of the repo.
-    - name: Copy dist if needed
-      run: |
-        if [ "$PLUGIN_DIRECTORY" != "." ]; then
-          mkdir -p dist
-          cp -r $PLUGIN_DIRECTORY/dist/* dist/
-        fi
-      shell: bash
-      env:
-        PLUGIN_DIRECTORY: ${{ inputs.plugin-directory }}
-      if: inputs.plugin-directory != '.'


### PR DESCRIPTION
Small fixes for ci workflow:

- It's not necessary to build the backend back into the "dist" folder, ci can now properly handle repos where the plugin is not in the root (similar to https://github.com/grafana/plugin-ci-workflows/pull/438/changes#r2603439434, but for backend)
- Fixed an issue where the `universal-zip-url-latest` and `universal-zip-url-commit` outputs of the CI job were paths rather than URLs, as specified by the name. I did a quick search on the usage, and no third-party workflows are using those outputs in the Grafana org (just to be sure, I am marking it as a breaking change anyways)

BEGIN_COMMIT_OVERRIDE
fix(ci): do not copy backend into the "dist" folder
fix(ci)!: `universal-zip-url-*` outputs are now URLs rather than paths
END_COMMIT_OVERRIDE