### PR TITLE
fix(cd): skip latest GCS artifact upload for non-release branches

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,6 +15,14 @@ on:
     inputs:
       # Those inputs can be customized depending on the plugin's needs:
       # Publishing options (GCS and/or catalog)
+      upload-gcs-latest:
+        description: |
+          If true, upload artifacts to the GCS latest path even when triggered from a non-release reference (branch).
+          By default, the latest GCS artifacts are only uploaded when the `branch` input matches the `release-reference-regex`.
+          Set to true to force the upload of latest artifacts from any branch.
+        type: boolean
+        required: false
+        default: false
       gcs-only:
         description: |
           Only publish the plugin to GCS, do not publish the plugin to the Grafana Plugin Catalog.
@@ -547,6 +555,7 @@ jobs:
       publish-docs: ${{ steps.vars.outputs.publish-docs }}
       plugin-version-suffix: ${{ steps.vars.outputs.plugin-version-suffix }}
       platforms: ${{ steps.vars.outputs.platforms }}
+      is-release-reference: ${{ steps.vars.outputs.is-release-reference }}
     steps:
       - name: Checkout specified branch
         id: checkout-specified-branch
@@ -649,6 +658,7 @@ jobs:
               console.log(`No plugin version suffix will be used.`);
             }
             core.setOutput('plugin-version-suffix', pluginVersionSuffix);
+            core.setOutput('is-release-reference', String(isReleaseReference));
 
             // Docs only: skip plugin deployment
             if (!DISABLE_DOCS_PUBLISHING && DOCS_ONLY) {
@@ -1087,6 +1097,7 @@ jobs:
           process_gcloudignore: false
 
       - name: Upload GCS release artifact (latest)
+        if: ${{ inputs.upload-gcs-latest || needs.setup.outputs.is-release-reference == 'true' }}
         uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3.0.0
         with:
           path: /tmp/dist-artifacts-latest
@@ -1096,7 +1107,7 @@ jobs:
           process_gcloudignore: false
 
       - name: Upload GCS release artifacts (latest, any)
-        if: ${{ matrix.platform == 'any' }}
+        if: ${{ (inputs.upload-gcs-latest || needs.setup.outputs.is-release-reference == 'true') && matrix.platform == 'any' }}
         uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3.0.0
         with:
           path: /tmp/dist-artifacts-latest/${{ fromJSON(needs.ci.outputs.plugin).id }}-latest.zip

--- a/tests/act/internal/workflow/cd/cd.go
+++ b/tests/act/internal/workflow/cd/cd.go
@@ -133,6 +133,7 @@ type WorkflowInputs struct {
 	ReleaseReferenceRegex    *string
 	DocsOnly                 *bool
 	AllowPublishingPRsToProd *bool
+	UploadGCSLatest          *bool
 }
 
 // WithWorkflowInputs sets the inputs for the CD workflow.
@@ -157,6 +158,7 @@ func WithWorkflowInputs(inputs WorkflowInputs) WorkflowOption {
 		workflow.SetJobInput(job, "release-reference-regex", inputs.ReleaseReferenceRegex)
 		workflow.SetJobInput(job, "docs-only", inputs.DocsOnly)
 		workflow.SetJobInput(job, "allow-publishing-prs-to-prod", inputs.AllowPublishingPRsToProd)
+		workflow.SetJobInput(job, "upload-gcs-latest", inputs.UploadGCSLatest)
 	}
 }
 

--- a/tests/act/main_cd_setup_test.go
+++ b/tests/act/main_cd_setup_test.go
@@ -385,6 +385,42 @@ func TestCD_Setup(t *testing.T) {
 			},
 		},
 		{
+			name: "is-release-reference",
+			testCases: []testCase{
+				{
+					name:         "true when branch matches release-reference-regex",
+					triggerEvent: newPointer(act.NewPushEventPayload("main")),
+					inputs: cd.WorkflowInputs{
+						Environment: workflow.Input("dev"),
+					},
+					expOutputs: map[string]string{
+						"is-release-reference": "true",
+					},
+				},
+				{
+					name:         "false when branch does not match release-reference-regex",
+					triggerEvent: newPointer(act.NewPushEventPayload("feature-branch")),
+					inputs: cd.WorkflowInputs{
+						Environment: workflow.Input("dev"),
+					},
+					expOutputs: map[string]string{
+						"is-release-reference": "false",
+					},
+				},
+				{
+					name:         "true when branch matches custom release-reference-regex",
+					triggerEvent: newPointer(act.NewPushEventPayload("release/1.2.0")),
+					inputs: cd.WorkflowInputs{
+						Environment:           workflow.Input("dev"),
+						ReleaseReferenceRegex: workflow.Input(`release/.*`),
+					},
+					expOutputs: map[string]string{
+						"is-release-reference": "true",
+					},
+				},
+			},
+		},
+		{
 			name: "docs publishing",
 			testCases: []testCase{
 				{

--- a/tests/act/main_cd_test.go
+++ b/tests/act/main_cd_test.go
@@ -259,6 +259,136 @@ func TestCD(t *testing.T) {
 	}
 }
 
+func TestCD_GCSLatest(t *testing.T) {
+	// Tests that "latest" GCS release artifacts are only uploaded for release references,
+	// and can be forced via the upload-gcs-latest input.
+
+	const (
+		pluginVersion = "1.0.0"
+		pluginFolder  = "simple-frontend"
+		pluginSlug    = "grafana-simplefrontend-panel"
+		fakeIapToken  = "dummy-iap-token"
+	)
+
+	mockVault := workflow.VaultSecrets{
+		DefaultValue: newPointer(""),
+		CommonSecrets: map[string]string{
+			"plugins/gcom-publish-token:dev": "dummy-gcom-api-key-dev",
+		},
+	}
+
+	for _, tc := range []struct {
+		name              string
+		branch            string
+		uploadGCSLatest   bool
+		expLatestUploaded bool
+	}{
+		{
+			name:              "does not upload latest for non-release branch",
+			branch:            "feature-branch",
+			uploadGCSLatest:   false,
+			expLatestUploaded: false,
+		},
+		{
+			name:              "uploads latest for non-release branch when upload-gcs-latest is true",
+			branch:            "feature-branch",
+			uploadGCSLatest:   true,
+			expLatestUploaded: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			runner, err := act.NewRunner(t)
+			require.NoError(t, err)
+
+			runner.GCOM.HandleFunc("GET /api/plugins/{pluginID}", func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+					"id":     1,
+					"status": "active",
+					"slug":   pluginSlug,
+				}))
+			})
+			runner.GCOM.HandleFunc("POST /api/plugins", func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+					"plugin": map[string]any{"id": 1337},
+				}))
+			})
+
+			wf, err := cd.NewWorkflow(
+				cd.WithWorkflowInputs(cd.WorkflowInputs{
+					CI: ci.WorkflowInputs{
+						PluginDirectory:     workflow.Input(filepath.Join("tests", pluginFolder)),
+						DistArtifactsPrefix: workflow.Input(pluginFolder + "-"),
+						Testing:             workflow.Input(false),
+						AllowUnsigned:       workflow.Input(true),
+						RunTruffleHog:       workflow.Input(false),
+						RunPluginValidator:  workflow.Input(false),
+						RunPlaywright:       workflow.Input(false),
+					},
+					DisableDocsPublishing: workflow.Input(true),
+					DisableGitHubRelease:  workflow.Input(true),
+					Environment:           workflow.Input("dev"),
+					Scopes:                workflow.Input("universal"),
+					UploadGCSLatest:       workflow.Input(tc.uploadGCSLatest),
+				}),
+				cd.WithCIOptions(
+					ci.WithMockedPackagedDistArtifacts(
+						t,
+						"dist/"+pluginFolder,
+						"dist-artifacts-unsigned/"+pluginFolder,
+					),
+					ci.WithMockedWorkflowContext(t, ci.Context{IsTrusted: true}),
+				),
+				cd.WithMockedGCOM(t, runner.GCOM),
+				cd.MutateAllWorkflows().With(
+					workflow.WithMockedVault(t, mockVault),
+					workflow.WithMockedGitHubAppToken(t),
+					workflow.WithMockedGCS(t),
+				),
+				cd.MutateCDWorkflow().With(
+					workflow.WithNoOpStep(t, "upload-to-gcs-release", "gcloud-sdk"),
+					workflow.WithNoOpStep(t, "publish-to-catalog", "check-artifact-zips"),
+					workflow.WithReplacedStep(
+						t, "publish-to-catalog", "gcloud",
+						workflow.MockOutputsStep(map[string]string{
+							"id_token": fakeIapToken,
+						}),
+					),
+					workflow.WithMatrix("publish-to-catalog", map[string][]string{
+						"environment": {"dev"},
+					}),
+					workflow.WithMatrix("upload-to-gcs-release", map[string][]string{
+						"platform": {"any"},
+					}),
+				),
+			)
+			require.NoError(t, err)
+
+			r, err := runner.Run(wf, act.NewPushEventPayload(tc.branch))
+			require.NoError(t, err)
+			require.True(t, r.Success, "workflow should succeed")
+
+			// The "latest" release files are the ones under release/latest/ in GCS.
+			// The "any" platform zip has two entries: one in a platform subdirectory and one at the root.
+			latestFiles := []string{
+				filepath.Join("integration-artifacts", pluginSlug, "release", "latest", "any", anyZipFileName(pluginSlug, "latest")),
+				filepath.Join("integration-artifacts", pluginSlug, "release", "latest", anyZipFileName(pluginSlug, "latest")),
+			}
+
+			if tc.expLatestUploaded {
+				err = checkFilesExist(runner.GCS.Fs, latestFiles, checkFilesExistOptions{strict: false})
+				require.NoError(t, err, "release/latest/ GCS files should be present")
+			} else {
+				err = checkFilesDontExist(runner.GCS.Fs, latestFiles)
+				require.NoError(t, err, "release/latest/ GCS files should NOT be uploaded for non-release branches")
+			}
+		})
+	}
+}
+
 func gcsPublishURL(pluginSlug string, version string, platform string) string {
 	return "https://storage.googleapis.com/integration-artifacts/" + pluginSlug + "/release/" + version + "/" + platform + "/" + pluginSlug + "-" + version + ".zip"
 }


### PR DESCRIPTION
## Summary

Fixes a bug where the CD workflow would overwrite the `latest` GCS artifact path when triggered from a PR or non-release branch.

Closes grafana/plugin-ci-workflows#275

## Changes

### `cd.yml`

- **New input `upload-gcs-latest`** (boolean, default `false`): allows callers to explicitly force the `latest` upload from any branch when needed.
- **New job output `is-release-reference`** from the `setup` job: exposes whether the `branch` input matched the `release-reference-regex`. This was already computed internally but not surfaced as an output.
- **`if:` guards on both `latest` upload steps**: the steps now only run when `upload-gcs-latest` is `true` OR `is-release-reference` is `true`. For non-release branches with the default input, both steps are skipped.

## Note for reviewers
Apart from the unit tests added, I've also ran an action in https://github.com/grafana/plugins-drone-to-gha.
The results can be found here:
https://github.com/grafana/plugins-drone-to-gha/actions/runs/24337934198
The actions was triggered from this a feature branch and the PR can be seen here: https://github.com/grafana/plugins-drone-to-gha/pull/79