### PR TITLE
chore(deps): configure renovate for nektos/act

### DIFF
--- a/.github/workflows/pr-checks-test-ci.yml
+++ b/.github/workflows/pr-checks-test-ci.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Install act
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash -s -- -b /usr/bin "v${ACT_VERSION}"
+          curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash -s -- -b /usr/bin "${ACT_VERSION}"
         env:
           ACT_VERSION: v${{ env.ACT_VERSION }}
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/pr-checks-test-ci.yml
+++ b/.github/workflows/pr-checks-test-ci.yml
@@ -27,7 +27,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  ACT_VERSION: v0.2.82
+  ACT_VERSION: "0.2.82"
 
 permissions:
   contents: read
@@ -55,9 +55,9 @@ jobs:
 
       - name: Install act
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash -s -- -b /usr/bin "${ACT_VERSION}"
+          curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash -s -- -b /usr/bin "v${ACT_VERSION}"
         env:
-          ACT_VERSION: ${{ env.ACT_VERSION }}
+          ACT_VERSION: v${{ env.ACT_VERSION }}
           GH_TOKEN: ${{ github.token }}
         shell: bash
 

--- a/renovate.json
+++ b/renovate.json
@@ -87,6 +87,15 @@
             "packageNameTemplate": "rhysd/actionlint",
             "datasourceTemplate": "github-releases",
             "extractVersionTemplate": "^v?(?<version>.*)$"
+        },
+        {
+            "customType": "regex",
+            "managerFilePatterns": ["\\.github/workflows/.*\\.ya?ml$"],
+            "matchStrings": ["ACT_VERSION:\\s*\"(?<currentValue>[^\"]+)\""],
+            "depNameTemplate": "act",
+            "packageNameTemplate": "nektos/act",
+            "datasourceTemplate": "github-releases",
+            "extractVersionTemplate": "^v?(?<version>.*)$"
         }
     ],
     "minimumReleaseAge": "14 days",


### PR DESCRIPTION
Adds renovate config for nektos/act used by the GHA that runs act tests