### PR TITLE
test(act): fix flaky setup go step in act tests

### DIFF
--- a/tests/act/main_cache_warmup_test.go
+++ b/tests/act/main_cache_warmup_test.go
@@ -80,16 +80,20 @@ func TestCacheWarmup_GoNodeVersions(t *testing.T) {
 			line := scanner.Text()
 			isToolchain := strings.HasPrefix(line, "toolchain")
 			isGo := strings.HasPrefix(line, "go")
-			if isToolchain || isGo {
-				parts := strings.Split(line, " ")
-				require.Len(t, parts, 2, "expected 2 parts in go.mod for 'go' or 'toolchain' directive")
-				if len(parts) > 1 {
-					goVersion = parts[1]
-				}
-				// Toolchain has higher priority, so if we find it, break immediately.
-				if isToolchain {
-					break
-				}
+			if !isToolchain && !isGo {
+				continue
+			}
+
+			// Extract the Go version from the line
+			parts := strings.Split(line, " ")
+			require.Len(t, parts, 2, "expected 2 parts in go.mod for 'go' or 'toolchain' directive")
+			if len(parts) > 1 {
+				goVersion = parts[1]
+			}
+
+			// Toolchain has higher priority, so if we find it, break immediately.
+			if isToolchain {
+				break
 			}
 		}
 		if err := scanner.Err(); err != nil {

--- a/tests/act/main_cache_warmup_test.go
+++ b/tests/act/main_cache_warmup_test.go
@@ -87,9 +87,7 @@ func TestCacheWarmup_GoNodeVersions(t *testing.T) {
 			// Extract the Go version from the line
 			parts := strings.Split(line, " ")
 			require.Len(t, parts, 2, "expected 2 parts in go.mod for 'go' or 'toolchain' directive")
-			if len(parts) > 1 {
-				goVersion = parts[1]
-			}
+			goVersion = parts[1]
 
 			// Toolchain has higher priority, so if we find it, break immediately.
 			if isToolchain {

--- a/tests/act/main_cache_warmup_test.go
+++ b/tests/act/main_cache_warmup_test.go
@@ -32,7 +32,7 @@ func TestCacheWarmup_GoNodeVersions(t *testing.T) {
 
 	var examplesErr error
 	var scannedExamples int
-	err = filepath.WalkDir(filepath.Join("tests"), func(path string, d fs.DirEntry, err error) error {
+	walkErr := filepath.WalkDir(filepath.Join("tests"), func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -99,6 +99,7 @@ func TestCacheWarmup_GoNodeVersions(t *testing.T) {
 		}
 		return nil
 	})
+	require.NoError(t, walkErr, "error while walking directory")
 	require.NotZero(t, scannedExamples, "no examples found")
 	require.NoError(t, examplesErr, "some examples are not using the default Go or Node versions: this will cause issues with the act cache warmup.")
 }

--- a/tests/act/main_cache_warmup_test.go
+++ b/tests/act/main_cache_warmup_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/grafana/plugin-ci-workflows/tests/act/internal/workflow"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCacheWarmup_GoNodeVersions(t *testing.T) {
+	// Ensure that all test cases use the same Go and Node versions as the default versions in ci.yml.
+	// These versions are used to warm up the act cache, so if they are not the same, the cache will not be warmup correctly.
+	// If the cache is not warmed up correctly, Go/Node will be downloaded and installed again for each test case, which:
+	// - Takes longer to run the tests
+	// - Causes the tests to be flaky because the cache directory used for download is shared between test cases, and is not cleaned up between test cases.
+	// This test ensures that all test cases are using the same Go and Node versions as the default versions in ci.yml,
+	// so that the act cache warmup is effective.
+
+	ciWf, err := workflow.NewBaseWorkflowFromFile(filepath.Join(".github", "workflows", "ci.yml"))
+	require.NoError(t, err)
+
+	defaultGoVersion := ciWf.Env["DEFAULT_GO_VERSION"]
+	defaultNodeVersion := ciWf.Env["DEFAULT_NODE_VERSION"]
+	require.NotEmpty(t, defaultGoVersion, "DEFAULT_GO_VERSION is not set in ci.yml")
+	require.NotEmpty(t, defaultNodeVersion, "DEFAULT_NODE_VERSION is not set in ci.yml")
+
+	var examplesErr error
+	var scannedExamples int
+	err = filepath.WalkDir(filepath.Join("tests"), func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		// Skip files and "act" directory itself
+		if !d.IsDir() || d.Name() == "act" {
+			return nil
+		}
+
+		nvmrcPath := filepath.Join(path, ".nvmrc")
+		if _, err := os.Stat(nvmrcPath); os.IsNotExist(err) {
+			return nil
+		}
+
+		scannedExamples++
+		t.Logf("checking example %q", path)
+
+		// Check Node version
+		nvmrcContent, err := os.ReadFile(nvmrcPath)
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(string(nvmrcContent)) != defaultNodeVersion {
+			examplesErr = fmt.Errorf("example %q: node version in .nvmrc is not the default version: expected %q, got %q", path, defaultNodeVersion, string(nvmrcContent))
+			// Do not return the error to WalkDir so we continue scanning other examples.
+			return nil
+		}
+
+		// Check Go version
+		// This can be in either "toolchain" or "go" line in go.mod
+		// Toolchain has higher priority for the compiler version.
+		goModPath := filepath.Join(path, "go.mod")
+		if _, err := os.Stat(goModPath); os.IsNotExist(err) {
+			return nil
+		}
+		goModContent, err := os.ReadFile(goModPath)
+		if err != nil {
+			return err
+		}
+		var goVersion string
+		scanner := bufio.NewScanner(strings.NewReader(string(goModContent)))
+		for scanner.Scan() {
+			line := scanner.Text()
+			isToolchain := strings.HasPrefix(line, "toolchain")
+			isGo := strings.HasPrefix(line, "go")
+			if isToolchain || isGo {
+				parts := strings.Split(line, " ")
+				require.Len(t, parts, 2, "expected 2 parts in go.mod for 'go' or 'toolchain' directive")
+				if len(parts) > 1 {
+					goVersion = parts[1]
+				}
+				// Toolchain has higher priority, so if we find it, break immediately.
+				if isToolchain {
+					break
+				}
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			return err
+		}
+		if goVersion != defaultGoVersion {
+			examplesErr = fmt.Errorf("example %q: go version in go.mod is not the default version: expected %q, got %q", path, defaultGoVersion, goVersion)
+			// Do not return the error to WalkDir so we continue scanning other examples.
+			return nil
+		}
+		return nil
+	})
+	require.NotZero(t, scannedExamples, "no examples found")
+	require.NoError(t, examplesErr, "some examples are not using the default Go or Node versions: this will cause issues with the act cache warmup.")
+}

--- a/tests/act/main_cache_warmup_test.go
+++ b/tests/act/main_cache_warmup_test.go
@@ -67,12 +67,15 @@ func TestCacheWarmup_GoNodeVersions(t *testing.T) {
 		if _, err := os.Stat(goModPath); os.IsNotExist(err) {
 			return nil
 		}
-		goModContent, err := os.ReadFile(goModPath)
+		f, err := os.Open(goModPath)
 		if err != nil {
 			return err
 		}
+		defer func() {
+			require.NoError(t, f.Close())
+		}()
 		var goVersion string
-		scanner := bufio.NewScanner(strings.NewReader(string(goModContent)))
+		scanner := bufio.NewScanner(f)
 		for scanner.Scan() {
 			line := scanner.Text()
 			isToolchain := strings.HasPrefix(line, "toolchain")

--- a/tests/simple-backend/go.mod
+++ b/tests/simple-backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/simple-backend
 
-go 1.25.0
+go 1.25
 
 require github.com/grafana/grafana-plugin-sdk-go v0.280.0
 

--- a/tests/simple-backend/go.mod
+++ b/tests/simple-backend/go.mod
@@ -1,7 +1,6 @@
 module github.com/grafana/simple-backend
 
 go 1.25.0
-toolchain go1.25.5
 
 require github.com/grafana/grafana-plugin-sdk-go v0.280.0
 


### PR DESCRIPTION
Fixes the following failure that sometimes happens in Act tests during "Setup Go" step:

```
2026-01-16T13:24:38.3786049Z TestGCS/simple-backend/push: [CI/Plugins - CI/Test and build plugin    ] Successfully cached go to /opt/hostedtoolcache/go/1.25.5/x64
2026-01-16T13:24:38.3788452Z TestGCS/simple-backend/push: [CI/Plugins - CI/Test and build plugin    ] Added go to the path
2026-01-16T13:24:38.3791419Z TestGCS/simple-backend/push: [CI/Plugins - CI/Test and build plugin    ] Successfully set up Go version 1.25.5
2026-01-16T13:24:38.3800898Z TestGCS/simple-backend/push: [CI/Plugins - CI/Test and build plugin    ] ❓  ::debug::which go ::
2026-01-16T13:24:38.3810927Z TestGCS/simple-frontend/push: [CI/Plugins - CI/Test and build plugin    ] ⭐ Run Post Go
2026-01-16T13:24:38.3858401Z TestGCS/simple-backend/push: [CI/Plugins - CI/Test and build plugin    ] /bin/sh: 1: version: not found
2026-01-16T13:24:38.3860975Z TestGCS/simple-backend/push: [CI/Plugins - CI/Test and build plugin    ] ❗  ::error::Command failed:  version%0A/bin/sh: 1: version: not found%0A
2026-01-16T13:24:38.3899662Z TestGCS/simple-frontend/push: [CI/Plugins - CI/Test and build plugin    ] 🐳  docker exec cmd=[/opt/acttoolcache/node/18.20.8/x64/bin/node /var/run/act/actions/actions-setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c/dist/cache-save/index.js] user= workdir=
2026-01-16T13:24:38.3986299Z TestGCS/simple-backend/push: [CI/Plugins - CI/Test and build plugin    ] ❌  Failure - Main Go [9.383143406s]
2026-01-16T13:24:38.4010719Z TestGCS/simple-backend/push: [CI/Plugins - CI/Test and build plugin    ] ⚙  ::set-env:: GOTOOLCHAIN=local
2026-01-16T13:24:38.4078259Z TestGCS/simple-backend/push: [CI/Plugins - CI/Test and build plugin    ] ⚙  ::add-path:: /opt/hostedtoolcache/go/1.25.5/x64/bin
2026-01-16T13:24:38.4079028Z TestGCS/simple-backend/push: [CI/Plugins - CI/Test and build plugin    ] exitcode '1': failure
2026-01-16T13:24:38.4927541Z TestGCS/simple-backend/push: [CI/Plugins - CI/Test and build plugin    ] ❌  Failure - Main Setup [13.544153485s]
2026-01-16T13:24:38.4948923Z TestGCS/simple-backend/push: [CI/Plugins - CI/Test and build plugin    ] ⚙  ::set-env:: GOTOOLCHAIN=local
2026-01-16T13:24:38.5027355Z TestGCS/simple-backend/push: [CI/Plugins - CI/Test and build plugin    ] ⚙  ::add-path:: /opt/hostedtoolcache/go/1.25.5/x64/bin
2026-01-16T13:24:38.5028145Z TestGCS/simple-backend/push: [CI/Plugins - CI/Test and build plugin    ] exitcode '1': failure
```

This happens because the act cache is warmed up using the `DEFAULT_GO_VERSION=1.25`, which matches to Go 1.25.6 (latest 1.25.x release). However, the backend example requests 1.25.5 explicitly via the `toolchain` directive in `go.mod`. This causes 1.25.5 to be downloaded for every test case, rather than using the cached 1.25.6. Since the cache is shared among all containers, they could read/write to the same files at the same time while downloading Go 1.25.5 (not cached), resulting in flaky tests.

This PR removes the `toolchain` directive so 1.25.6 (or any other 1.25.x in the future) is used instead.

This PR also adds a test case to ensure the Node and Go versions used by each test case are up-to-date with DEFAULT_GO_VERSION and DEFAULT_NODE_VERSION, to catch errors like this in the future when the default Node/Go versions are bumped.