### PR TITLE
fix: use /api/health as default Grafana readiness URL for wait-for-grafana

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -171,7 +171,7 @@ on:
         description: The URL where Grafana is available at when running Playwright tests
         type: string
         required: false
-        default: http://localhost:3000/
+        default: http://localhost:3000/api/health
       playwright-secrets:
         description: |
           The secrets to use for Playwright tests.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ on:
         description: The URL where Grafana is available at when running Playwright tests
         type: string
         required: false
-        default: http://localhost:3000/
+        default: http://localhost:3000/api/health
       playwright-secrets:
         description: |
           The secrets to use for Playwright tests.

--- a/.github/workflows/playwright-docker.yml
+++ b/.github/workflows/playwright-docker.yml
@@ -57,7 +57,7 @@ on:
         description: The Grafana URL to wait for before running the tests
         type: string
         required: false
-        default: http://localhost:3000/
+        default: http://localhost:3000/api/health
 
 permissions:
   contents: read

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -65,7 +65,7 @@ on:
         description: The Grafana URL to wait for before running the tests
         type: string
         required: false
-        default: http://localhost:3000/
+        default: http://localhost:3000/api/health
       node-version:
         description: Node.js version to use
         type: string


### PR DESCRIPTION
## Problem

`wait-for-grafana` was timing out on Grafana v13, causing e2e jobs to fail with "Grafana never started". The action polls the configured URL every 0.5 s for 60 s looking for HTTP 200. All four workflows (`ci.yml`, `cd.yml`, `playwright.yml`, `playwright-docker.yml`) defaulted to polling `http://localhost:3000/`.

## Why `/` is unreliable in Grafana v13

The root route in Grafana is registered as:

```
r.Get("/", reqSignedIn, hs.Index)
```

`hs.Index` calls `webassets.GetWebAssets`, which reads `public/build/assets-manifest.json` from the filesystem. **If that file is absent or malformed the handler returns HTTP 500**, not 200 — so the health check loops until timeout. This affects `grafana/grafana-dev` nightly builds (OSS dev artifacts, where the manifest can be inconsistent) and may also affect early Grafana v13 Enterprise images.

Additionally, when anonymous auth is disabled (a common production configuration), `/` returns a **302 redirect** to `/login`, never satisfying the `200` check. The `/login` check used by `grafana/plugin-tools` for exactly this reason — but `/api/health` is even better because it is auth-independent.

## Why `/api/health` is chosen

`/api/health` is Grafana's canonical readiness endpoint:
- Not gated on anonymous auth or login state
- Not dependent on `assets-manifest.json` or frontend asset build state
- Returns 200 once the Grafana backend and database are ready
- Already used by Kubernetes liveness/readiness probes and monitoring

This should match the semantic intent of "wait until Grafana is ready to serve requests" more directly than checking for a 200 on the frontend app page, which does not appear to work reliably in all cases as of v13.

## Changes

Changed the default value of `grafana-url` / `playwright-grafana-url` in all four entry-point workflow files from `http://localhost:3000/` to `http://localhost:3000/api/health`.

Callers that already pass an explicit `grafana-url` override are unaffected.

## Notes

- Observed in: `grafana/grafana-dev` builds at Grafana v13.x (OSS nightly); possibly also stable Grafana Enterprise v13
- The `wait-for-grafana` action itself (`grafana/plugin-actions`) is unchanged; only the default URL passed to it changes here
- `grafana/plugin-tools` already uses `http://localhost:3000/login` for their internal e2e workflow — `/api/health` is a more robust alternative that doesn't require any particular auth mode
