### PR TITLE
feat(ci): support react image in e2e matrix

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -123,7 +123,7 @@ on:
         description: "Optionally, you can skip the Grafana React 19 preview image"
         type: boolean
         required: false
-        default: true
+        default: false
       run-playwright-with-version-resolver-type:
         description: Define which version resolver type to use for Playwright E2E tests.
         type: string

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -119,6 +119,11 @@ on:
         type: boolean
         required: false
         default: false
+      run-playwright-with-skip-grafana-react-19-preview-image:
+        description: "Optionally, you can skip the Grafana React 19 preview image"
+        type: boolean
+        required: false
+        default: true
       run-playwright-with-version-resolver-type:
         description: Define which version resolver type to use for Playwright E2E tests.
         type: string
@@ -561,6 +566,7 @@ jobs:
       run-playwright-docker: ${{ inputs.run-playwright-docker }}
       run-playwright-with-grafana-dependency: ${{ inputs.run-playwright-with-grafana-dependency }}
       run-playwright-with-skip-grafana-dev-image: ${{ inputs.run-playwright-with-skip-grafana-dev-image }}
+      run-playwright-with-skip-grafana-react-19-preview-image: ${{ inputs.run-playwright-with-skip-grafana-react-19-preview-image }}
       run-playwright-with-version-resolver-type: ${{ inputs.run-playwright-with-version-resolver-type }}
       upload-playwright-artifacts: ${{ inputs.upload-playwright-artifacts }}
       playwright-report-path: ${{ inputs.playwright-report-path }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ on:
         description: Optionally, you can skip the Grafana React 19 preview image
         type: boolean
         required: false
-        default: true
+        default: false
       run-playwright-with-version-resolver-type:
         description: Define which version resolver type to use for Playwright E2E tests.
         type: string

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,11 @@ on:
         type: boolean
         required: false
         default: false
+      run-playwright-with-skip-grafana-react-19-preview-image:
+        description: Optionally, you can skip the Grafana React 19 preview image
+        type: boolean
+        required: false
+        default: true
       run-playwright-with-version-resolver-type:
         description: Define which version resolver type to use for Playwright E2E tests.
         type: string
@@ -677,6 +682,7 @@ jobs:
       plugin-directory: ${{ inputs.plugin-directory }}
       grafana-dependency: ${{ inputs.run-playwright-with-grafana-dependency }}
       skip-grafana-dev-image: ${{ inputs.run-playwright-with-skip-grafana-dev-image }}
+      skip-grafana-react-19-preview-image: ${{ inputs.run-playwright-with-skip-grafana-react-19-preview-image }}
       version-resolver-type: ${{ inputs.run-playwright-with-version-resolver-type }}
       upload-artifacts: ${{ inputs.upload-playwright-artifacts }}
       docker-compose-file: ${{ inputs.playwright-docker-compose-file }}
@@ -698,6 +704,7 @@ jobs:
       version: ${{ fromJSON(needs.test-and-build.outputs.plugin).version}}
       grafana-dependency: ${{ inputs.run-playwright-with-grafana-dependency }}
       skip-grafana-dev-image: ${{ inputs.run-playwright-with-skip-grafana-dev-image }}
+      skip-grafana-react-19-preview-image: ${{ inputs.run-playwright-with-skip-grafana-react-19-preview-image }}
       version-resolver-type: ${{ inputs.run-playwright-with-version-resolver-type }}
       upload-artifacts: ${{ inputs.upload-playwright-artifacts }}
       grafana-compose-file: ${{ inputs.playwright-docker-compose-file }}

--- a/.github/workflows/playwright-docker.yml
+++ b/.github/workflows/playwright-docker.yml
@@ -22,6 +22,10 @@ on:
         default: false
         required: false
         type: boolean
+      skip-grafana-react-19-preview-image:
+        default: true
+        required: false
+        type: boolean
       version-resolver-type:
         required: false
         type: string
@@ -71,9 +75,10 @@ jobs:
 
       - name: Resolve Grafana E2E versions
         id: resolve-versions
-        uses: grafana/plugin-actions/e2e-version@e2e-version/v1.1.2
+        uses: grafana/plugin-actions/e2e-version@e2e-version/v1.2.0
         with:
           skip-grafana-dev-image: ${{ inputs.skip-grafana-dev-image }}
+          skip-grafana-react-19-preview-image: ${{ inputs.skip-grafana-react-19-preview-image }}
           version-resolver-type: ${{ inputs.version-resolver-type }}
           grafana-dependency: ${{ inputs.grafana-dependency }}
 

--- a/.github/workflows/playwright-docker.yml
+++ b/.github/workflows/playwright-docker.yml
@@ -23,7 +23,7 @@ on:
         required: false
         type: boolean
       skip-grafana-react-19-preview-image:
-        default: true
+        default: false
         required: false
         type: boolean
       version-resolver-type:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -25,6 +25,10 @@ on:
         default: false
         required: false
         type: boolean
+      skip-grafana-react-19-preview-image:
+        default: true
+        required: false
+        type: boolean
       version-resolver-type:
         required: false
         type: string
@@ -89,9 +93,10 @@ jobs:
 
       - name: Resolve Grafana E2E versions
         id: resolve-versions
-        uses: grafana/plugin-actions/e2e-version@e2e-version/v1.1.2
+        uses: grafana/plugin-actions/e2e-version@e2e-version/v1.2.0
         with:
           skip-grafana-dev-image: ${{ inputs.skip-grafana-dev-image }}
+          skip-grafana-react-19-preview-image: ${{ inputs.skip-grafana-react-19-preview-image }}
           version-resolver-type: ${{ inputs.version-resolver-type }}
           grafana-dependency: ${{ inputs.grafana-dependency }}
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -26,7 +26,7 @@ on:
         required: false
         type: boolean
       skip-grafana-react-19-preview-image:
-        default: true
+        default: false
         required: false
         type: boolean
       version-resolver-type:


### PR DESCRIPTION
This PR updates the `e2e-version` action to v1.2.0. By doing so, the `e2e-versions` action will include a Grafana image built with react 19. This allows devs to test whether their plugins are forwards-compatiblity, as Grafana will move to React 19 in Grafana 13. 

The Grafana React image is added to the matrix by default, but users of plugin-ci-workflows will be able to disable it by setting the `skip-grafana-react-19-preview-image` to true. 