### PR TITLE
fix(cd): fix github auth error in "publish docs" job

### DIFF
--- a/actions/internal/plugins/docs/publish/script.sh
+++ b/actions/internal/plugins/docs/publish/script.sh
@@ -17,7 +17,10 @@ plugin_version="$2"
 tmp=$(mktemp -d)
 cd "$tmp"
 git config --global --add safe.directory .
-git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+# Accept either a raw token or one already prefixed with "x-access-token:"
+# so callers that pass "x-access-token:<token>" keep working.
+github_token="${GITHUB_TOKEN#x-access-token:}"
+git config --global url."https://x-access-token:${github_token}@github.com/".insteadOf "https://github.com/"
 git clone \
     --depth 1 --single-branch --no-tags \
     https://github.com/grafana/website.git


### PR DESCRIPTION
Fixes a bug introduced in #625 which makes "Publish docs" job fail with the following error:

```
Cloning into 'website'...
remote: Invalid username or token. Password authentication is not supported for Git operations.
fatal: Authentication failed for 'https://github.com/grafana/website.git/'
Error: Process completed with exit code 128.
```