### PR TITLE
fix(act): disable sdkusage analyzer in plugin-validator tests to fix flaky tests

### DIFF
--- a/tests/act/main_validator_test.go
+++ b/tests/act/main_validator_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"path/filepath"
-	"slices"
 	"strings"
 	"testing"
 
@@ -54,17 +53,11 @@ func TestValidator(t *testing.T) {
 		expPluginValidatorVersion string
 	}{
 		{
-			name:               "simple-backend succeeds with warnings",
-			sourceFolder:       "simple-backend",
-			packagedDistFolder: "dist-artifacts-unsigned/simple-backend",
-			expSuccess:         true,
-			expAnnotations: append(slices.Clone(baseValidatorAnnotations), []act.Annotation{
-				{
-					Level:   act.AnnotationLevelWarning,
-					Title:   "plugin-validator: Warning: Your Grafana Go SDK is older than 2 months",
-					Message: `Please upgrade your Grafana Go SDK to the latest version by running: "go get -u github.com/grafana/grafana-plugin-sdk-go"`,
-				},
-			}...),
+			name:                      "simple-backend succeeds with warnings",
+			sourceFolder:              "simple-backend",
+			packagedDistFolder:        "dist-artifacts-unsigned/simple-backend",
+			expSuccess:                true,
+			expAnnotations:            baseValidatorAnnotations,
 			expPluginValidatorVersion: defaultPluginValidatorVersion,
 		},
 		{
@@ -112,7 +105,12 @@ func TestValidator(t *testing.T) {
 global:
   enabled: true
 analyzers:
+  # Disabled because it takes too much resources and time.
   osv-scanner:
+    enabled: false
+
+  # Warns if backend SDK is too old. Disabled so we don't have to bump it to fix tests.
+  sdkusage:
     enabled: false
 `
 			wf, err := ci.NewWorkflow(


### PR DESCRIPTION
Fixes #593. Disables sdkusage analyzer in the validator, which reports if the backend SDK is too old. If we don't bump the SDK in testdata, the analyzer will eventually flag the issue and cause tests to fail