### PR TITLE
chore(renovate): group frontend-e2e-against-stack action dependency bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,11 @@
             "matchManagers": ["github-actions"],
             "matchPackageNames": ["grafana/docs-base"],
             "pinDigests": false
+        },
+        {
+            "matchPaths": ["actions/plugins/frontend-e2e-against-stack/**"],
+            "groupName": "frontend-e2e-against-stack dependencies",
+            "schedule": ["weekly"]
         }
     ],
     "minimumReleaseAge": "14 days",

--- a/renovate.json
+++ b/renovate.json
@@ -22,8 +22,7 @@
         },
         {
             "matchPaths": ["actions/plugins/frontend-e2e-against-stack/**"],
-            "groupName": "frontend-e2e-against-stack dependencies",
-            "schedule": ["weekly"]
+            "groupName": "frontend-e2e-against-stack dependencies"
         }
     ],
     "minimumReleaseAge": "14 days",


### PR DESCRIPTION
Reduces renovate noise by grouping together all dependency bumps for actions/plugins/frontend-e2e-against-stack.

Fixes #448 