### PR TITLE
chore: fix release-please paths for ci-cd-workflows component

### DIFF
--- a/.github/prompts/review-code.prompt.md
+++ b/.github/prompts/review-code.prompt.md
@@ -121,7 +121,9 @@ If a new workflow file is added that's part of `ci.yml`/`cd.yml` (like `playwrig
 
 ### New User-Facing Actions
 
-If an action is added to `actions/plugins/`, verify `release-please-config.json` is updated.
+If an action is added to `actions/plugins/`, verify `release-please-config.json` is updated in two places:
+1. A new package entry under `packages` with its `package-name`.
+2. The package path added to the `.` package's `exclude-paths` list (otherwise commits in the new plugin double-count toward the `ci-cd-workflows` release).
 
 ### Examples Directory
 
@@ -173,7 +175,7 @@ For every PR, verify:
 - [ ] No `ubuntu-latest` — using self-hosted runner labels
 - [ ] Same-repo references use `@main`
 - [ ] New shared workflows added to switch-references in all 3 files
-- [ ] New `actions/plugins/` actions added to `release-please-config.json`
+- [ ] New `actions/plugins/` actions added to `release-please-config.json` (both as a new package entry AND in the `.` package's `exclude-paths`)
 - [ ] `make genreadme` run if `examples/base/` modified
 - [ ] `make mockdata` run if `tests/simple-*` modified
 - [ ] Go errors wrapped with context

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "actions/plugins/publish/publish": "2.0.1",
-  ".github/workflows": "7.2.0",
+  ".": "7.2.0",
   "actions/plugins/version-bump-changelog": "1.1.0",
   "actions/plugins/publish/change-plugin-scope": "1.0.0",
   "actions/plugins/release-please": "1.0.1",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,9 @@ When adding a new shared workflow (internal to ci/cd), add its path to the `swit
 - `.github/workflows/release-please-pr-update-tagged-references.yml`
 - `.github/workflows/release-please-restore-rolling-release.yml`
 
-When adding a new user-facing action in `actions/plugins/`, update `release-please-config.json`.
+When adding a new user-facing action in `actions/plugins/`, update `release-please-config.json`:
+1. Add the new package entry under `packages` (with its `package-name`).
+2. Add the package path to the `.` package's `exclude-paths` list. This prevents commits in the new plugin from double-counting toward the `ci-cd-workflows` release.
 
 ## Testing Framework
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -66,6 +66,7 @@
     },
     ".": {
       "package-name": "ci-cd-workflows",
+      "changelog-path": ".github/workflows/CHANGELOG.md",
       "exclude-paths": [
         "actions/plugins/publish/publish",
         "actions/plugins/version-bump-changelog",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -64,8 +64,15 @@
     "actions/plugins/frontend-e2e-against-stack": {
       "package-name": "plugins-frontend-e2e-against-stack"
     },
-    ".github/workflows": {
-      "package-name": "ci-cd-workflows"
+    ".": {
+      "package-name": "ci-cd-workflows",
+      "exclude-paths": [
+        "actions/plugins/publish/publish",
+        "actions/plugins/version-bump-changelog",
+        "actions/plugins/publish/change-plugin-scope",
+        "actions/plugins/release-please",
+        "actions/plugins/frontend-e2e-against-stack"
+      ]
     }
   },
   "release-type": "simple",


### PR DESCRIPTION
Fixes an issue with release-please config that prevents changes outside of `.github/workflows` (e.g.: `actions/internal`) to trigger the release-please PR, when in reality it should as those actions are **referenced** by the workflows, even if they do not cause changes within the `.github/workflows` folder

Also updates agents markdown files with this new pattern.