### PR TITLE
fix(tests): fix setup-node and setup-go act tests

### DIFF
--- a/tests/act/internal/versions/versions.go
+++ b/tests/act/internal/versions/versions.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	nodeReleasesURL = "https://raw.githubusercontent.com/actions/node-versions/refs/heads/main/versions-manifest.json"
-	goReleasesURL   = "https://golang.org/dl/?mode=json&include=all"
+	goReleasesURL   = "https://raw.githubusercontent.com/actions/go-versions/refs/heads/main/versions-manifest.json"
 	httpTimeout     = 30 * time.Second
 )
 
@@ -23,7 +23,7 @@ type nodeRelease struct {
 }
 
 type goRelease struct {
-	Version string `json:"version"` // e.g., "go1.25.6"
+	Version string `json:"version"` // e.g., "1.25.6"
 	Stable  bool   `json:"stable"`
 }
 
@@ -56,17 +56,16 @@ func LatestGoVersion(majorMinor string) (string, error) {
 		return "", fmt.Errorf("fetch go releases: %w", err)
 	}
 
-	prefix := "go" + majorMinor
 	var candidates []string
 
 	for _, r := range releases {
 		if !r.Stable {
 			continue
 		}
-		// Match "go1.25" or "go1.25.x"
-		if r.Version == prefix || strings.HasPrefix(r.Version, prefix+".") {
-			// Convert to semver format: "go1.25.6" -> "v1.25.6"
-			v := "v" + strings.TrimPrefix(r.Version, "go")
+		// Match "1.25" or "1.25.x"
+		if r.Version == majorMinor || strings.HasPrefix(r.Version, majorMinor+".") {
+			// Convert to semver format: "1.25.6" -> "v1.25.6"
+			v := "v" + r.Version
 			candidates = append(candidates, v)
 		}
 	}

--- a/tests/act/internal/versions/versions.go
+++ b/tests/act/internal/versions/versions.go
@@ -13,13 +13,13 @@ import (
 )
 
 const (
-	nodeReleasesURL = "https://nodejs.org/download/release/index.json"
+	nodeReleasesURL = "https://raw.githubusercontent.com/actions/node-versions/refs/heads/main/versions-manifest.json"
 	goReleasesURL   = "https://golang.org/dl/?mode=json&include=all"
 	httpTimeout     = 30 * time.Second
 )
 
 type nodeRelease struct {
-	Version string `json:"version"` // e.g., "v24.12.0"
+	Version string `json:"version"` // e.g., "24.12.0"
 }
 
 type goRelease struct {
@@ -35,12 +35,13 @@ func LatestNodeVersion(major string) (string, error) {
 		return "", fmt.Errorf("fetch node releases: %w", err)
 	}
 
-	// Match versions like "v24.x.y" for major "24"
-	prefix := "v" + major + "."
+	// Match versions like "24.x.y" for major "24"
+	prefix := major + "."
 	for _, r := range releases {
 		if strings.HasPrefix(r.Version, prefix) {
 			// The releases are sorted newest first, so the first match is the latest
-			return r.Version, nil
+			// Add "v" prefix to match format used by setup-node action
+			return "v" + r.Version, nil
 		}
 	}
 


### PR DESCRIPTION
Fixes tests failing shortly after a new Node.js or Go version is released

setup-node and setup-go actions read the versions from:
- https://raw.githubusercontent.com/actions/node-versions/refs/heads/main/versions-manifest.json (instead of https://nodejs.org/download/release/index.json)
- https://raw.githubusercontent.com/actions/go-versions/refs/heads/main/versions-manifest.json (instead of https://golang.org/dl/?mode=json&include=all)

If a new Node.js or Go version is released but it hasn't been added to the setup-node/setup-go manifest yet, tests fail.

Source:
- https://github.com/actions/setup-node/blob/53b83947a5a98c8d113130e565377fae1a50d02f/src/distributions/official_builds/official_builds.ts#L187
- https://github.com/actions/setup-go/blob/78961f6f84d799cd858575bb931c3e51d3b13290/src/installer.ts#L461-L470

This PR changes the code for fetching the latest Node.js and Go versions in the tooling tests so that it's consistent with the URLs used by the setup-node and setup-go action.

The schema is also slightly different and the code has been changed to account for that too.