### PR TITLE
feat(ci): add warning when ci and cd workflows are not on the same reference

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -538,7 +538,7 @@ jobs:
 
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@giuseppe/warn-on-ci-cd-mismatch
     needs:
       - setup
     with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -538,7 +538,7 @@ jobs:
 
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@giuseppe/warn-on-ci-cd-mismatch
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main
     needs:
       - setup
     with:

--- a/.github/workflows/check-release-channel.yml
+++ b/.github/workflows/check-release-channel.yml
@@ -1,0 +1,111 @@
+# Description:
+# Checks for release channel usage in workflow files.
+# This reusable workflow verifies that:
+# - The rolling releases channel (@main) is not being used (warning)
+# - Commit hashes are not used for pinning (error)
+# - All workflow references to ci.yml and cd.yml use the same version (warning)
+
+name: Plugins - Check release channel
+
+on:
+  workflow_call:
+    inputs:
+      DO-NOT-USE-allow-pinned-commit-hashes:
+        description: |
+          FOR INTERNAL TESTING ONLY, DO NOT USE.
+          If `true`, skip hard fail in case the workflow is pinned to a commit hash.
+          Vault access may still fail in such cases, depending on the WIF policies in place.
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+  check-for-release-channel:
+    name: Check for release channel
+    runs-on: ubuntu-arm64-small
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Check for rolling releases channel
+        run: |
+          diff=$(grep -E 'grafana/plugin-ci-workflows.+@main' -rn .github/workflows/ || true)
+          if [[ -n "$diff" ]]; then
+            echo "Found usage of rolling releases channel in the following files:"
+            echo "$diff"
+
+            title="Detected plugin-ci-workflows rolling release channel"
+            message="You are using workflows from plugin-ci-workflows rolling releases channel (\`@main\`). \
+          This is discouraged as it may lead to unexpected breaking changes. \
+          Please pin to a specific tagged release to ensure better stability. \
+          For more information, refer to the docs: https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#versions-and-release-channels"
+
+            echo "::warning title=$title::$message"
+            exit 0
+          fi
+        shell: bash
+
+      - name: Check for plugin-ci-workflows pinned to commit hash
+        run: |
+          diff=$(grep -E 'grafana/plugin-ci-workflows.+@[0-9a-f]{6,40}' -rn .github/workflows/ || true)
+          if [[ -n "$diff" ]]; then
+            echo "Found plugin-ci-workflows pinned to a commit hash in the following files:"
+            echo "$diff"
+
+            title="Detected plugin-ci-workflows pinned to a commit hash"
+            message="You are pinning plugin-ci-workflows to a commit hash. \
+          To limit the amount of exposure (security reasons), this is not allowed and the workflow will fail. \
+          Please pin to a specific tagged release instead. \
+          For more information, refer to the docs: https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#versions-and-release-channels"
+
+            echo "::error title=$title::$message"
+            if [ "${ALLOW_PINNED_COMMIT_HASHES}" != "true" ]; then
+              # Hard fail by default
+              exit 1
+            else
+              exit 0
+            fi
+          fi
+        env:
+          ALLOW_PINNED_COMMIT_HASHES: ${{ inputs.DO-NOT-USE-allow-pinned-commit-hashes }}
+        shell: bash
+
+      - name: Check for inconsistent workflow references
+        run: |
+          # Extract all workflow references to ci.yml and cd.yml from plugin-ci-workflows
+          refs=$(grep -roEh 'grafana/plugin-ci-workflows/\.github/workflows/(ci|cd)\.yml@[^[:space:]"'"'"']+' .github/workflows/ | sort -u || true)
+
+          if [[ -z "$refs" ]]; then
+            echo "No workflow references to ci.yml or cd.yml found."
+            exit 0
+          fi
+
+          echo "Found workflow references:"
+          echo "$refs"
+
+          # Get unique versions (the part after @)
+          versions=$(echo "$refs" | sed 's/.*@//' | sort -u)
+          version_count=$(echo "$versions" | wc -l | tr -d ' ')
+
+          if [ "$version_count" -gt 1 ]; then
+            echo ""
+            echo "Found inconsistent workflow references with different versions:"
+            echo "$versions"
+
+            # Show which files have which references
+            echo ""
+            echo "Details:"
+            grep -rn 'grafana/plugin-ci-workflows/\.github/workflows/\(ci\|cd\)\.yml@' .github/workflows/ || true
+
+            title="Inconsistent plugin-ci-workflows references"
+            message="Found multiple versions of plugin-ci-workflows being referenced in workflow files. \
+          All references to ci.yml and cd.yml should use the same version. \
+          Found versions: $(echo $versions | tr '\n' ' ')"
+
+            echo "::warning title=$title::$message"
+          else
+            echo ""
+            echo "All workflow references use the same version: $versions"
+          fi
+        shell: bash
+

--- a/.github/workflows/check-release-channel.yml
+++ b/.github/workflows/check-release-channel.yml
@@ -93,22 +93,28 @@ jobs:
             echo "Found inconsistent workflow references with different versions!"
             echo ""
 
-            # Build a markdown list showing each version and which files use it
-            details=""
-            while IFS= read -r version; do
-              details+=$'\n'"- \`@${version}\` is used in:"
-              # Find files using this version
-              while IFS=: read -r file line match; do
-                if [[ "$match" == *"@${version}" ]]; then
-                  details+=$'\n'"  - \`${file}\` (line ${line})"
-                fi
-              done <<< "$refs_with_files"
-            done <<< "$versions"
-
             title="Inconsistent plugin-ci-workflows references"
-            message="Found multiple versions of plugin-ci-workflows being referenced in workflow files. All references to ci.yml and cd.yml should use the same version.${details}"
+            short_message="Found multiple versions of plugin-ci-workflows being referenced in workflow files. All references to ci.yml and cd.yml should use the same version. See job summary for details."
 
-            echo "::warning title=$title::$message"
+            # Write simple warning annotation (doesn't support multi-line)
+            echo "::warning title=$title::$short_message"
+
+            # Write detailed markdown to job summary
+            {
+              echo "## :warning: $title"
+              echo ""
+              echo "Found multiple versions of plugin-ci-workflows being referenced in workflow files."
+              echo "All references to ci.yml and cd.yml should use the same version."
+              echo ""
+              while IFS= read -r version; do
+                echo "- \`@${version}\` is used in:"
+                while IFS=: read -r file line match; do
+                  if [[ "$match" == *"@${version}" ]]; then
+                    echo "  - \`${file}\` (line ${line})"
+                  fi
+                done <<< "$refs_with_files"
+              done <<< "$versions"
+            } >> "$GITHUB_STEP_SUMMARY"
           else
             echo ""
             echo "All workflow references use the same version: $versions"

--- a/.github/workflows/check-release-channel.yml
+++ b/.github/workflows/check-release-channel.yml
@@ -90,7 +90,7 @@ jobs:
 
           if [ "$version_count" -gt 1 ]; then
             echo ""
-            echo "⚠️ Found inconsistent workflow references with different versions!"
+            echo "Found inconsistent workflow references with different versions!"
             echo ""
 
             # Build a markdown list showing each version and which files use it
@@ -111,7 +111,7 @@ jobs:
             echo "::warning title=$title::$message"
           else
             echo ""
-            echo "✅ All workflow references use the same version: $versions"
+            echo "All workflow references use the same version: $versions"
           fi
         shell: bash
 

--- a/.github/workflows/check-release-channel.yml
+++ b/.github/workflows/check-release-channel.yml
@@ -96,11 +96,11 @@ jobs:
             # Build a markdown list showing each version and which files use it
             details=""
             while IFS= read -r version; do
-              details="${details}%0A- \`@${version}\` is used in:"
+              details+=$'\n'"- \`@${version}\` is used in:"
               # Find files using this version
               while IFS=: read -r file line match; do
                 if [[ "$match" == *"@${version}" ]]; then
-                  details="${details}%0A  - \`${file}\` (line ${line})"
+                  details+=$'\n'"  - \`${file}\` (line ${line})"
                 fi
               done <<< "$refs_with_files"
             done <<< "$versions"

--- a/.github/workflows/check-release-channel.yml
+++ b/.github/workflows/check-release-channel.yml
@@ -73,39 +73,45 @@ jobs:
       - name: Check for inconsistent workflow references
         run: |
           # Extract all workflow references to ci.yml and cd.yml from plugin-ci-workflows
-          refs=$(grep -roEh 'grafana/plugin-ci-workflows/\.github/workflows/(ci|cd)\.yml@[^[:space:]"'"'"']+' .github/workflows/ | sort -u || true)
+          # Output format: filename:line:match
+          refs_with_files=$(grep -rnoE 'grafana/plugin-ci-workflows/\.github/workflows/(ci|cd)\.yml@[^[:space:]"'"'"']+' .github/workflows/ || true)
 
-          if [[ -z "$refs" ]]; then
+          if [[ -z "$refs_with_files" ]]; then
             echo "No workflow references to ci.yml or cd.yml found."
             exit 0
           fi
 
           echo "Found workflow references:"
-          echo "$refs"
+          echo "$refs_with_files"
 
           # Get unique versions (the part after @)
-          versions=$(echo "$refs" | sed 's/.*@//' | sort -u)
+          versions=$(echo "$refs_with_files" | sed 's/.*@//' | sort -u)
           version_count=$(echo "$versions" | wc -l | tr -d ' ')
 
           if [ "$version_count" -gt 1 ]; then
             echo ""
-            echo "Found inconsistent workflow references with different versions:"
-            echo "$versions"
-
-            # Show which files have which references
+            echo "⚠️ Found inconsistent workflow references with different versions!"
             echo ""
-            echo "Details:"
-            grep -rn 'grafana/plugin-ci-workflows/\.github/workflows/\(ci\|cd\)\.yml@' .github/workflows/ || true
+
+            # Build a markdown list showing each version and which files use it
+            details=""
+            while IFS= read -r version; do
+              details="${details}%0A- \`@${version}\` is used in:"
+              # Find files using this version
+              while IFS=: read -r file line match; do
+                if [[ "$match" == *"@${version}" ]]; then
+                  details="${details}%0A  - \`${file}\` (line ${line})"
+                fi
+              done <<< "$refs_with_files"
+            done <<< "$versions"
 
             title="Inconsistent plugin-ci-workflows references"
-            message="Found multiple versions of plugin-ci-workflows being referenced in workflow files. \
-          All references to ci.yml and cd.yml should use the same version. \
-          Found versions: $(echo $versions | tr '\n' ' ')"
+            message="Found multiple versions of plugin-ci-workflows being referenced in workflow files. All references to ci.yml and cd.yml should use the same version.${details}"
 
             echo "::warning title=$title::$message"
           else
             echo ""
-            echo "All workflow references use the same version: $versions"
+            echo "✅ All workflow references use the same version: $versions"
           fi
         shell: bash
 

--- a/.github/workflows/check-release-channel.yml
+++ b/.github/workflows/check-release-channel.yml
@@ -114,4 +114,3 @@ jobs:
             echo "All workflow references use the same version: $versions"
           fi
         shell: bash
-

--- a/.github/workflows/check-release-channel.yml
+++ b/.github/workflows/check-release-channel.yml
@@ -93,28 +93,22 @@ jobs:
             echo "Found inconsistent workflow references with different versions!"
             echo ""
 
+            # Build a markdown list showing each version and which files use it
+            details=""
+            while IFS= read -r version; do
+              details="${details}%0A- \`@${version}\` is used in:"
+              # Find files using this version
+              while IFS=: read -r file line match; do
+                if [[ "$match" == *"@${version}" ]]; then
+                  details="${details}%0A  - \`${file}\` (line ${line})"
+                fi
+              done <<< "$refs_with_files"
+            done <<< "$versions"
+
             title="Inconsistent plugin-ci-workflows references"
-            short_message="Found multiple versions of plugin-ci-workflows being referenced in workflow files. All references to ci.yml and cd.yml should use the same version. See job summary for details."
+            message="Found multiple versions of plugin-ci-workflows being referenced in workflow files. All references to ci.yml and cd.yml should use the same version.${details}"
 
-            # Write simple warning annotation (doesn't support multi-line)
-            echo "::warning title=$title::$short_message"
-
-            # Write detailed markdown to job summary
-            {
-              echo "## :warning: $title"
-              echo ""
-              echo "Found multiple versions of plugin-ci-workflows being referenced in workflow files."
-              echo "All references to ci.yml and cd.yml should use the same version."
-              echo ""
-              while IFS= read -r version; do
-                echo "- \`@${version}\` is used in:"
-                while IFS=: read -r file line match; do
-                  if [[ "$match" == *"@${version}" ]]; then
-                    echo "  - \`${file}\` (line ${line})"
-                  fi
-                done <<< "$refs_with_files"
-              done <<< "$versions"
-            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning title=$title::$message"
           else
             echo ""
             echo "All workflow references use the same version: $versions"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,53 +302,9 @@ env:
 jobs:
   check-for-release-channel:
     name: Check for release channel
-    runs-on: ubuntu-arm64-small
-    steps:
-      - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-
-      - name: Check for rolling releases channel
-        run: |
-          diff=$(grep -E 'grafana/plugin-ci-workflows.+@main' -rn .github/workflows/ || true)
-          if [[ -n "$diff" ]]; then
-            echo "Found usage of rolling releases channel in the following files:"
-            echo "$diff"
-
-            title="Detected plugin-ci-workflows rolling release channel"
-            message="You are using workflows from plugin-ci-workflows rolling releases channel (\`@main\`). \
-          This is discouraged as it may lead to unexpected breaking changes. \
-          Please pin to a specific tagged release to ensure better stability. \
-          For more information, refer to the docs: https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#versions-and-release-channels"
-
-            echo "::warning title=$title::$message"
-            exit 0
-          fi
-        shell: bash
-
-      - name: Check for plugin-ci-workflows pinned to commit hash
-        run: |
-          diff=$(grep -E 'grafana/plugin-ci-workflows.+@[0-9a-f]{6,40}' -rn .github/workflows/ || true)
-          if [[ -n "$diff" ]]; then
-            echo "Found plugin-ci-workflows pinned to a commit hash in the following files:"
-            echo "$diff"
-
-            title="Detected plugin-ci-workflows pinned to a commit hash"
-            message="You are pinning plugin-ci-workflows to a commit hash. \
-          To limit the amount of exposure (security reasons), this is not allowed and the workflow will fail. \
-          Please pin to a specific tagged release instead. \
-          For more information, refer to the docs: https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#versions-and-release-channels"
-
-            echo "::error title=$title::$message"
-            if [ "${ALLOW_PINNED_COMMIT_HASHES}" != "true" ]; then
-              # Hard fail by default
-              exit 1
-            else
-              exit 0
-            fi
-          fi
-        env:
-          ALLOW_PINNED_COMMIT_HASHES: ${{ inputs.DO-NOT-USE-allow-pinned-commit-hashes }}
-        shell: bash
+    uses: grafana/plugin-ci-workflows/.github/workflows/check-release-channel.yml@main
+    with:
+      DO-NOT-USE-allow-pinned-commit-hashes: ${{ inputs.DO-NOT-USE-allow-pinned-commit-hashes }}
 
   test-and-build:
     name: Test and build plugin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,7 +302,7 @@ env:
 jobs:
   check-for-release-channel:
     name: Check for release channel
-    uses: grafana/plugin-ci-workflows/.github/workflows/check-release-channel.yml@giuseppe/warn-on-ci-cd-mismatch
+    uses: grafana/plugin-ci-workflows/.github/workflows/check-release-channel.yml@main
     with:
       DO-NOT-USE-allow-pinned-commit-hashes: ${{ inputs.DO-NOT-USE-allow-pinned-commit-hashes }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,7 +302,7 @@ env:
 jobs:
   check-for-release-channel:
     name: Check for release channel
-    uses: grafana/plugin-ci-workflows/.github/workflows/check-release-channel.yml@main
+    uses: grafana/plugin-ci-workflows/.github/workflows/check-release-channel.yml@giuseppe/warn-on-ci-cd-mismatch
     with:
       DO-NOT-USE-allow-pinned-commit-hashes: ${{ inputs.DO-NOT-USE-allow-pinned-commit-hashes }}
 

--- a/.github/workflows/pr-checks-workflow-references.yml
+++ b/.github/workflows/pr-checks-workflow-references.yml
@@ -35,6 +35,7 @@ jobs:
             .github/workflows/cd.yml
             .github/workflows/playwright.yml
             .github/workflows/playwright-docker.yml
+            .github/workflows/check-release-channel.yml
             actions/plugins/**
 
       - name: Check drift

--- a/.github/workflows/release-please-pr-update-tagged-references.yml
+++ b/.github/workflows/release-please-pr-update-tagged-references.yml
@@ -132,6 +132,7 @@ jobs:
             .github/workflows/cd.yml
             .github/workflows/playwright.yml
             .github/workflows/playwright-docker.yml
+            .github/workflows/check-release-channel.yml
             actions/plugins/**
 
       # For "examples", update references by filtering for an additional prefix.

--- a/.github/workflows/release-please-restore-rolling-release.yml
+++ b/.github/workflows/release-please-restore-rolling-release.yml
@@ -76,6 +76,7 @@ jobs:
             .github/workflows/cd.yml
             .github/workflows/playwright.yml
             .github/workflows/playwright-docker.yml
+            .github/workflows/check-release-channel.yml
             actions/plugins/**
 
       - name: Get bot user info


### PR DESCRIPTION


- Extracts the reference checks into a separate workflow
- Add a new check to ensure ci and cd are on the same tag (Fixes #491)

Example: https://github.com/grafana/grafana-pluginsplatformprovisioned-app/actions/runs/20849128713

<img width="593" height="179" alt="immagine" src="https://github.com/user-attachments/assets/8cb9e1de-b859-4851-98cb-91bfcbe314c8" />
