### PR TITLE
fix: Replace cp with rsync for copying docs

### DIFF
--- a/actions/internal/plugins/docs/publish/script.sh
+++ b/actions/internal/plugins/docs/publish/script.sh
@@ -25,7 +25,7 @@ cd website
 
 docs_folder="content/docs/plugins/$plugin_id/v$plugin_version"
 mkdir -p "$docs_folder"
-cp -a "$GITHUB_WORKSPACE/docs/sources/." "$docs_folder/"
+rsync -a --quiet --delete "$GITHUB_WORKSPACE/docs/sources/" "$docs_folder"
 
 git add "$docs_folder"
 git config user.name "144369747+grafana-plugins-platform-bot[bot]@users.noreply.github.com"


### PR DESCRIPTION
Now that docs can be published to the same directory multiple times, you need to handle deleting docs that have been removed from the source directory or you end up with duplicated pages.