### PR TITLE
fix(ci): fix plugin-validator failing with non-standard frontend build tooling error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -568,7 +568,7 @@ jobs:
 
           # Copy workspace to a new tempdir to avoid issues when mounting the folder when running with act
           TEMP_WORKSPACE_DIR=$(mktemp -d)
-          cp -r "${PLUGIN_DIRECTORY}"/* "$TEMP_WORKSPACE_DIR/"
+          cp -r "${PLUGIN_DIRECTORY}/." "$TEMP_WORKSPACE_DIR/"
           # Add validator config file
           mv "$PLUGIN_VALIDATOR_CONFIG_PATH" "$TEMP_WORKSPACE_DIR/.plugin-validator.yaml"
           # Remove node_modules so it's not scanned by the validator


### PR DESCRIPTION
Fixes the following error in plugin-validator:

```
::error title=plugin-validator: Error: non-standard frontend build tooling::The plugin does not appear to use Grafana's standard frontend build tooling. Please use create-plugin to scaffold your plugin: https://grafana.com/developers/plugin-tools/
```

The validator added a new analyzer that inspects the .config folder. Due to a bug, the CI workflow doesn't copy hidden folders into the validator container, so .config is not visible to the validator. This PR fixes this bug and ensures that all files and folders, including hidden ones, are copied into the validator container.