### PR TITLE
fix: remove gcs artifact exists step

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -314,7 +314,7 @@ on:
           Branch or tag to publish from.
           Can be used to deploy PRs to dev.
           Can also be used to deploy specific branches (e.g.: release branches) or tags (e.g.: release tags) to any target environment.
-          In order to deploy to `prod` or `prod-canary`, where PRs or unreleased changes should not be deployed, 
+          In order to deploy to `prod` or `prod-canary`, where PRs or unreleased changes should not be deployed,
           the branch or tag must match the `release-reference-regex`, otherwise the workflow will fail.
           Defaults to `main`.
         default: main
@@ -888,10 +888,14 @@ jobs:
         shell: bash
 
       - name: Login to Google Cloud
+        id: gcloud
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
           service_account: github-plugin-ci-workflows@grafanalabs-workload-identity.iam.gserviceaccount.com
+          token_format: id_token
+          id_token_audience: 194555723165-aftshfqa32nig79trcrh96ha94ta46jd.apps.googleusercontent.com
+          id_token_include_email: true
 
       - name: "Set up Cloud SDK"
         id: gcloud-sdk
@@ -927,15 +931,28 @@ jobs:
 
       # Fail early if this version is already published in the Grafana catalog.
       # If the version exists in GCOM, re-publishing would conflict; the plugin version must be bumped.
-      # If the version is not in GCOM (e.g. a previous publish was rejected with a validation error),
+      # If the version is not in GCOM (e.g. a previous publish was rejected with a validation error or new version),
       # we proceed so the fixed artifact can be re-uploaded to GCS and re-submitted to GCOM.
+      # The highest target environment is used as the GCOM source of truth:
+      #   prod  → grafana.com       (public, no IAP)
+      #   ops   → grafana-ops.com   (IAP)
+      #   dev   → grafana-dev.com   (IAP)
       - name: Check if version is already published in Grafana catalog
         id: gcom_version_exists
         run: |
-          gcom_url="https://grafana.com/api/plugins/${PLUGIN_ID}/versions/${PLUGIN_VERSION}"
-          echo "Checking GCOM for existing version: $gcom_url"
+          if echo "${ENVIRONMENTS}" | jq -e 'contains(["prod"])' > /dev/null; then
+            gcom_url="https://grafana.com/api/plugins/${PLUGIN_ID}/versions/${PLUGIN_VERSION}"
+            curl_args=()
+          elif echo "${ENVIRONMENTS}" | jq -e 'contains(["ops"])' > /dev/null; then
+            gcom_url="https://grafana-ops.com/api/plugins/${PLUGIN_ID}/versions/${PLUGIN_VERSION}"
+            curl_args=(-H "Authorization: Bearer ${GCLOUD_ID_TOKEN}")
+          else
+            gcom_url="https://grafana-dev.com/api/plugins/${PLUGIN_ID}/versions/${PLUGIN_VERSION}"
+            curl_args=(-H "Authorization: Bearer ${GCLOUD_ID_TOKEN}")
+          fi
 
-          http_status=$(curl -sSo /dev/null -w "%{http_code}" "$gcom_url")
+          echo "Checking GCOM for existing version: $gcom_url"
+          http_status=$(curl -sSo /dev/null -w "%{http_code}" "${curl_args[@]}" "$gcom_url")
 
           if [ "$http_status" = "200" ]; then
             echo "❌ Plugin ${PLUGIN_ID} version ${PLUGIN_VERSION} is already published in the Grafana catalog."
@@ -948,6 +965,8 @@ jobs:
         env:
           PLUGIN_ID: ${{ fromJSON(needs.ci.outputs.plugin).id }}
           PLUGIN_VERSION: ${{ fromJSON(needs.ci.outputs.plugin).version }}
+          ENVIRONMENTS: ${{ needs.setup.outputs.environments }}
+          GCLOUD_ID_TOKEN: ${{ steps.gcloud.outputs.id_token }}
         shell: bash
 
       # if an artifact already exists we don't want to overwrite it

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -888,14 +888,10 @@ jobs:
         shell: bash
 
       - name: Login to Google Cloud
-        id: gcloud
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
           service_account: github-plugin-ci-workflows@grafanalabs-workload-identity.iam.gserviceaccount.com
-          token_format: id_token
-          id_token_audience: 194555723165-aftshfqa32nig79trcrh96ha94ta46jd.apps.googleusercontent.com
-          id_token_include_email: true
 
       - name: "Set up Cloud SDK"
         id: gcloud-sdk
@@ -929,71 +925,7 @@ jobs:
           GCS_UNIVERSAL_ZIP_URL_COMMIT: ${{ needs.ci.outputs.gcs-universal-zip-url-commit }}
         shell: bash
 
-      # Fail early if this version is already published in the Grafana catalog.
-      # If the version exists in GCOM, re-publishing would conflict; the plugin version must be bumped.
-      # If the version is not in GCOM (e.g. a previous publish was rejected with a validation error or new version),
-      # we proceed so the fixed artifact can be re-uploaded to GCS and re-submitted to GCOM.
-      # The highest target environment is used as the GCOM source of truth:
-      #   prod  → grafana.com       (public, no IAP)
-      #   ops   → grafana-ops.com   (IAP)
-      #   dev   → grafana-dev.com   (IAP)
-      - name: Check if version is already published in Grafana catalog
-        id: gcom_version_exists
-        run: |
-          if echo "${ENVIRONMENTS}" | jq -e 'contains(["prod"])' > /dev/null; then
-            gcom_url="https://grafana.com/api/plugins/${PLUGIN_ID}/versions/${PLUGIN_VERSION}"
-            curl_args=()
-          elif echo "${ENVIRONMENTS}" | jq -e 'contains(["ops"])' > /dev/null; then
-            gcom_url="https://grafana-ops.com/api/plugins/${PLUGIN_ID}/versions/${PLUGIN_VERSION}"
-            curl_args=(-H "Authorization: Bearer ${GCLOUD_ID_TOKEN}")
-          else
-            gcom_url="https://grafana-dev.com/api/plugins/${PLUGIN_ID}/versions/${PLUGIN_VERSION}"
-            curl_args=(-H "Authorization: Bearer ${GCLOUD_ID_TOKEN}")
-          fi
-
-          echo "Checking GCOM for existing version: $gcom_url"
-          http_status=$(curl -sSo /dev/null -w "%{http_code}" "${curl_args[@]}" "$gcom_url")
-
-          if [ "$http_status" = "200" ]; then
-            echo "❌ Plugin ${PLUGIN_ID} version ${PLUGIN_VERSION} is already published in the Grafana catalog."
-            echo "Please bump the plugin version before re-publishing."
-            exit 1
-          else
-            echo "✅ Version ${PLUGIN_VERSION} not yet published in GCOM (HTTP ${http_status}), proceeding."
-            echo "gcom_version_exists=false" >> "$GITHUB_OUTPUT"
-          fi
-        env:
-          PLUGIN_ID: ${{ fromJSON(needs.ci.outputs.plugin).id }}
-          PLUGIN_VERSION: ${{ fromJSON(needs.ci.outputs.plugin).version }}
-          ENVIRONMENTS: ${{ needs.setup.outputs.environments }}
-          GCLOUD_ID_TOKEN: ${{ steps.gcloud.outputs.id_token }}
-        shell: bash
-
-      # if an artifact already exists we don't want to overwrite it
-      # this creates conflicts with checksums and will break the release
-      # all environments use the same artifacts
-      - name: Check if artifacts already exist
-        id: gcs_artifacts_exist
-        run: |
-          bucket_path="gs://${GCS_ARTIFACTS_RELEASE_PATH_TAG}/${PLATFORM}/"
-
-          echo "Checking for any existing artifacts in: $bucket_path"
-
-          if gsutil ls "$bucket_path" 2>/dev/null | grep -q "."; then
-            echo "⚠️Existing artifact found, skipping upload"
-            echo "gcs_artifacts_exist=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "✅ No existing artifacts found, proceeding with upload"
-            echo "gcs_artifacts_exist=false" >> "$GITHUB_OUTPUT"
-          fi
-        env:
-          PLATFORM: ${{ matrix.platform }}
-          PLUGIN_VERSION: ${{ fromJSON(needs.ci.outputs.plugin).version }}
-          GCS_ARTIFACTS_RELEASE_PATH_TAG: ${{ steps.paths.outputs.gcs_artifacts_release_path_tag }}
-        shell: bash
-
       - name: Upload GCS release artifact (tag)
-        if: ${{ steps.gcs_artifacts_exist.outputs.gcs_artifacts_exist == 'false' || steps.gcom_version_exists.outputs.gcom_version_exists == 'false' }}
         uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3.0.0
         with:
           path: /tmp/dist-artifacts
@@ -1003,7 +935,6 @@ jobs:
           process_gcloudignore: false
 
       - name: Upload GCS release artifact (latest)
-        if: ${{ steps.gcs_artifacts_exist.outputs.gcs_artifacts_exist == 'false' || steps.gcom_version_exists.outputs.gcom_version_exists == 'false' }}
         uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3.0.0
         with:
           path: /tmp/dist-artifacts-latest
@@ -1013,7 +944,7 @@ jobs:
           process_gcloudignore: false
 
       - name: Upload GCS release artifacts (latest, any)
-        if: ${{ matrix.platform == 'any' && (steps.gcs_artifacts_exist.outputs.gcs_artifacts_exist == 'false' || steps.gcom_version_exists.outputs.gcom_version_exists == 'false') }}
+        if: ${{ matrix.platform == 'any' }}
         uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3.0.0
         with:
           path: /tmp/dist-artifacts-latest/${{ fromJSON(needs.ci.outputs.plugin).id }}-latest.zip

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -925,6 +925,31 @@ jobs:
           GCS_UNIVERSAL_ZIP_URL_COMMIT: ${{ needs.ci.outputs.gcs-universal-zip-url-commit }}
         shell: bash
 
+      # Fail early if this version is already published in the Grafana catalog.
+      # If the version exists in GCOM, re-publishing would conflict; the plugin version must be bumped.
+      # If the version is not in GCOM (e.g. a previous publish was rejected with a validation error),
+      # we proceed so the fixed artifact can be re-uploaded to GCS and re-submitted to GCOM.
+      - name: Check if version is already published in Grafana catalog
+        id: gcom_version_exists
+        run: |
+          gcom_url="https://grafana.com/api/plugins/${PLUGIN_ID}/versions/${PLUGIN_VERSION}"
+          echo "Checking GCOM for existing version: $gcom_url"
+
+          http_status=$(curl -sSo /dev/null -w "%{http_code}" "$gcom_url")
+
+          if [ "$http_status" = "200" ]; then
+            echo "❌ Plugin ${PLUGIN_ID} version ${PLUGIN_VERSION} is already published in the Grafana catalog."
+            echo "Please bump the plugin version before re-publishing."
+            exit 1
+          else
+            echo "✅ Version ${PLUGIN_VERSION} not yet published in GCOM (HTTP ${http_status}), proceeding."
+            echo "gcom_version_exists=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          PLUGIN_ID: ${{ fromJSON(needs.ci.outputs.plugin).id }}
+          PLUGIN_VERSION: ${{ fromJSON(needs.ci.outputs.plugin).version }}
+        shell: bash
+
       # if an artifact already exists we don't want to overwrite it
       # this creates conflicts with checksums and will break the release
       # all environments use the same artifacts
@@ -949,7 +974,7 @@ jobs:
         shell: bash
 
       - name: Upload GCS release artifact (tag)
-        if: ${{ steps.gcs_artifacts_exist.outputs.gcs_artifacts_exist == 'false' }}
+        if: ${{ steps.gcs_artifacts_exist.outputs.gcs_artifacts_exist == 'false' || steps.gcom_version_exists.outputs.gcom_version_exists == 'false' }}
         uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3.0.0
         with:
           path: /tmp/dist-artifacts
@@ -959,7 +984,7 @@ jobs:
           process_gcloudignore: false
 
       - name: Upload GCS release artifact (latest)
-        if: ${{ steps.gcs_artifacts_exist.outputs.gcs_artifacts_exist == 'false' }}
+        if: ${{ steps.gcs_artifacts_exist.outputs.gcs_artifacts_exist == 'false' || steps.gcom_version_exists.outputs.gcom_version_exists == 'false' }}
         uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3.0.0
         with:
           path: /tmp/dist-artifacts-latest
@@ -969,7 +994,7 @@ jobs:
           process_gcloudignore: false
 
       - name: Upload GCS release artifacts (latest, any)
-        if: ${{ matrix.platform == 'any' && steps.gcs_artifacts_exist.outputs.gcs_artifacts_exist == 'false' }}
+        if: ${{ matrix.platform == 'any' && (steps.gcs_artifacts_exist.outputs.gcs_artifacts_exist == 'false' || steps.gcom_version_exists.outputs.gcom_version_exists == 'false') }}
         uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3.0.0
         with:
           path: /tmp/dist-artifacts-latest/${{ fromJSON(needs.ci.outputs.plugin).id }}-latest.zip

--- a/tests/act/main_cd_test.go
+++ b/tests/act/main_cd_test.go
@@ -172,12 +172,6 @@ func TestCD(t *testing.T) {
 				cd.MutateCDWorkflow().With(
 					// Mock GCS artifacts exist safety check
 					workflow.WithNoOpStep(t, "upload-to-gcs-release", "gcloud-sdk"),
-					workflow.WithReplacedStep(
-						t, "upload-to-gcs-release", "gcs_artifacts_exist",
-						workflow.MockOutputsStep(map[string]string{
-							"gcs_artifacts_exist": "false",
-						}),
-					),
 					workflow.WithNoOpStep(t, "publish-to-catalog", "check-artifact-zips"),
 
 					// Mock IAP token for GCOM API calls


### PR DESCRIPTION
Fixes https://github.com/grafana/plugin-ci-workflows/issues/583
Always upload.
The plugin version ZIP files sent to GCOM as URLs are copied from integration-artifacts to its own grafana-plugins-catalog[-dev|-ops] bucket by GCOM (https://github.com/grafana/grafana-com/issues/14289). This was not in place when plugin-ci-workflows was originally built. Due to this, I think we can safely ALWAYS overwrite files in integration-artifacts, so we can skip the exist check completely and always allow overwrite the files (provided the ZIP files are copied to its own, read-only bucket and those files in integration-artifacts are not used anywhere else by GCOM, rather than just for downloading and re-uploading to a different bucket).

With this proposed approach, attempting to publish a plugin version whose version value already exists in the catalog, the file in integration-artifacts file would be overwritten by plugin-ci-workflows, but GCOM will reject the plugin version with "plugin version already exists" error. Provided the integration-artifacts file is not used anywhere else, it should be safe. 
