### PR TITLE
chore(renovate): handle default go, node and tooling versions in workflows via renovate

### DIFF
--- a/.github/workflows/pr-checks-lint.yml
+++ b/.github/workflows/pr-checks-lint.yml
@@ -16,7 +16,7 @@ permissions:
 
 env:
   ACTIONLINT_VERSION: "1.7.3"
-  GOLANGCI_LINT_VERSION: "v2.7.2"
+  GOLANGCI_LINT_VERSION: "2.7.2"
 
 jobs:
   actionlint:
@@ -61,5 +61,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: ${{ env.GOLANGCI_LINT_VERSION }}
+          version: v${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: ${{ matrix.directory }}

--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,11 @@
             "matchManagers": ["github-actions"],
             "matchPackageNames": ["grafana/docs-base"],
             "pinDigests": false
+        },
+        {
+            "matchPaths": ["actions/plugins/frontend-e2e-against-stack/**"],
+            "groupName": "frontend-e2e-against-stack dependencies",
+            "schedule": ["weekly"]
         }
     ],
     "minimumReleaseAge": "14 days",

--- a/renovate.json
+++ b/renovate.json
@@ -22,8 +22,7 @@
         },
         {
             "matchPaths": ["actions/plugins/frontend-e2e-against-stack/**"],
-            "groupName": "frontend-e2e-against-stack dependencies",
-            "schedule": ["weekly"]
+            "groupName": "frontend-e2e-against-stack dependencies"
         }
     ],
     "minimumReleaseAge": "14 days",

--- a/renovate.json
+++ b/renovate.json
@@ -26,6 +26,54 @@
             "schedule": ["weekly"]
         }
     ],
+    "regexManagers": [
+        {
+            "fileMatch": ["\\.github/workflows/.*\\.ya?ml$"],
+            "matchStrings": ["DEFAULT_NODE_VERSION:\\s*\"(?<currentValue>\\d+)\""],
+            "depNameTemplate": "node",
+            "datasourceTemplate": "node-version",
+            "replacementStringTemplate": "{{newMajor}}"
+        },
+        {
+            "fileMatch": ["\\.github/workflows/.*\\.ya?ml$"],
+            "matchStrings": ["DEFAULT_GO_VERSION:\\s*\"(?<currentValue>\\d+\\.\\d+)\""],
+            "depNameTemplate": "go",
+            "datasourceTemplate": "golang-version",
+            "replacementStringTemplate": "{{newMajor}}.{{newMinor}}"
+        },
+        {
+            "fileMatch": ["\\.github/workflows/.*\\.ya?ml$"],
+            "matchStrings": ["(?:DEFAULT_)?GOLANGCI_LINT_VERSION:\\s*\"(?<currentValue>[^\"]+)\""],
+            "depNameTemplate": "golangci-lint",
+            "packageNameTemplate": "golangci/golangci-lint",
+            "datasourceTemplate": "github-releases",
+            "extractVersionTemplate": "^v?(?<version>.*)$"
+        },
+        {
+            "fileMatch": ["\\.github/workflows/.*\\.ya?ml$"],
+            "matchStrings": ["DEFAULT_TRUFFLEHOG_VERSION:\\s*\"(?<currentValue>[^\"]+)\""],
+            "depNameTemplate": "trufflehog",
+            "packageNameTemplate": "trufflesecurity/trufflehog",
+            "datasourceTemplate": "github-releases",
+            "extractVersionTemplate": "^v?(?<version>.*)$"
+        },
+        {
+            "fileMatch": ["\\.github/workflows/.*\\.ya?ml$"],
+            "matchStrings": ["DEFAULT_MAGE_VERSION:\\s*\"(?<currentValue>[^\"]+)\""],
+            "depNameTemplate": "mage",
+            "packageNameTemplate": "magefile/mage",
+            "datasourceTemplate": "github-releases",
+            "extractVersionTemplate": "^v?(?<version>.*)$"
+        },
+        {
+            "fileMatch": ["\\.github/workflows/.*\\.ya?ml$"],
+            "matchStrings": ["ACTIONLINT_VERSION:\\s*\"(?<currentValue>[^\"]+)\""],
+            "depNameTemplate": "actionlint",
+            "packageNameTemplate": "rhysd/actionlint",
+            "datasourceTemplate": "github-releases",
+            "extractVersionTemplate": "^v?(?<version>.*)$"
+        }
+    ],
     "minimumReleaseAge": "14 days",
     "prConcurrentLimit": 10,
     "rebaseWhen": "behind-base-branch"


### PR DESCRIPTION
Configures renovate to bump the default go, node, trufflehog, actionlin, golangci-lint and mage versions in the workflows. Fixes #385 