### PR TITLE
chore(act): remove DO-NOT-USE-gcom-api-url and use workflow mutator instead

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -825,8 +825,9 @@ jobs:
         id: trigger-argo-workflow
         uses: grafana/shared-workflows/actions/trigger-argo-workflow@e100806688f1209051080dfea5719fbbd1d18cc0 # trigger-argo-workflow/v1.2.1
         with:
+          instance: dev # TODO: remove
           namespace: grafana-plugins-cd
-          workflow_template: grafana-plugins-deploy
+          workflow_template: grafana-plugins-deploy-dev # TODO: switch back to stable wf template
           parameters: |
             slug=${{ fromJSON(needs.ci.outputs.plugin).id }}
             version=${{ fromJSON(needs.ci.outputs.plugin).version }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -358,14 +358,6 @@ on:
         type: boolean
         required: false
         default: false
-      DO-NOT-USE-gcom-api-url:
-        description: |
-          FOR INTERNAL TESTING ONLY, DO NOT USE.
-          If set, overrides the GCOM API URL for all publish operations.
-          Used for testing with mock GCOM servers.
-        type: string
-        required: false
-        default: ""
 
     outputs:
       # Same outputs as the CI workflow.
@@ -763,7 +755,6 @@ jobs:
           environment: ${{ matrix.environment }}
           gcom-publish-token: ${{ env.GCOM_PUBLISH_TOKEN }}
           gcloud-auth-token: ${{ steps.gcloud.outputs.id_token }}
-          gcom-api-url: ${{ inputs.DO-NOT-USE-gcom-api-url }}
 
       - name: Check artifact ZIP(s)
         id: check-artifact-zips
@@ -782,7 +773,6 @@ jobs:
           gcloud-auth-token: ${{ steps.gcloud.outputs.id_token }}
           ignore-conflicts: ${{ steps.determine-continue.outputs.ignore_conflicts }}
           publish-as-pending: ${{ matrix.environment == 'prod-canary' || inputs.publish-to-catalog-as-pending }}
-          gcom-api-url: ${{ inputs.DO-NOT-USE-gcom-api-url }}
 
       - name: Print publish summary
         run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -825,9 +825,8 @@ jobs:
         id: trigger-argo-workflow
         uses: grafana/shared-workflows/actions/trigger-argo-workflow@e100806688f1209051080dfea5719fbbd1d18cc0 # trigger-argo-workflow/v1.2.1
         with:
-          instance: dev # TODO: remove
           namespace: grafana-plugins-cd
-          workflow_template: grafana-plugins-deploy-dev # TODO: switch back to stable wf template
+          workflow_template: grafana-plugins-deploy
           parameters: |
             slug=${{ fromJSON(needs.ci.outputs.plugin).id }}
             version=${{ fromJSON(needs.ci.outputs.plugin).version }}

--- a/tests/act/main_cd_test.go
+++ b/tests/act/main_cd_test.go
@@ -161,7 +161,7 @@ func TestCD(t *testing.T) {
 				),
 
 				// Mocks
-				cd.WithMockedGCOM(runner.GCOM),
+				cd.WithMockedGCOM(t, runner.GCOM),
 				cd.MutateAllWorkflows().With(
 					workflow.WithMockedVault(t, mockVault),
 					workflow.WithMockedGitHubAppToken(t),


### PR DESCRIPTION
Changes to the GCOM API mock: remove the `DO-NOT-USE-gcom-api-url` and use a workflow mutator instead.

This prevents users from setting the input by accident, which is only used by act.