### PR TITLE
feat: add cursor as trusted bot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,6 +360,7 @@ jobs:
             const trustedBots = [
               'dependabot[bot]',
               'renovate-sh-app[bot]',
+              'cursor[bot]',
               // Used by other shared workflows such as the version bump workflow
               'grafana-plugins-platform-bot[bot]'
             ].map((s) => s.toLowerCase());


### PR DESCRIPTION
Our team started to use the Cursor bot to review our PRs, and suggest and potentially apply fixes. When we apply a suggestion, Cursor pushes a commit on our branch, which triggers a run of the `ci` workflow. In these cases we saw our e2e playwright tests fail, because the secret was not passed to the playwright job, and the reason for that is that Cursor is not a trusted bot. The current workaround for us is to push an empty commit, but we'd like this process to be smoother, if possible.