### PR TITLE
feat(ci): consider "release" event as trusted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,7 +371,7 @@ jobs:
             const isTesting = process.env['INPUT_TESTING'] === 'true';
 
             // Events that are considered trusted because can be run by a trusted user (unless it's a bot)
-            const isTrustedEvent = ['push', 'workflow_dispatch'].includes(context.eventName);
+            const isTrustedEvent = ['push', 'workflow_dispatch', 'release'].includes(context.eventName);
             const isTrusted = (isTrustedEvent || (isPR && !isForkPR)) && !isTesting && (!isBot || isTrustedBot);
 
             const o = { isTrusted, isForkPR };

--- a/tests/act/internal/act/workflows.go
+++ b/tests/act/internal/act/workflows.go
@@ -19,6 +19,7 @@ const (
 	EventKindPush              EventKind = "push"
 	EventKindPullRequest       EventKind = "pull_request"
 	EventKindPullRequestTarget EventKind = "pull_request_target"
+	EventKindRelease           EventKind = "release"
 	EventKindWorkflowDispatch  EventKind = "workflow_dispatch"
 )
 

--- a/tests/act/internal/workflow/testing.go
+++ b/tests/act/internal/workflow/testing.go
@@ -382,6 +382,18 @@ func WithPullRequestTargetTrigger(branches []string) TestingWorkflowOption {
 	}
 }
 
+// WithReleaseTrigger is a TestingWorkflowOption that sets a release trigger to the workflow.
+// This can be used to test workflows that respond to release events.
+func WithReleaseTrigger(types []string) TestingWorkflowOption {
+	return func(t *TestingWorkflow) {
+		t.On = On{
+			Release: OnRelease{
+				Types: types,
+			},
+		}
+	}
+}
+
 // WithWorkflowDispatchTrigger is a TestingWorkflowOption that sets a workflow_dispatch trigger to the workflow.
 // This can be used to test workflows that are manually triggered via the GitHub UI or API.
 func WithWorkflowDispatchTrigger(inputs map[string]WorkflowCallInput) TestingWorkflowOption {

--- a/tests/act/internal/workflow/workflow.go
+++ b/tests/act/internal/workflow/workflow.go
@@ -253,6 +253,7 @@ type On struct {
 	Push              OnPush              `yaml:"push,omitempty"`
 	PullRequest       OnPullRequest       `yaml:"pull_request,omitempty"`
 	PullRequestTarget OnPullRequestTarget `yaml:"pull_request_target,omitempty"`
+	Release           OnRelease           `yaml:"release,omitempty"`
 	WorkflowCall      OnWorkflowCall      `yaml:"workflow_call,omitempty"`
 	WorkflowDispatch  OnWorkflowDispatch  `yaml:"workflow_dispatch,omitempty"`
 }
@@ -270,6 +271,11 @@ type OnPullRequest struct {
 // OnPullRequestTarget is the YAML representation of GitHub Actions pull_request_target event trigger.
 type OnPullRequestTarget struct {
 	Branches []string `yaml:"branches,omitempty"`
+}
+
+// OnRelease is the YAML representation of GitHub Actions release event trigger.
+type OnRelease struct {
+	Types []string `yaml:"types,omitempty"`
 }
 
 // OnWorkflowCall is the YAML representation of GitHub Actions workflow_call event trigger.

--- a/tests/act/main_context_test.go
+++ b/tests/act/main_context_test.go
@@ -256,4 +256,64 @@ func TestContext(t *testing.T) {
 			require.Equalf(t, tc.expIsForkPR, context.IsForkPR, "pull_request_target should not be detected as fork PR")
 		})
 	}
+
+	// Test release events - should be trusted when coming from a trusted actor
+	for _, tc := range []struct {
+		name         string
+		actor        string
+		testingInput bool
+		expIsTrusted bool
+	}{
+		// Release events are trusted (like push), so trust depends on actor + testing mode
+		{name: "release from regular user", actor: "regular-user", testingInput: false, expIsTrusted: true},
+		{name: "release from regular user (testing)", actor: "regular-user", testingInput: true, expIsTrusted: false},
+		{name: "release from trusted bot", actor: "dependabot[bot]", testingInput: false, expIsTrusted: true},
+		{name: "release from trusted bot (testing)", actor: "dependabot[bot]", testingInput: true, expIsTrusted: false},
+		{name: "release from untrusted bot", actor: "hacker[bot]", testingInput: false, expIsTrusted: false},
+		{name: "release from untrusted bot (testing)", actor: "hacker[bot]", testingInput: true, expIsTrusted: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			runner, err := act.NewRunner(t)
+			require.NoError(t, err)
+
+			wf, err := ci.NewWorkflow(
+				ci.WithWorkflowInputs(ci.WorkflowInputs{
+					PluginDirectory:     workflow.Input(filepath.Join("tests", "simple-frontend")),
+					DistArtifactsPrefix: workflow.Input("simple-frontend-"),
+					Testing:             workflow.Input(tc.testingInput),
+				}),
+				ci.MutateCIWorkflow().With(
+					workflow.WithOnlyOneJob(t, testAndBuild, false),
+					workflow.WithRemoveAllStepsAfter(t, testAndBuild, workflowContext),
+				),
+				ci.MutateTestingWorkflow().With(
+					workflow.WithReleaseTrigger([]string{"published"}),
+				),
+			)
+			require.NoError(t, err)
+
+			releaseEvent := act.NewEventPayload(act.EventKindRelease, map[string]any{
+				"action": "published",
+				"release": map[string]any{
+					"tag_name": "v1.0.0",
+				},
+			}, act.WithEventActor(tc.actor))
+
+			r, err := runner.Run(wf, releaseEvent)
+			require.NoError(t, err)
+			require.True(t, r.Success, "workflow should succeed")
+
+			contextPayload, ok := r.Outputs.Get(testAndBuild, workflowContext, "result")
+			require.True(t, ok, "output result should be present")
+			var context struct {
+				IsTrusted bool `json:"isTrusted"`
+				IsForkPR  bool `json:"isForkPR"`
+			}
+			require.NoError(t, json.Unmarshal([]byte(contextPayload), &context))
+			require.Equalf(t, tc.expIsTrusted, context.IsTrusted, "release event trust status mismatch")
+			require.False(t, context.IsForkPR, "release event should not be a fork PR")
+		})
+	}
 }


### PR DESCRIPTION
Consider "release" event as trusted, so CI/CD can be triggered from tags