### PR TITLE
fix(renovate): fix regexManagers for tooling versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,23 +35,26 @@
             "groupName": "frontend-e2e-against-stack dependencies"
         }
     ],
-    "regexManagers": [
+    "customManagers": [
         {
-            "fileMatch": ["\\.github/workflows/.*\\.ya?ml$"],
+            "customType": "regex",
+            "managerFilePatterns": ["\\.github/workflows/.*\\.ya?ml$"],
             "matchStrings": ["DEFAULT_NODE_VERSION:\\s*\"(?<currentValue>\\d+)\""],
             "depNameTemplate": "node",
             "datasourceTemplate": "node-version",
-            "replacementStringTemplate": "{{newMajor}}"
+            "extractVersionTemplate": "^(?<version>\\d+)"
         },
         {
-            "fileMatch": ["\\.github/workflows/.*\\.ya?ml$"],
+            "customType": "regex",
+            "managerFilePatterns": ["\\.github/workflows/.*\\.ya?ml$"],
             "matchStrings": ["DEFAULT_GO_VERSION:\\s*\"(?<currentValue>\\d+\\.\\d+)\""],
             "depNameTemplate": "go",
             "datasourceTemplate": "golang-version",
-            "replacementStringTemplate": "{{newMajor}}.{{newMinor}}"
+            "extractVersionTemplate": "^(?<version>\\d+\\.\\d+)"
         },
         {
-            "fileMatch": ["\\.github/workflows/.*\\.ya?ml$"],
+            "customType": "regex",
+            "managerFilePatterns": ["\\.github/workflows/.*\\.ya?ml$"],
             "matchStrings": ["(?:DEFAULT_)?GOLANGCI_LINT_VERSION:\\s*\"(?<currentValue>[^\"]+)\""],
             "depNameTemplate": "golangci-lint",
             "packageNameTemplate": "golangci/golangci-lint",
@@ -59,7 +62,8 @@
             "extractVersionTemplate": "^v?(?<version>.*)$"
         },
         {
-            "fileMatch": ["\\.github/workflows/.*\\.ya?ml$"],
+            "customType": "regex",
+            "managerFilePatterns": ["\\.github/workflows/.*\\.ya?ml$"],
             "matchStrings": ["DEFAULT_TRUFFLEHOG_VERSION:\\s*\"(?<currentValue>[^\"]+)\""],
             "depNameTemplate": "trufflehog",
             "packageNameTemplate": "trufflesecurity/trufflehog",
@@ -67,7 +71,8 @@
             "extractVersionTemplate": "^v?(?<version>.*)$"
         },
         {
-            "fileMatch": ["\\.github/workflows/.*\\.ya?ml$"],
+            "customType": "regex",
+            "managerFilePatterns": ["\\.github/workflows/.*\\.ya?ml$"],
             "matchStrings": ["DEFAULT_MAGE_VERSION:\\s*\"(?<currentValue>[^\"]+)\""],
             "depNameTemplate": "mage",
             "packageNameTemplate": "magefile/mage",
@@ -75,7 +80,8 @@
             "extractVersionTemplate": "^v?(?<version>.*)$"
         },
         {
-            "fileMatch": ["\\.github/workflows/.*\\.ya?ml$"],
+            "customType": "regex",
+            "managerFilePatterns": ["\\.github/workflows/.*\\.ya?ml$"],
             "matchStrings": ["ACTIONLINT_VERSION:\\s*\"(?<currentValue>[^\"]+)\""],
             "depNameTemplate": "actionlint",
             "packageNameTemplate": "rhysd/actionlint",


### PR DESCRIPTION
Should f.ix #537. Also replaces some deprecated options with supported ones.