### PR TITLE
feat(playwright)!: remove version and image arguments

### DIFF
--- a/.github/workflows/playwright-docker.yml
+++ b/.github/workflows/playwright-docker.yml
@@ -152,8 +152,6 @@ jobs:
           docker compose --profile playwright ${DOCKER_COMPOSE_FILE:+-f "$DOCKER_COMPOSE_FILE"} up playwright --exit-code-from playwright
         env:
           DOCKER_COMPOSE_FILE: ${{ inputs.grafana-compose-file }}
-          GRAFANA_VERSION: ${{ matrix.GRAFANA_IMAGE.VERSION }}
-          GRAFANA_IMAGE: ${{ matrix.GRAFANA_IMAGE.NAME }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -244,8 +244,6 @@ jobs:
         run: ${{ steps.package-manager.outputs.execLocalCmd }} playwright test --config "${PLAYWRIGHT_CONFIG}"
         env:
           PLAYWRIGHT_CONFIG: ${{ inputs.playwright-config }}
-          GRAFANA_VERSION: ${{ matrix.GRAFANA_IMAGE.VERSION }}
-          GRAFANA_IMAGE: ${{ matrix.GRAFANA_IMAGE.NAME }}
         working-directory: ${{ inputs.plugin-directory }}
 
       - name: Upload artifacts


### PR DESCRIPTION
Passing grafana version to Playwright has side effect, as plugin-e2e uses the version environment variable (if available) when resolving e2e-selectors. 

# ⚠️ **Breaking change**
For consumers of the shared workflows that wants to detect Grafana version within plugin-e2e tests, there's an alternative approach using the [official API](https://grafana.com/developers/plugin-tools/e2e-test-a-plugin/): 

```ts
test('should be possible to enable advanced mode', async ({ grafanaVersion, alertRuleEditPage }) => {
   test.skip(semver.lt(grafanaVersion, '11.6.0'), 'Advanced mode is not supported in Grafana versions < 11.6.0');
   // test code
});
 ```


This PR reverts the feature introduced in https://github.com/grafana/plugin-ci-workflows/pull/206