### PR TITLE
feat: add plugin-directory support for playwright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -707,7 +707,7 @@ jobs:
 
   playwright:
     name: Playwright E2E tests
-    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@use-plugin-directory-on-playwrite
+    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@main
     if: ${{ inputs.run-playwright == true }}
     needs:
       - test-and-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -707,7 +707,7 @@ jobs:
 
   playwright:
     name: Playwright E2E tests
-    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@main
+    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@use-plugin-directory-on-playwrite
     if: ${{ inputs.run-playwright == true }}
     needs:
       - test-and-build

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -188,6 +188,7 @@ jobs:
       - name: Install Playwright Browsers
         run: ${{ steps.setup.outputs.node-package-manager-exec-local-cmd }} playwright install --with-deps chromium
         shell: bash
+        working-directory: ${{ inputs.plugin-directory }}
 
       - name: Download GitHub artifact
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -94,6 +94,15 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Read Grafana dependency from plugin.json
+        id: read-grafana-dep
+        if: inputs.plugin-directory != '.' && inputs.grafana-dependency == ''
+        run: |
+          DEP=$(jq -r '.dependencies.grafanaDependency // empty' "${PLUGIN_DIRECTORY}/src/plugin.json")
+          echo "grafana-dependency=${DEP}" >> "$GITHUB_OUTPUT"
+        env:
+          PLUGIN_DIRECTORY: ${{ inputs.plugin-directory }}
+
       - name: Resolve Grafana E2E versions
         id: resolve-versions
         uses: grafana/plugin-actions/e2e-version@e2e-version/v1.2.1
@@ -101,7 +110,7 @@ jobs:
           skip-grafana-dev-image: ${{ inputs.skip-grafana-dev-image }}
           skip-grafana-react-19-preview-image: ${{ inputs.skip-grafana-react-19-preview-image }}
           version-resolver-type: ${{ inputs.version-resolver-type }}
-          grafana-dependency: ${{ inputs.grafana-dependency }}
+          grafana-dependency: ${{ inputs.grafana-dependency || steps.read-grafana-dep.outputs.grafana-dependency }}
 
   playwright-tests:
     needs: resolve-versions


### PR DESCRIPTION
## Summary

When a plugin lives in a subdirectory (e.g. monorepos using `plugin-directory`), the Playwright workflow failed to resolve the correct Grafana versions to test against. The `e2e-version` action always looked for `src/plugin.json` at the repo root, ignoring `plugin-directory`. The only workaround was to manually duplicate the Grafana version range via `run-playwright-with-grafana-dependency`, which is easy to forget and gets stale.

This PR eliminates the workaround by automatically reading `grafanaDependency` from the plugin's own `src/plugin.json` (inside `plugin-directory`) when neither an explicit `grafana-dependency` input nor a root-level `src/plugin.json` applies.

A secondary bug was also fixed: the "Install Playwright Browsers" step was missing `working-directory`, causing `npx` to run from the repo root (where no `node_modules` exists in a monorepo layout), which silently installed a different playwright version globally and downloaded the wrong Chromium revision.

Closes #553.

## Changes

- **`playwright.yml` — auto-read `grafanaDependency` from `plugin-directory/src/plugin.json`**
  Added a `Read Grafana dependency from plugin.json` step that runs when `plugin-directory != '.'` and no explicit `grafana-dependency` is provided. It reads `grafanaDependency` from `${plugin-directory}/src/plugin.json` using `jq` and passes it as a fallback to the `e2e-version` action. This makes the workflow self-contained for monorepo plugins without requiring any manual input.

- **`playwright.yml` — fix missing `working-directory` on browser install step**
  The `Install Playwright Browsers` step lacked `working-directory: ${{ inputs.plugin-directory }}`. When the plugin is in a subdirectory, `npx` ran from the repo root (no local `node_modules`), fell back to downloading the latest `playwright` from the registry, and installed the wrong Chromium revision — causing all E2E test jobs to fail with "Executable doesn't exist". Added the missing `working-directory` to match every other npm step in the job.

## Tests

- We checked that the changes didn't cause any issue when running without providing the plugin directory:
https://github.com/grafana/plugins-drone-to-gha/actions/runs/24903292302
https://github.com/grafana/plugins-drone-to-gha/actions/runs/24902780309

- We checked that the changes worked when provinding the plugin directory:
https://github.com/grafana/plugins-drone-to-gha/actions/runs/24901502734
