### PR TITLE
chore: use go version from go.mod

### DIFF
--- a/.github/workflows/pr-checks-examples-readmes.yml
+++ b/.github/workflows/pr-checks-examples-readmes.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.24"
+          go-version-file: examples/base/go.mod
 
       - name: Generate README
         working-directory: examples/base


### PR DESCRIPTION
## Summary

Replaces the hardcoded `go-version: "1.24"` in `pr-checks-examples-readmes.yml` with `go-version-file: examples/base/go.mod`

Closes #461.

## Note
`pr-checks-examples-readmes.yml` was the only place where hardcoded go version was still in use.