### PR TITLE
feat(plugin-validator): provide a better default plugin-validator config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -556,22 +556,24 @@ jobs:
         run: |
           if [ -n "${PLUGIN_VALIDATOR_CONFIG}" ]; then
             # User-provided configuration content
-            echo "Using provided plugin-validator configuration content."
+            PLUGIN_VALIDATOR_CONFIG_SOURCE="custom"
             PLUGIN_VALIDATOR_CONFIG_PATH=$(mktemp)
             echo "${PLUGIN_VALIDATOR_CONFIG}" > "${PLUGIN_VALIDATOR_CONFIG_PATH}"
           elif [ -n "${PLUGIN_VALIDATOR_CONFIG_PATH}" ]; then
             # User-provided configuration file path
-            echo "Using plugin-validator configuration file at path: ${PLUGIN_VALIDATOR_CONFIG_PATH}"
+            PLUGIN_VALIDATOR_CONFIG_SOURCE="file"
             if [ ! -f "${PLUGIN_VALIDATOR_CONFIG_PATH}" ]; then
               echo "::error title=plugin-validator: missing config file::${PLUGIN_VALIDATOR_CONFIG_PATH} configuration file is missing."
               exit 1
             fi
           else
             # Default configuration
-            echo "No plugin-validator configuration provided. Using default configuration."
+            PLUGIN_VALIDATOR_CONFIG_SOURCE="default"
             PLUGIN_VALIDATOR_CONFIG_PATH=$(mktemp)
             echo "${DEFAULT_PLUGIN_VALIDATOR_CONFIG}" > "${PLUGIN_VALIDATOR_CONFIG_PATH}"
           fi
+
+          printf '::act-debug::msg="%s" source=%s\n' "plugin-validator configuration" "${PLUGIN_VALIDATOR_CONFIG_SOURCE}"
 
           echo "Using configuration:"
           cat "${PLUGIN_VALIDATOR_CONFIG_PATH}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,6 +302,22 @@ env:
   DEFAULT_MAGE_VERSION: "1.15.0"
   DEFAULT_PLUGIN_VALIDATOR_VERSION: "0.37.1"
 
+  # Default plugin-validator configuration, used when no configuration is provided by the caller.
+  # Disables some analyzers that are not relevant for Grafana Labs plugins.
+  DEFAULT_PLUGIN_VALIDATOR_CONFIG: |
+    global:
+      enabled: true
+
+    analyzers:
+      discoverability:
+        enabled: false
+      license:
+        enabled: false
+      org:
+        enabled: false
+      sponsorshiplink:
+        enabled: false
+
   GCS_ARTIFACTS_BUCKET: integration-artifacts
   VAULT_INSTANCE: ops
 
@@ -551,13 +567,10 @@ jobs:
               exit 1
             fi
           else
-            # Default hardcoded configuration
-            echo "${PLUGIN_VALIDATOR_CONFIG_PATH} configuration file is missing. Providing a default one as fallback."
+            # Default configuration
+            echo "No plugin-validator configuration provided. Using default configuration."
             PLUGIN_VALIDATOR_CONFIG_PATH=$(mktemp)
-            cat <<EOF > "${PLUGIN_VALIDATOR_CONFIG_PATH}"
-          global:
-            enabled: true
-          EOF
+            echo "${DEFAULT_PLUGIN_VALIDATOR_CONFIG}" > "${PLUGIN_VALIDATOR_CONFIG_PATH}"
           fi
 
           echo "Using configuration:"

--- a/tests/act/main_validator_test.go
+++ b/tests/act/main_validator_test.go
@@ -43,37 +43,61 @@ func TestValidator(t *testing.T) {
 			Message: `Your current license file contains generic text from the license template. Please make sure to replace {name of copyright owner} and {yyyy} with the correct values in your LICENSE file.`,
 		},
 	}
+	// Custom validator config used by most test cases, which disables some analyzers
+	// that are too slow or flaky for testing.
+	validatorConfig := `
+global:
+  enabled: true
+analyzers:
+  # Disabled because it takes too much resources and time.
+  osv-scanner:
+    enabled: false
+
+  # Warns if backend SDK is too old. Disabled so we don't have to bump it to fix tests.
+  sdkusage:
+    enabled: false
+`
+
 	for _, tc := range []struct {
 		name               string
 		sourceFolder       string
 		packagedDistFolder string
 
-		expSuccess                bool
-		expAnnotations            []act.Annotation
-		expPluginValidatorVersion string
+		validatorConfig *string
+
+		expSuccess                          *bool
+		expAnnotations                      []act.Annotation
+		unexpectedAnnotationTitleSubstrings []string
+		expPluginValidatorVersion           string
+		expPluginValidatorConfigSource      string
 	}{
 		{
-			name:                      "simple-backend succeeds with warnings",
-			sourceFolder:              "simple-backend",
-			packagedDistFolder:        "dist-artifacts-unsigned/simple-backend",
-			expSuccess:                true,
-			expAnnotations:            baseValidatorAnnotations,
-			expPluginValidatorVersion: defaultPluginValidatorVersion,
+			name:                           "simple-backend succeeds with warnings",
+			sourceFolder:                   "simple-backend",
+			packagedDistFolder:             "dist-artifacts-unsigned/simple-backend",
+			validatorConfig:                &validatorConfig,
+			expSuccess:                     newPointer(true),
+			expAnnotations:                 baseValidatorAnnotations,
+			expPluginValidatorVersion:      defaultPluginValidatorVersion,
+			expPluginValidatorConfigSource: "custom",
 		},
 		{
-			name:                      "simple-frontend-yarn succeeds with warnings",
-			sourceFolder:              "simple-frontend-yarn",
-			packagedDistFolder:        "dist-artifacts-unsigned/simple-frontend-yarn",
-			expSuccess:                true,
-			expAnnotations:            baseValidatorAnnotations,
-			expPluginValidatorVersion: defaultPluginValidatorVersion,
+			name:                           "simple-frontend-yarn succeeds with warnings",
+			sourceFolder:                   "simple-frontend-yarn",
+			packagedDistFolder:             "dist-artifacts-unsigned/simple-frontend-yarn",
+			validatorConfig:                &validatorConfig,
+			expSuccess:                     newPointer(true),
+			expAnnotations:                 baseValidatorAnnotations,
+			expPluginValidatorVersion:      defaultPluginValidatorVersion,
+			expPluginValidatorConfigSource: "custom",
 		},
 		// Special ZIP where the archive is malformed, used to test plugin-validator error handling
 		{
 			name:               "simple-frontend-validator-error fails",
 			sourceFolder:       "simple-frontend",
 			packagedDistFolder: "dist-artifacts-other/simple-frontend-validator-error",
-			expSuccess:         false,
+			validatorConfig:    &validatorConfig,
+			expSuccess:         newPointer(false),
 			expAnnotations: []act.Annotation{
 				{
 					Level:   act.AnnotationLevelError,
@@ -93,7 +117,29 @@ func TestValidator(t *testing.T) {
 					Message: `Fix the errors reported by archive before LLM review can run.`,
 				},
 			},
-			expPluginValidatorVersion: defaultPluginValidatorVersion,
+			expPluginValidatorVersion:      defaultPluginValidatorVersion,
+			expPluginValidatorConfigSource: "custom",
+		},
+		// Test that the default configuration (from the workflow env DEFAULT_PLUGIN_VALIDATOR_CONFIG)
+		// is used when no custom config is provided.
+		// We don't assert on success/failure or exact annotations because the default config
+		// leaves osv-scanner enabled, which may produce different results depending on the
+		// current vulnerability database. Instead, we verify the config was applied by checking
+		// that annotations from disabled analyzers are NOT present.
+		{
+			name:               "simple-frontend-yarn with default config",
+			sourceFolder:       "simple-frontend-yarn",
+			packagedDistFolder: "dist-artifacts-unsigned/simple-frontend-yarn",
+			validatorConfig:    nil,
+			// Annotations from disabled analyzers (discoverability, license, sponsorshiplink)
+			// should not appear when the default config is used.
+			unexpectedAnnotationTitleSubstrings: []string{
+				"description is empty", // discoverability analyzer
+				"License file",         // license analyzer
+				"sponsorship link",     // sponsorshiplink analyzer
+			},
+			expPluginValidatorVersion:      defaultPluginValidatorVersion,
+			expPluginValidatorConfigSource: "default",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -101,31 +147,23 @@ func TestValidator(t *testing.T) {
 			runner, err := act.NewRunner(t, act.WithLinuxAMD64ContainerArchitecture())
 			require.NoError(t, err)
 
-			validatorConfig := `
-global:
-  enabled: true
-analyzers:
-  # Disabled because it takes too much resources and time.
-  osv-scanner:
-    enabled: false
+			inputs := ci.WorkflowInputs{
+				PluginDirectory:     workflow.Input("tests/" + tc.sourceFolder),
+				DistArtifactsPrefix: workflow.Input(tc.sourceFolder + "-"),
 
-  # Warns if backend SDK is too old. Disabled so we don't have to bump it to fix tests.
-  sdkusage:
-    enabled: false
-`
+				// Disable some features to speed up the test
+				RunPlaywright: workflow.Input(false),
+				RunTruffleHog: workflow.Input(false),
+
+				// Enable the plugin validator (opt-in)
+				RunPluginValidator: workflow.Input(true),
+			}
+			if tc.validatorConfig != nil {
+				inputs.PluginValidatorConfig = tc.validatorConfig
+			}
+
 			wf, err := ci.NewWorkflow(
-				ci.WithWorkflowInputs(ci.WorkflowInputs{
-					PluginDirectory:     workflow.Input("tests/" + tc.sourceFolder),
-					DistArtifactsPrefix: workflow.Input(tc.sourceFolder + "-"),
-
-					// Disable some features to speed up the test
-					RunPlaywright: workflow.Input(false),
-					RunTruffleHog: workflow.Input(false),
-
-					// Enable the plugin validator (opt-in)
-					RunPluginValidator:    workflow.Input(true),
-					PluginValidatorConfig: workflow.Input(validatorConfig),
-				}),
+				ci.WithWorkflowInputs(inputs),
 				// Mock dist so we don't spend time building the plugin
 				ci.WithMockedPackagedDistArtifacts(t, "dist/"+tc.sourceFolder, tc.packagedDistFolder),
 			)
@@ -133,10 +171,12 @@ analyzers:
 
 			r, err := runner.Run(wf, act.NewPushEventPayload("main"))
 			require.NoError(t, err)
-			if tc.expSuccess {
-				require.True(t, r.Success, "workflow should succeed")
-			} else {
-				require.False(t, r.Success, "workflow should fail")
+			if tc.expSuccess != nil {
+				if *tc.expSuccess {
+					require.True(t, r.Success, "workflow should succeed")
+				} else {
+					require.False(t, r.Success, "workflow should fail")
+				}
 			}
 
 			// Check debug annotation with the validator version, if necessary
@@ -149,15 +189,34 @@ analyzers:
 				})
 			}
 
-			// Check annotation entries
-			require.Subset(t, r.Annotations, tc.expAnnotations)
-			var validatorAnnotationCount int
-			for _, s := range r.Annotations {
-				if strings.HasPrefix(s.Title, "plugin-validator:") {
-					validatorAnnotationCount++
+			// Check debug annotation with the validator config source
+			if tc.expPluginValidatorConfigSource != "" {
+				logFmtMsg, err := logfmt.MarshalKeyvals("msg", "plugin-validator configuration", "source", tc.expPluginValidatorConfigSource)
+				require.NoError(t, err)
+				require.Contains(t, r.Annotations, act.Annotation{
+					Level:   act.AnnotationLevelDebug,
+					Message: string(logFmtMsg),
+				})
+			}
+
+			// Check expected annotation entries and exact count
+			if tc.expAnnotations != nil {
+				require.Subset(t, r.Annotations, tc.expAnnotations)
+				var validatorAnnotationCount int
+				for _, s := range r.Annotations {
+					if strings.HasPrefix(s.Title, "plugin-validator:") {
+						validatorAnnotationCount++
+					}
+				}
+				require.Equal(t, validatorAnnotationCount, len(tc.expAnnotations), "found unexpected plugin-validator gha annotation entries")
+			}
+
+			// Check that annotations from disabled analyzers are NOT present
+			for _, unexpected := range tc.unexpectedAnnotationTitleSubstrings {
+				for _, a := range r.Annotations {
+					require.NotContains(t, a.Title, unexpected, "annotation from a disabled analyzer should not be present: %s", a.Title)
 				}
 			}
-			require.Equal(t, validatorAnnotationCount, len(tc.expAnnotations), "found unexpected plugin-validator gha annotation entries")
 		})
 	}
 }


### PR DESCRIPTION
Provides a better default configuration for plugin-validator. The new config disables some analyzers that are not relevant for Grafana Labs plugins. When using custom config, users should take care of carrying over the options from the default configuration file into the custom one.