### PR TITLE
fix(tests): fix act checkout in pull_request events

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -367,8 +367,8 @@ jobs:
         id: checkout-specified-branch
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          # Force main ref when running in act (it copies files locally, it breaks if we specify another ref)
-          ref: ${{ !github.event.act && inputs.branch || 'main' }}
+          # Force exact ref when running in act (it copies files locally, it breaks if we specify another ref)
+          ref: ${{ !github.event.act && inputs.branch || github.sha }}
           persist-credentials: false
 
       - name: Determine plugin version suffix
@@ -585,8 +585,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          # Force main ref when running in act (it copies files locally, it breaks if we specify another ref)
-          ref: ${{ !github.event.act && inputs.branch || 'main' }}
+          # Force exact ref when running in act (it copies files locally, it breaks if we specify another ref)
+          ref: ${{ !github.event.act && inputs.branch || github.sha }}
           persist-credentials: false
 
       - name: Determine if it should continue the pipeline if a publishing conflict was detected
@@ -956,8 +956,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          # Force main ref when running in act (it copies files locally, it breaks if we specify another ref)
-          ref: ${{ !github.event.act && inputs.branch || 'main' }}
+          # Force exact ref when running in act (it copies files locally, it breaks if we specify another ref)
+          ref: ${{ !github.event.act && inputs.branch || github.sha }}
           persist-credentials: false
 
       - name: Get secrets from Vault
@@ -1004,8 +1004,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          # Force main ref when running in act (it copies files locally, it breaks if we specify another ref)
-          ref: ${{ !github.event.act && inputs.branch || 'main' }}
+          # Force exact ref when running in act (it copies files locally, it breaks if we specify another ref)
+          ref: ${{ !github.event.act && inputs.branch || github.sha }}
           persist-credentials: false
 
       - name: Download GitHub artifact

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -367,7 +367,8 @@ jobs:
         id: checkout-specified-branch
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          ref: ${{ inputs.branch }}
+          # Force main ref when running in act (it copies files locally, it breaks if we specify another ref)
+          ref: ${{ !github.event.act && inputs.branch || 'main' }}
           persist-credentials: false
 
       - name: Determine plugin version suffix
@@ -584,7 +585,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          ref: ${{ inputs.branch }}
+          # Force main ref when running in act (it copies files locally, it breaks if we specify another ref)
+          ref: ${{ !github.event.act && inputs.branch || 'main' }}
           persist-credentials: false
 
       - name: Determine if it should continue the pipeline if a publishing conflict was detected
@@ -954,7 +956,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          ref: ${{ inputs.branch }}
+          # Force main ref when running in act (it copies files locally, it breaks if we specify another ref)
+          ref: ${{ !github.event.act && inputs.branch || 'main' }}
           persist-credentials: false
 
       - name: Get secrets from Vault
@@ -1001,7 +1004,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          ref: ${{ inputs.branch }}
+          # Force main ref when running in act (it copies files locally, it breaks if we specify another ref)
+          ref: ${{ !github.event.act && inputs.branch || 'main' }}
           persist-credentials: false
 
       - name: Download GitHub artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,7 +366,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          ref: ${{ inputs.branch }}
+          ref: ${{ !github.event.act && inputs.branch || '' }}
           persist-credentials: false
 
       - name: Determine workflow context
@@ -632,7 +632,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          ref: ${{ inputs.branch }}
+          ref: ${{ !github.event.act && inputs.branch || '' }}
           persist-credentials: false
 
       - name: Check docs exist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,7 +366,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          ref: ${{ !github.event.act && inputs.branch || '' }}
+          # Force main ref when running in act (it copies files locally, it breaks if we specify another ref)
+          ref: ${{ !github.event.act && inputs.branch || 'main' }}
           persist-credentials: false
 
       - name: Determine workflow context
@@ -632,7 +633,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          ref: ${{ !github.event.act && inputs.branch || '' }}
+          # Force main ref when running in act (it copies files locally, it breaks if we specify another ref)
+          ref: ${{ !github.event.act && inputs.branch || 'main' }}
           persist-credentials: false
 
       - name: Check docs exist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,8 +366,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          # Force main ref when running in act (it copies files locally, it breaks if we specify another ref)
-          ref: ${{ !github.event.act && inputs.branch || 'main' }}
+          # Force exact ref when running in act (it copies files locally, it breaks if we specify another ref)
+          ref: ${{ !github.event.act && inputs.branch || github.sha }}
           persist-credentials: false
 
       - name: Determine workflow context
@@ -633,8 +633,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          # Force main ref when running in act (it copies files locally, it breaks if we specify another ref)
-          ref: ${{ !github.event.act && inputs.branch || 'main' }}
+          # Force exact ref when running in act (it copies files locally, it breaks if we specify another ref)
+          ref: ${{ !github.event.act && inputs.branch || github.sha }}
           persist-credentials: false
 
       - name: Check docs exist

--- a/tests/act/internal/act/act.go
+++ b/tests/act/internal/act/act.go
@@ -90,7 +90,7 @@ func NewRunner(t *testing.T) (*Runner, error) {
 }
 
 // args returns the CLI arguments to pass to act for the given workflow and event payload files.
-func (r *Runner) args(workflowFile string, payloadFile string) ([]string, error) {
+func (r *Runner) args(eventKind EventKind, workflowFile string, payloadFile string) ([]string, error) {
 	// Get a unique free port for the act artifact server, so multiple act instances can run in parallel
 	artifactServerPort, err := getFreePort()
 	if err != nil {
@@ -98,6 +98,10 @@ func (r *Runner) args(workflowFile string, payloadFile string) ([]string, error)
 	}
 
 	args := []string{
+		// Positional args: event kind
+		string(eventKind),
+
+		// Flags
 		"-W", workflowFile,
 		"-e", payloadFile,
 		"--rm",
@@ -182,7 +186,7 @@ func (r *Runner) localRepositoryArgs() ([]string, error) {
 }
 
 // Run runs the given workflow with the given event payload using act.
-func (r *Runner) Run(workflow workflow.Workflow, eventPayload EventPayload) (*RunResult, error) {
+func (r *Runner) Run(workflow workflow.Workflow, event Event) (*RunResult, error) {
 	runResult := newRunResult()
 
 	// Create temp workflow file inside .github/workflows or act won't
@@ -195,13 +199,13 @@ func (r *Runner) Run(workflow workflow.Workflow, eventPayload EventPayload) (*Ru
 	// defer os.Remove(workflowFile)
 
 	// Create temp event payload file to simulate a GitHub event
-	payloadFile, err := CreateTempEventFile(eventPayload)
+	payloadFile, err := CreateTempEventFile(event)
 	if err != nil {
 		return nil, fmt.Errorf("create temp event file: %w", err)
 	}
 	defer os.Remove(payloadFile)
 
-	args, err := r.args(workflowFile, payloadFile)
+	args, err := r.args(event.Kind, workflowFile, payloadFile)
 	if err != nil {
 		return nil, fmt.Errorf("get act args: %w", err)
 	}

--- a/tests/act/internal/act/workflows.go
+++ b/tests/act/internal/act/workflows.go
@@ -47,6 +47,9 @@ type Event struct {
 // NewEventPayload creates a new EventPayload with the given data.
 // It always includes an "act": true key-value pair.
 func NewEventPayload(kind EventKind, data map[string]any) Event {
+	if data == nil {
+		data = map[string]any{}
+	}
 	e := Event{
 		Kind:    kind,
 		Payload: data,

--- a/tests/act/internal/workflow/ci.go
+++ b/tests/act/internal/workflow/ci.go
@@ -194,14 +194,9 @@ func WithMockedWorkflowContext(t *testing.T, ctx Context) SimpleCIOption {
 // This allows testing GCS upload functionality without actually accessing GCS.
 // Since GCS is only used in trusted contexts, callers should most likely also use WithMockedWorkflowContext.
 func WithMockedGCS(t *testing.T) SimpleCIOption {
-	const (
-		gcsLoginAction  = "google-github-actions/auth"
-		gcsUploadAction = "google-github-actions/upload-cloud-storage"
-	)
-
 	return func(w *SimpleCI) {
 		jobs := w.CIWorkflow().BaseWorkflow.Jobs
-		for jk, job := range jobs {
+		for _, job := range jobs {
 			for i, step := range job.Steps {
 				switch {
 				case strings.HasPrefix(step.Uses, gcsLoginAction):
@@ -210,16 +205,10 @@ func WithMockedGCS(t *testing.T) SimpleCIOption {
 					require.NoError(t, err)
 
 				case strings.HasPrefix(step.Uses, gcsUploadAction):
-					// Extract the existing inputs and use them in the mocked bash step.
-					// Make sure they are strings and not empty
-					srcPath, ok1 := step.With["path"].(string)
-					destPath, ok2 := step.With["destination"].(string)
-					if srcPath == "" || destPath == "" || !ok1 || !ok2 {
-						require.FailNow(t, "could not mock gcs in job %q step %q (index: %d) because inputs are not valid", jk, step.ID, i)
-					}
-
 					// Replace the step
-					err := job.ReplaceStepAtIndex(i, MockGCSUploadStep(srcPath, destPath))
+					mockedStep, err := MockGCSUploadStep(step)
+					require.NoError(t, err)
+					err = job.ReplaceStepAtIndex(i, mockedStep)
 					require.NoError(t, err)
 				}
 			}

--- a/tests/act/internal/workflow/mock.go
+++ b/tests/act/internal/workflow/mock.go
@@ -4,6 +4,12 @@ package workflow
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
+)
+
+const (
+	gcsLoginAction  = "google-github-actions/auth"
+	gcsUploadAction = "google-github-actions/upload-cloud-storage"
 )
 
 // CopyMockFilesStep returns a Step that copies mock files from a source folder to a destination folder.
@@ -38,11 +44,26 @@ func NoOpStep(id string) Step {
 
 // MockGCSUploadStep returns a Step that mocks uploading files to Google Cloud Storage (GCS).
 // Instead of actually uploading to GCS, it copies files to a local folder mounted into the act container at /gcs.
-// The srcPath is the source path of the files to upload inside the GitHub Actions runner workspace.
-// The destPath is the destination path inside the mocked GCS bucket (i.e., inside /gcs).
-func MockGCSUploadStep(srcPath, destPath string) Step {
+// The originalStep parameter is the original GCS upload step to be mocked.
+// The original step must use the `google-github-actions/upload-cloud-storage` action
+// and have valid "path" and "destination" inputs.
+// If those conditions are not met, an error is returned.
+func MockGCSUploadStep(originalStep Step) (Step, error) {
+	// Make sure the original step is indeed a GCS upload step
+	if !strings.HasPrefix(originalStep.Uses, gcsUploadAction) {
+		return Step{}, fmt.Errorf("cannot mock gcs for a step that uses %q action, must be %q", originalStep.Uses, gcsUploadAction)
+	}
+
+	// Extract the existing inputs and use them in the mocked bash step.
+	// Make sure they are strings and not empty
+	srcPath, ok1 := originalStep.With["path"].(string)
+	destPath, ok2 := originalStep.With["destination"].(string)
+	if srcPath == "" || destPath == "" || !ok1 || !ok2 {
+		return Step{}, fmt.Errorf("could not mock gcs step %q (id: %q) because inputs are not valid", originalStep.Name, originalStep.ID)
+	}
+
 	return Step{
-		Name: "Upload to GCS (mocked)",
+		Name: originalStep.Name + " (mocked)",
 		Run: Commands{
 			"set -x",
 			`mkdir -p /gcs/` + destPath,
@@ -61,7 +82,7 @@ func MockGCSUploadStep(srcPath, destPath string) Step {
 			`echo "uploaded=$files" >> "$GITHUB_OUTPUT"`,
 		}.String(),
 		Shell: "bash",
-	}
+	}, nil
 }
 
 // MockWorkflowContextStep returns a Step that mocks the "workflow-context" step

--- a/tests/act/main_gcs_test.go
+++ b/tests/act/main_gcs_test.go
@@ -37,11 +37,11 @@ func TestGCS(t *testing.T) {
 		t.Run(tc.folder, func(t *testing.T) {
 			t.Parallel()
 
-			for _, event := range []act.EventPayload{
+			for _, event := range []act.Event{
 				act.NewPushEventPayload("main"),
 				act.NewPullRequestEventPayload("feature-branch"),
 			} {
-				t.Run(event.Name(), func(t *testing.T) {
+				t.Run(string(event.Kind), func(t *testing.T) {
 					runner, err := act.NewRunner(t)
 					require.NoError(t, err)
 
@@ -82,7 +82,7 @@ func TestGCS(t *testing.T) {
 
 					// Expect commit hash any zip
 					expFiles := []string{filepath.Join(commitBasePath, anyZipFn)}
-					if event.IsPush() {
+					if event.Kind == act.EventKindPush {
 						// Also expect zips in the "latest" folder if the event is a push to main, rather than a PR
 						expFiles = append(expFiles, filepath.Join(latestBasePath, anyZipFn))
 					}
@@ -93,7 +93,7 @@ func TestGCS(t *testing.T) {
 							backendZipFn := osArchZipFileName(tc.id, tc.version, osArch)
 							expFiles = append(expFiles, filepath.Join(commitBasePath, backendZipFn))
 
-							if event.IsPush() {
+							if event.Kind == act.EventKindPush {
 								// Also latest os/arch zip
 								expFiles = append(expFiles, filepath.Join(latestBasePath, backendZipFn))
 							}
@@ -150,7 +150,7 @@ func TestGCS(t *testing.T) {
 						{outputName: "zip_urls_commit", expected: expCommitZIPURLs, shouldBePresentInPR: true},
 						{outputName: "zip_urls_latest", expected: expLatestZIPURLs, shouldBePresentInPR: false},
 					} {
-						if !exp.shouldBePresentInPR && !event.IsPush() {
+						if !exp.shouldBePresentInPR && event.Kind == act.EventKindPullRequest {
 							continue
 						}
 						jsonOutput, ok := r.Outputs.Get("upload-to-gcs", "outputs", exp.outputName)


### PR DESCRIPTION
The pull_request event is not handled correctly in act tests. This fixes it. When running with act, we have to make sure to always use the current git reference when checking out. This is because act normally copies files locally. If we specify a reference different than the current one that's locally checked out, the checkout step is not mocked properly by act and it tries to clone a non-existing ref, resulting in an error.