### PR TITLE
feat(playwright)!: bump e2e-version to v2.0.0

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -130,8 +130,13 @@ on:
         description: "Optionally, use this input to pass a semver range of supported Grafana versions to test against. This is only used when version-resolver-type is plugin-grafana-dependency. If not provided, the action will try to read grafanaDependency from the plugin.json file."
         type: string
         required: false
+      run-playwright-with-skip-grafana-nightly-image:
+        description: "Optionally, you can skip the Grafana nightly image"
+        type: boolean
+        required: false
+        default: false
       run-playwright-with-skip-grafana-dev-image:
-        description: "Optionally, you can skip the Grafana dev image"
+        description: "Deprecated: use run-playwright-with-skip-grafana-nightly-image instead"
         type: boolean
         required: false
         default: false
@@ -766,7 +771,7 @@ jobs:
       run-playwright: ${{ inputs.run-playwright }}
       run-playwright-docker: ${{ inputs.run-playwright-docker }}
       run-playwright-with-grafana-dependency: ${{ inputs.run-playwright-with-grafana-dependency }}
-      run-playwright-with-skip-grafana-dev-image: ${{ inputs.run-playwright-with-skip-grafana-dev-image }}
+      run-playwright-with-skip-grafana-nightly-image: ${{ inputs.run-playwright-with-skip-grafana-nightly-image || inputs.run-playwright-with-skip-grafana-dev-image }}
       run-playwright-with-skip-grafana-react-19-preview-image: ${{ inputs.run-playwright-with-skip-grafana-react-19-preview-image }}
       run-playwright-with-version-resolver-type: ${{ inputs.run-playwright-with-version-resolver-type }}
       upload-playwright-artifacts: ${{ inputs.upload-playwright-artifacts }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -771,7 +771,8 @@ jobs:
       run-playwright: ${{ inputs.run-playwright }}
       run-playwright-docker: ${{ inputs.run-playwright-docker }}
       run-playwright-with-grafana-dependency: ${{ inputs.run-playwright-with-grafana-dependency }}
-      run-playwright-with-skip-grafana-nightly-image: ${{ inputs.run-playwright-with-skip-grafana-nightly-image || inputs.run-playwright-with-skip-grafana-dev-image }}
+      run-playwright-with-skip-grafana-nightly-image: ${{ inputs.run-playwright-with-skip-grafana-nightly-image }}
+      run-playwright-with-skip-grafana-dev-image: ${{ inputs.run-playwright-with-skip-grafana-dev-image }}
       run-playwright-with-skip-grafana-react-19-preview-image: ${{ inputs.run-playwright-with-skip-grafana-react-19-preview-image }}
       run-playwright-with-version-resolver-type: ${{ inputs.run-playwright-with-version-resolver-type }}
       upload-playwright-artifacts: ${{ inputs.upload-playwright-artifacts }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,8 +103,13 @@ on:
           If not provided, the action will try to read grafanaDependency from the plugin.json file.
         type: string
         required: false
+      run-playwright-with-skip-grafana-nightly-image:
+        description: Optionally, you can skip the Grafana nightly image
+        type: boolean
+        required: false
+        default: false
       run-playwright-with-skip-grafana-dev-image:
-        description: Optionally, you can skip the Grafana dev image
+        description: "Deprecated: use run-playwright-with-skip-grafana-nightly-image instead"
         type: boolean
         required: false
         default: false
@@ -725,7 +730,7 @@ jobs:
       gar-registry: ${{ inputs.playwright-gar-registry }}
       plugin-directory: ${{ inputs.plugin-directory }}
       grafana-dependency: ${{ inputs.run-playwright-with-grafana-dependency }}
-      skip-grafana-dev-image: ${{ inputs.run-playwright-with-skip-grafana-dev-image }}
+      skip-grafana-nightly-image: ${{ inputs.run-playwright-with-skip-grafana-nightly-image || inputs.run-playwright-with-skip-grafana-dev-image }}
       skip-grafana-react-19-preview-image: ${{ inputs.run-playwright-with-skip-grafana-react-19-preview-image }}
       version-resolver-type: ${{ inputs.run-playwright-with-version-resolver-type }}
       upload-artifacts: ${{ inputs.upload-playwright-artifacts }}
@@ -748,7 +753,7 @@ jobs:
       version: ${{ fromJSON(needs.test-and-build.outputs.plugin).version}}
       gar-registry: ${{ inputs.playwright-gar-registry }}
       grafana-dependency: ${{ inputs.run-playwright-with-grafana-dependency }}
-      skip-grafana-dev-image: ${{ inputs.run-playwright-with-skip-grafana-dev-image }}
+      skip-grafana-nightly-image: ${{ inputs.run-playwright-with-skip-grafana-nightly-image || inputs.run-playwright-with-skip-grafana-dev-image }}
       skip-grafana-react-19-preview-image: ${{ inputs.run-playwright-with-skip-grafana-react-19-preview-image }}
       version-resolver-type: ${{ inputs.run-playwright-with-version-resolver-type }}
       upload-artifacts: ${{ inputs.upload-playwright-artifacts }}

--- a/.github/workflows/playwright-docker.yml
+++ b/.github/workflows/playwright-docker.yml
@@ -21,10 +21,16 @@ on:
         type: string
         required: false
       # https://github.com/grafana/plugin-actions/blob/main/e2e-version/action.yml
+      skip-grafana-nightly-image:
+        default: false
+        required: false
+        type: boolean
+        description: Optionally, you can skip the Grafana nightly image
       skip-grafana-dev-image:
         default: false
         required: false
         type: boolean
+        description: "Deprecated: use skip-grafana-nightly-image instead"
       skip-grafana-react-19-preview-image:
         default: false
         required: false
@@ -78,9 +84,9 @@ jobs:
 
       - name: Resolve Grafana E2E versions
         id: resolve-versions
-        uses: grafana/plugin-actions/e2e-version@e2e-version/v1.2.1
+        uses: grafana/plugin-actions/e2e-version@73cd57e848b81e75e3c17697e6701c9fa1404bcc # e2e-version/v2.0.0
         with:
-          skip-grafana-dev-image: ${{ inputs.skip-grafana-dev-image }}
+          skip-grafana-nightly-image: ${{ inputs.skip-grafana-nightly-image || inputs.skip-grafana-dev-image }}
           skip-grafana-react-19-preview-image: ${{ inputs.skip-grafana-react-19-preview-image }}
           version-resolver-type: ${{ inputs.version-resolver-type }}
           grafana-dependency: ${{ inputs.grafana-dependency }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -24,10 +24,16 @@ on:
         required: false
         default: .
       # https://github.com/grafana/plugin-actions/blob/main/e2e-version/action.yml
+      skip-grafana-nightly-image:
+        default: false
+        required: false
+        type: boolean
+        description: Optionally, you can skip the Grafana nightly image
       skip-grafana-dev-image:
         default: false
         required: false
         type: boolean
+        description: "Deprecated: use skip-grafana-nightly-image instead"
       skip-grafana-react-19-preview-image:
         default: false
         required: false
@@ -96,9 +102,9 @@ jobs:
 
       - name: Resolve Grafana E2E versions
         id: resolve-versions
-        uses: grafana/plugin-actions/e2e-version@e2e-version/v1.2.1
+        uses: grafana/plugin-actions/e2e-version@73cd57e848b81e75e3c17697e6701c9fa1404bcc # e2e-version/v2.0.0
         with:
-          skip-grafana-dev-image: ${{ inputs.skip-grafana-dev-image }}
+          skip-grafana-nightly-image: ${{ inputs.skip-grafana-nightly-image || inputs.skip-grafana-dev-image }}
           skip-grafana-react-19-preview-image: ${{ inputs.skip-grafana-react-19-preview-image }}
           version-resolver-type: ${{ inputs.version-resolver-type }}
           grafana-dependency: ${{ inputs.grafana-dependency }}


### PR DESCRIPTION
Bumps `grafana/plugin-actions/e2e-version` from v1.2.1 to v2.0.0.

## ⚠ Breaking change

Plugins will now test against `grafana-enterprise:nightly` instead of the `grafana-dev` image. No workflow file changes are needed, but test results may differ.

## What changed

e2e-version v2.0.0 switches the nightly Grafana image from `grafana-dev` to `grafana-enterprise:nightly` and renames the controlling input from `skip-grafana-dev-image` to `skip-grafana-nightly-image`.

## Changes in this repo

- `playwright.yml`, `playwright-docker.yml`: bump action to v2.0.0, add `skip-grafana-nightly-image` input, pass `nightly-image || dev-image` to the action
- `ci.yml`, `cd.yml`: add `run-playwright-with-skip-grafana-nightly-image` input alongside the deprecated `run-playwright-with-skip-grafana-dev-image`

The old `skip-grafana-dev-image` / `run-playwright-with-skip-grafana-dev-image` inputs are kept and still honoured, so existing plugin workflows continue to work without changes.

## Testing

To test before merging, point a plugin's CI temporarily at this branch:

```yaml
uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@feat/bump-e2e-version-v2
```