### PR TITLE
fix(cd): fix docs publishing failing due to missing rsync

### DIFF
--- a/actions/internal/plugins/docs/publish/script.sh
+++ b/actions/internal/plugins/docs/publish/script.sh
@@ -11,6 +11,9 @@ if [ -z "$GITHUB_TOKEN" ]; then
     exit 1
 fi
 
+echo "Installing pre-requisites"
+apk add rsync
+
 plugin_id="$1"
 plugin_version="$2"
 


### PR DESCRIPTION
Fixes the following error when publishing docs:

```
/home/runner/work/_actions/grafana/plugin-ci-workflows/ci-cd-workflows/v7.3.0/actions/internal/plugins/docs/publish/script.sh: line 32: rsync: command not found
Error: Process completed with exit code 127.
```