### PR TITLE
chore(act): run act tests when actions or cd workflow change

### DIFF
--- a/.github/workflows/pr-checks-test-ci.yml
+++ b/.github/workflows/pr-checks-test-ci.yml
@@ -8,6 +8,9 @@ on:
       - "tests/**"
       - ".github/workflows/pr-checks-test-ci.yml"
       - ".github/workflows/ci.yml"
+      - ".github/workflows/cd.yml"
+      - "actions/internal/**"
+      - "actions/plugins/publish/**"
   push:
     branches:
       - main
@@ -15,6 +18,9 @@ on:
       - "tests/**"
       - ".github/workflows/pr-checks-test-ci.yml"
       - ".github/workflows/ci.yml"
+      - ".github/workflows/cd.yml"
+      - "actions/internal/**"
+      - "actions/plugins/publish/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Adjusts the workflow triggers for act tests to include:

- cd.yml: we have tests for cd now as well
- actions/internal: to re-run act tests when an action used internally by ci.yml/cd.yml changes
- actions/plugins/publish: this action is re-usable but also used under the hood by cd.yml