### PR TITLE
fix: adjust renovate custom managers patterns for bumping tooling versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -38,7 +38,7 @@
     "customManagers": [
         {
             "customType": "regex",
-            "managerFilePatterns": ["\\.github/workflows/.*\\.ya?ml$"],
+            "managerFilePatterns": [".github/workflows/*.{yml,yaml}"],
             "matchStrings": ["DEFAULT_NODE_VERSION:\\s*\"(?<currentValue>\\d+)\""],
             "depNameTemplate": "node",
             "datasourceTemplate": "node-version",
@@ -46,7 +46,7 @@
         },
         {
             "customType": "regex",
-            "managerFilePatterns": ["\\.github/workflows/.*\\.ya?ml$"],
+            "managerFilePatterns": [".github/workflows/*.{yml,yaml}"],
             "matchStrings": ["DEFAULT_GO_VERSION:\\s*\"(?<currentValue>\\d+\\.\\d+)\""],
             "depNameTemplate": "go",
             "datasourceTemplate": "golang-version",
@@ -54,7 +54,7 @@
         },
         {
             "customType": "regex",
-            "managerFilePatterns": ["\\.github/workflows/.*\\.ya?ml$"],
+            "managerFilePatterns": [".github/workflows/*.{yml,yaml}"],
             "matchStrings": ["(?:DEFAULT_)?GOLANGCI_LINT_VERSION:\\s*\"(?<currentValue>[^\"]+)\""],
             "depNameTemplate": "golangci-lint",
             "packageNameTemplate": "golangci/golangci-lint",
@@ -63,7 +63,7 @@
         },
         {
             "customType": "regex",
-            "managerFilePatterns": ["\\.github/workflows/.*\\.ya?ml$"],
+            "managerFilePatterns": [".github/workflows/*.{yml,yaml}"],
             "matchStrings": ["DEFAULT_TRUFFLEHOG_VERSION:\\s*\"(?<currentValue>[^\"]+)\""],
             "depNameTemplate": "trufflehog",
             "packageNameTemplate": "trufflesecurity/trufflehog",
@@ -72,7 +72,7 @@
         },
         {
             "customType": "regex",
-            "managerFilePatterns": ["\\.github/workflows/.*\\.ya?ml$"],
+            "managerFilePatterns": [".github/workflows/*.{yml,yaml}"],
             "matchStrings": ["DEFAULT_MAGE_VERSION:\\s*\"(?<currentValue>[^\"]+)\""],
             "depNameTemplate": "mage",
             "packageNameTemplate": "magefile/mage",
@@ -81,7 +81,7 @@
         },
         {
             "customType": "regex",
-            "managerFilePatterns": ["\\.github/workflows/.*\\.ya?ml$"],
+            "managerFilePatterns": [".github/workflows/*.{yml,yaml}"],
             "matchStrings": ["ACTIONLINT_VERSION:\\s*\"(?<currentValue>[^\"]+)\""],
             "depNameTemplate": "actionlint",
             "packageNameTemplate": "rhysd/actionlint",
@@ -90,7 +90,7 @@
         },
         {
             "customType": "regex",
-            "managerFilePatterns": ["\\.github/workflows/.*\\.ya?ml$"],
+            "managerFilePatterns": [".github/workflows/*.{yml,yaml}"],
             "matchStrings": ["ACT_VERSION:\\s*\"(?<currentValue>[^\"]+)\""],
             "depNameTemplate": "act",
             "packageNameTemplate": "nektos/act",


### PR DESCRIPTION
The custom managers for renovate don't seem to work because there are new versions of nektos/act and go but no PRs were opened by Renovate.

Asked Claude for help:


I found the issue. The problem is in the managerFilePatterns value used by all your custom managers:

"managerFilePatterns": ["\\.github/workflows/.*\\.ya?ml$"]

This is regex syntax, but it's not wrapped in forward slashes. According to the [Renovate docs](https://docs.renovatebot.com/string-pattern-matching/), patterns that aren't enclosed in / are treated as glob patterns (parsed by minimatch), not regex. As a glob:

.* means "a dot followed by anything" (not "any characters" like in regex)
? means "any single character" (not "zero or one of the preceding" like in regex)
$ is treated as a literal character, not an end-of-string anchor
So the glob \.github/workflows/.*\.ya?ml$ will never match a file like .github/workflows/ci.yml because after /workflows/, minimatch expects a filename starting with ., which none of your workflow files do. This means none of the custom manager rules are matching any files — not just Go and act.

The fix is to either wrap in forward slashes (to use regex) or rewrite as a proper glob
