### PR TITLE
chore: bumping e2e version package

### DIFF
--- a/.github/workflows/playwright-docker.yml
+++ b/.github/workflows/playwright-docker.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Resolve Grafana E2E versions
         id: resolve-versions
-        uses: grafana/plugin-actions/e2e-version@e2e-version/v1.2.0
+        uses: grafana/plugin-actions/e2e-version@e2e-version/v1.2.1
         with:
           skip-grafana-dev-image: ${{ inputs.skip-grafana-dev-image }}
           skip-grafana-react-19-preview-image: ${{ inputs.skip-grafana-react-19-preview-image }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Resolve Grafana E2E versions
         id: resolve-versions
-        uses: grafana/plugin-actions/e2e-version@e2e-version/v1.2.0
+        uses: grafana/plugin-actions/e2e-version@e2e-version/v1.2.1
         with:
           skip-grafana-dev-image: ${{ inputs.skip-grafana-dev-image }}
           skip-grafana-react-19-preview-image: ${{ inputs.skip-grafana-react-19-preview-image }}


### PR DESCRIPTION
Updating e2e version package because the new version is using grafana **enterprise** react19 image instead of OSS. Mostly for consistency, OSS works just fine too.

Reference https://github.com/grafana/plugin-actions/pull/199, https://github.com/grafana/plugin-actions/pull/198