### PR TITLE
refactor(security): mask and unexport secrets when necessary

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1152,13 +1152,14 @@ jobs:
           common_secrets: |
             GITHUB_APP_ID=plugins-platform-bot-app:app-id
             GITHUB_APP_PRIVATE_KEY=plugins-platform-bot-app:private-key
+          export_env: false
 
       - name: Generate GitHub token
         id: generate-github-token
         uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         with:
-          app-id: ${{ env.GITHUB_APP_ID }}
-          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
+          app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
+          private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       - name: Publish docs

--- a/actions/internal/plugins/docs/publish/script.sh
+++ b/actions/internal/plugins/docs/publish/script.sh
@@ -17,9 +17,10 @@ plugin_version="$2"
 tmp=$(mktemp -d)
 cd "$tmp"
 git config --global --add safe.directory .
+git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
 git clone \
     --depth 1 --single-branch --no-tags \
-    https://$GITHUB_TOKEN@github.com/grafana/website.git
+    https://github.com/grafana/website.git
 
 cd website
 

--- a/actions/plugins/frontend-e2e-against-stack/action.yml
+++ b/actions/plugins/frontend-e2e-against-stack/action.yml
@@ -166,7 +166,12 @@ runs:
         echo "Parsing and setting plugin environment variables..."
         echo "$SECRETS_JSON" | jq -r 'to_entries[] | "\(.key)=\(.value)"' | while IFS='=' read -r key value; do
           echo "::add-mask::$value"
-          echo "$key=$value" >> "$GITHUB_ENV"
+          delimiter="ghadelim_$(openssl rand -hex 8)"
+          {
+            echo "$key<<$delimiter"
+            echo "$value"
+            echo "$delimiter"
+          } >> "$GITHUB_ENV"
         done
         echo "Plugin environment variables set."
 

--- a/actions/plugins/frontend-e2e-against-stack/action.yml
+++ b/actions/plugins/frontend-e2e-against-stack/action.yml
@@ -149,13 +149,6 @@ runs:
           HG_TOKEN=hg-ci:token
         export_env: false
 
-    - name: Mask common secrets
-      shell: bash
-      env:
-        HG_TOKEN: ${{ fromJSON(steps.get-common-secrets.outputs.secrets).HG_TOKEN }}
-      run: |
-        echo "::add-mask::$HG_TOKEN"
-
     - name: Set plugin secrets as environment variables
       id: set-env-vars
       if: ${{ inputs.plugin-secrets != '' }}

--- a/actions/plugins/frontend-e2e-against-stack/action.yml
+++ b/actions/plugins/frontend-e2e-against-stack/action.yml
@@ -149,6 +149,13 @@ runs:
           HG_TOKEN=hg-ci:token
         export_env: false
 
+    - name: Mask common secrets
+      shell: bash
+      env:
+        HG_TOKEN: ${{ fromJSON(steps.get-common-secrets.outputs.secrets).HG_TOKEN }}
+      run: |
+        echo "::add-mask::$HG_TOKEN"
+
     - name: Set plugin secrets as environment variables
       id: set-env-vars
       if: ${{ inputs.plugin-secrets != '' }}

--- a/actions/plugins/frontend-e2e-against-stack/action.yml
+++ b/actions/plugins/frontend-e2e-against-stack/action.yml
@@ -157,7 +157,10 @@ runs:
         SECRETS_JSON: "${{ inputs.plugin-secrets }}"
       run: |
         echo "Parsing and setting plugin environment variables..."
-        echo "$SECRETS_JSON" | jq -r 'to_entries[] | "echo \"\(.key)=\(.value)\" >> $GITHUB_ENV"' | bash
+        echo "$SECRETS_JSON" | jq -r 'to_entries[] | "\(.key)=\(.value)"' | while IFS='=' read -r key value; do
+          echo "::add-mask::$value"
+          echo "$key=$value" >> "$GITHUB_ENV"
+        done
         echo "Plugin environment variables set."
 
     - name: Generate provisioning

--- a/actions/plugins/release-please/action.yml
+++ b/actions/plugins/release-please/action.yml
@@ -36,6 +36,7 @@ runs:
         common_secrets: |
           GITHUB_APP_ID=plugins-platform-bot-app:app-id
           GITHUB_APP_PRIVATE_KEY=plugins-platform-bot-app:private-key
+        export_env: false
 
     - name: Generate GitHub token
       id: generate-github-token


### PR DESCRIPTION
Follow-up to #624. Improves security around how we handle secrets:
- Masking some secrets in frontend-e2e-against-stack
- Switches GitHub bot auth for docs publishing to credentials manager
- Use `export_env: false` whenever we can