### PR TITLE
feat(playwright): add plugin-directory input to e2e-version

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -114,7 +114,6 @@ on:
         description: "Optionally, use this input to pass a semver range of supported Grafana versions to test against. This is only used when version-resolver-type is plugin-grafana-dependency. If not provided, the action will try to read grafanaDependency from the plugin.json file."
         type: string
         required: false
-
       run-playwright-with-skip-grafana-dev-image:
         description: "Optionally, you can skip the Grafana dev image"
         type: boolean
@@ -614,7 +613,6 @@ jobs:
       run-playwright: ${{ inputs.run-playwright }}
       run-playwright-docker: ${{ inputs.run-playwright-docker }}
       run-playwright-with-grafana-dependency: ${{ inputs.run-playwright-with-grafana-dependency }}
-
       run-playwright-with-skip-grafana-dev-image: ${{ inputs.run-playwright-with-skip-grafana-dev-image }}
       run-playwright-with-skip-grafana-react-19-preview-image: ${{ inputs.run-playwright-with-skip-grafana-react-19-preview-image }}
       run-playwright-with-version-resolver-type: ${{ inputs.run-playwright-with-version-resolver-type }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -114,10 +114,7 @@ on:
         description: "Optionally, use this input to pass a semver range of supported Grafana versions to test against. This is only used when version-resolver-type is plugin-grafana-dependency. If not provided, the action will try to read grafanaDependency from the plugin.json file."
         type: string
         required: false
-      run-playwright-with-plugin-path:
-        description: Path to the plugin root directory containing src/plugin.json. Only used when version-resolver-type is plugin-grafana-dependency and grafana-dependency is not set.
-        type: string
-        required: false
+
       run-playwright-with-skip-grafana-dev-image:
         description: "Optionally, you can skip the Grafana dev image"
         type: boolean
@@ -617,7 +614,7 @@ jobs:
       run-playwright: ${{ inputs.run-playwright }}
       run-playwright-docker: ${{ inputs.run-playwright-docker }}
       run-playwright-with-grafana-dependency: ${{ inputs.run-playwright-with-grafana-dependency }}
-      run-playwright-with-plugin-path: ${{ inputs.run-playwright-with-plugin-path }}
+
       run-playwright-with-skip-grafana-dev-image: ${{ inputs.run-playwright-with-skip-grafana-dev-image }}
       run-playwright-with-skip-grafana-react-19-preview-image: ${{ inputs.run-playwright-with-skip-grafana-react-19-preview-image }}
       run-playwright-with-version-resolver-type: ${{ inputs.run-playwright-with-version-resolver-type }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -114,6 +114,10 @@ on:
         description: "Optionally, use this input to pass a semver range of supported Grafana versions to test against. This is only used when version-resolver-type is plugin-grafana-dependency. If not provided, the action will try to read grafanaDependency from the plugin.json file."
         type: string
         required: false
+      run-playwright-with-plugin-path:
+        description: Path to the plugin root directory containing src/plugin.json. Only used when version-resolver-type is plugin-grafana-dependency and grafana-dependency is not set.
+        type: string
+        required: false
       run-playwright-with-skip-grafana-dev-image:
         description: "Optionally, you can skip the Grafana dev image"
         type: boolean
@@ -613,6 +617,7 @@ jobs:
       run-playwright: ${{ inputs.run-playwright }}
       run-playwright-docker: ${{ inputs.run-playwright-docker }}
       run-playwright-with-grafana-dependency: ${{ inputs.run-playwright-with-grafana-dependency }}
+      run-playwright-with-plugin-path: ${{ inputs.run-playwright-with-plugin-path }}
       run-playwright-with-skip-grafana-dev-image: ${{ inputs.run-playwright-with-skip-grafana-dev-image }}
       run-playwright-with-skip-grafana-react-19-preview-image: ${{ inputs.run-playwright-with-skip-grafana-react-19-preview-image }}
       run-playwright-with-version-resolver-type: ${{ inputs.run-playwright-with-version-resolver-type }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,6 @@ on:
           If not provided, the action will try to read grafanaDependency from the plugin.json file.
         type: string
         required: false
-
       run-playwright-with-skip-grafana-dev-image:
         description: Optionally, you can skip the Grafana dev image
         type: boolean

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,10 +91,7 @@ on:
           If not provided, the action will try to read grafanaDependency from the plugin.json file.
         type: string
         required: false
-      run-playwright-with-plugin-path:
-        description: Path to the plugin root directory containing src/plugin.json. Only used when version-resolver-type is plugin-grafana-dependency and grafana-dependency is not set.
-        type: string
-        required: false
+
       run-playwright-with-skip-grafana-dev-image:
         description: Optionally, you can skip the Grafana dev image
         type: boolean
@@ -693,7 +690,6 @@ jobs:
       version: ${{ fromJSON(needs.test-and-build.outputs.plugin).version}}
       plugin-directory: ${{ inputs.plugin-directory }}
       grafana-dependency: ${{ inputs.run-playwright-with-grafana-dependency }}
-      plugin-path: ${{ inputs.run-playwright-with-plugin-path }}
       skip-grafana-dev-image: ${{ inputs.run-playwright-with-skip-grafana-dev-image }}
       skip-grafana-react-19-preview-image: ${{ inputs.run-playwright-with-skip-grafana-react-19-preview-image }}
       version-resolver-type: ${{ inputs.run-playwright-with-version-resolver-type }}
@@ -716,7 +712,7 @@ jobs:
       id: ${{ fromJSON(needs.test-and-build.outputs.plugin).id}}
       version: ${{ fromJSON(needs.test-and-build.outputs.plugin).version}}
       grafana-dependency: ${{ inputs.run-playwright-with-grafana-dependency }}
-      plugin-path: ${{ inputs.run-playwright-with-plugin-path }}
+      plugin-directory: ${{ inputs.plugin-directory }}
       skip-grafana-dev-image: ${{ inputs.run-playwright-with-skip-grafana-dev-image }}
       skip-grafana-react-19-preview-image: ${{ inputs.run-playwright-with-skip-grafana-react-19-preview-image }}
       version-resolver-type: ${{ inputs.run-playwright-with-version-resolver-type }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,10 @@ on:
           If not provided, the action will try to read grafanaDependency from the plugin.json file.
         type: string
         required: false
+      run-playwright-with-plugin-path:
+        description: Path to the plugin root directory containing src/plugin.json. Only used when version-resolver-type is plugin-grafana-dependency and grafana-dependency is not set.
+        type: string
+        required: false
       run-playwright-with-skip-grafana-dev-image:
         description: Optionally, you can skip the Grafana dev image
         type: boolean
@@ -689,6 +693,7 @@ jobs:
       version: ${{ fromJSON(needs.test-and-build.outputs.plugin).version}}
       plugin-directory: ${{ inputs.plugin-directory }}
       grafana-dependency: ${{ inputs.run-playwright-with-grafana-dependency }}
+      plugin-path: ${{ inputs.run-playwright-with-plugin-path }}
       skip-grafana-dev-image: ${{ inputs.run-playwright-with-skip-grafana-dev-image }}
       skip-grafana-react-19-preview-image: ${{ inputs.run-playwright-with-skip-grafana-react-19-preview-image }}
       version-resolver-type: ${{ inputs.run-playwright-with-version-resolver-type }}
@@ -711,6 +716,7 @@ jobs:
       id: ${{ fromJSON(needs.test-and-build.outputs.plugin).id}}
       version: ${{ fromJSON(needs.test-and-build.outputs.plugin).version}}
       grafana-dependency: ${{ inputs.run-playwright-with-grafana-dependency }}
+      plugin-path: ${{ inputs.run-playwright-with-plugin-path }}
       skip-grafana-dev-image: ${{ inputs.run-playwright-with-skip-grafana-dev-image }}
       skip-grafana-react-19-preview-image: ${{ inputs.run-playwright-with-skip-grafana-react-19-preview-image }}
       version-resolver-type: ${{ inputs.run-playwright-with-version-resolver-type }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -684,7 +684,7 @@ jobs:
 
   playwright:
     name: Playwright E2E tests
-    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@ci-cd-workflows/v6.1.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@feat/e2e-version-plugin-path
     if: ${{ inputs.run-playwright == true }}
     needs:
       - test-and-build
@@ -708,7 +708,7 @@ jobs:
 
   playwright-docker:
     name: Plugins - Dockerized Playwright E2E tests
-    uses: grafana/plugin-ci-workflows/.github/workflows/playwright-docker.yml@ci-cd-workflows/v6.1.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/playwright-docker.yml@feat/e2e-version-plugin-path
     if: ${{ inputs.run-playwright-docker == true }}
     needs:
       - test-and-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -773,7 +773,7 @@ jobs:
 
   playwright:
     name: Playwright E2E tests
-    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@feat/e2e-version-plugin-path
+    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@main
     if: ${{ inputs.run-playwright == true }}
     needs:
       - test-and-build
@@ -800,7 +800,7 @@ jobs:
 
   playwright-docker:
     name: Plugins - Dockerized Playwright E2E tests
-    uses: grafana/plugin-ci-workflows/.github/workflows/playwright-docker.yml@feat/e2e-version-plugin-path
+    uses: grafana/plugin-ci-workflows/.github/workflows/playwright-docker.yml@main
     if: ${{ inputs.run-playwright-docker == true }}
     needs:
       - test-and-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -773,7 +773,7 @@ jobs:
 
   playwright:
     name: Playwright E2E tests
-    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@main
+    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@feat/e2e-version-plugin-path
     if: ${{ inputs.run-playwright == true }}
     needs:
       - test-and-build
@@ -800,7 +800,7 @@ jobs:
 
   playwright-docker:
     name: Plugins - Dockerized Playwright E2E tests
-    uses: grafana/plugin-ci-workflows/.github/workflows/playwright-docker.yml@main
+    uses: grafana/plugin-ci-workflows/.github/workflows/playwright-docker.yml@feat/e2e-version-plugin-path
     if: ${{ inputs.run-playwright-docker == true }}
     needs:
       - test-and-build
@@ -808,6 +808,7 @@ jobs:
       id: ${{ fromJSON(needs.test-and-build.outputs.plugin).id}}
       version: ${{ fromJSON(needs.test-and-build.outputs.plugin).version}}
       gar-registry: ${{ inputs.playwright-gar-registry }}
+      plugin-directory: ${{ inputs.plugin-directory }}
       grafana-dependency: ${{ inputs.run-playwright-with-grafana-dependency }}
       skip-grafana-nightly-image: ${{ inputs.run-playwright-with-skip-grafana-nightly-image || inputs.run-playwright-with-skip-grafana-dev-image }}
       version-resolver-type: ${{ inputs.run-playwright-with-version-resolver-type }}

--- a/.github/workflows/playwright-docker.yml
+++ b/.github/workflows/playwright-docker.yml
@@ -33,6 +33,10 @@ on:
       grafana-dependency:
         required: false
         type: string
+      plugin-path:
+        required: false
+        type: string
+        description: Path to the plugin root directory containing src/plugin.json. Only used when version-resolver-type is plugin-grafana-dependency and grafana-dependency is not set.
       upload-artifacts:
         required: false
         type: boolean
@@ -75,12 +79,13 @@ jobs:
 
       - name: Resolve Grafana E2E versions
         id: resolve-versions
-        uses: grafana/plugin-actions/e2e-version@e2e-version/v1.2.1
+        uses: grafana/plugin-actions/e2e-version@c81db32e08b8b880fc68f758eb60c29673878150 # feat/plugin-path-input (grafana/plugin-actions#212)
         with:
           skip-grafana-dev-image: ${{ inputs.skip-grafana-dev-image }}
           skip-grafana-react-19-preview-image: ${{ inputs.skip-grafana-react-19-preview-image }}
           version-resolver-type: ${{ inputs.version-resolver-type }}
           grafana-dependency: ${{ inputs.grafana-dependency }}
+          plugin-path: ${{ inputs.plugin-path }}
 
   playwright-tests:
     needs: resolve-versions

--- a/.github/workflows/playwright-docker.yml
+++ b/.github/workflows/playwright-docker.yml
@@ -33,7 +33,7 @@ on:
       grafana-dependency:
         required: false
         type: string
-      plugin-path:
+      plugin-directory:
         required: false
         type: string
         description: Path to the plugin root directory containing src/plugin.json. Only used when version-resolver-type is plugin-grafana-dependency and grafana-dependency is not set.
@@ -85,7 +85,7 @@ jobs:
           skip-grafana-react-19-preview-image: ${{ inputs.skip-grafana-react-19-preview-image }}
           version-resolver-type: ${{ inputs.version-resolver-type }}
           grafana-dependency: ${{ inputs.grafana-dependency }}
-          plugin-path: ${{ inputs.plugin-path }}
+          plugin-directory: ${{ inputs.plugin-directory }}
 
   playwright-tests:
     needs: resolve-versions

--- a/.github/workflows/playwright-docker.yml
+++ b/.github/workflows/playwright-docker.yml
@@ -20,6 +20,11 @@ on:
       gar-registry:
         type: string
         required: false
+      plugin-directory:
+        description: Directory of the plugin, if not in the root of the repository.
+        type: string
+        required: false
+        default: .
       # https://github.com/grafana/plugin-actions/blob/main/e2e-version/action.yml
       skip-grafana-nightly-image:
         default: false
@@ -80,11 +85,12 @@ jobs:
 
       - name: Resolve Grafana E2E versions
         id: resolve-versions
-        uses: grafana/plugin-actions/e2e-version@304ed38a05911eda030608b10ff9ca59616e465c # e2e-version/v3.0.1
+        uses: grafana/plugin-actions/e2e-version@64ea9946103fc0a569c53cf53d27f568af2a44ce # e2e-version/v3.1.0
         with:
           skip-grafana-nightly-image: ${{ inputs.skip-grafana-nightly-image || inputs.skip-grafana-dev-image }}
           version-resolver-type: ${{ inputs.version-resolver-type }}
           grafana-dependency: ${{ inputs.grafana-dependency }}
+          plugin-directory: ${{ inputs.plugin-directory }}
 
   playwright-tests:
     needs: resolve-versions

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -36,6 +36,10 @@ on:
       grafana-dependency:
         required: false
         type: string
+      plugin-path:
+        required: false
+        type: string
+        description: Path to the plugin root directory containing src/plugin.json. Only used when version-resolver-type is plugin-grafana-dependency and grafana-dependency is not set.
       upload-artifacts:
         required: false
         type: boolean
@@ -93,12 +97,13 @@ jobs:
 
       - name: Resolve Grafana E2E versions
         id: resolve-versions
-        uses: grafana/plugin-actions/e2e-version@e2e-version/v1.2.1
+        uses: grafana/plugin-actions/e2e-version@c81db32e08b8b880fc68f758eb60c29673878150 # feat/plugin-path-input (grafana/plugin-actions#212)
         with:
           skip-grafana-dev-image: ${{ inputs.skip-grafana-dev-image }}
           skip-grafana-react-19-preview-image: ${{ inputs.skip-grafana-react-19-preview-image }}
           version-resolver-type: ${{ inputs.version-resolver-type }}
           grafana-dependency: ${{ inputs.grafana-dependency }}
+          plugin-path: ${{ inputs.plugin-path }}
 
   playwright-tests:
     needs: resolve-versions

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -36,10 +36,6 @@ on:
       grafana-dependency:
         required: false
         type: string
-      plugin-path:
-        required: false
-        type: string
-        description: Path to the plugin root directory containing src/plugin.json. Only used when version-resolver-type is plugin-grafana-dependency and grafana-dependency is not set.
       upload-artifacts:
         required: false
         type: boolean
@@ -103,7 +99,7 @@ jobs:
           skip-grafana-react-19-preview-image: ${{ inputs.skip-grafana-react-19-preview-image }}
           version-resolver-type: ${{ inputs.version-resolver-type }}
           grafana-dependency: ${{ inputs.grafana-dependency }}
-          plugin-path: ${{ inputs.plugin-path }}
+          plugin-directory: ${{ inputs.plugin-directory }}
 
   playwright-tests:
     needs: resolve-versions

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -245,6 +245,7 @@ jobs:
 
       - name: Install Playwright browsers
         shell: bash
+        working-directory: ${{ inputs.plugin-directory }}
         env:
           PLAYWRIGHT_BROWSERS_LIST: ${{ steps.browsers.outputs.list }}
           NPM_EXEC_CMD: ${{ steps.setup.outputs.node-package-manager-exec-local-cmd }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -130,11 +130,12 @@ jobs:
 
       - name: Resolve Grafana E2E versions
         id: resolve-versions
-        uses: grafana/plugin-actions/e2e-version@304ed38a05911eda030608b10ff9ca59616e465c # e2e-version/v3.0.1
+        uses: grafana/plugin-actions/e2e-version@64ea9946103fc0a569c53cf53d27f568af2a44ce # e2e-version/v3.1.0
         with:
           skip-grafana-nightly-image: ${{ inputs.skip-grafana-nightly-image || inputs.skip-grafana-dev-image }}
           version-resolver-type: ${{ inputs.version-resolver-type }}
           grafana-dependency: ${{ inputs.grafana-dependency }}
+          plugin-directory: ${{ inputs.plugin-directory }}
 
   playwright-tests:
     needs: resolve-versions


### PR DESCRIPTION
Passes `plugin-directory` through to `grafana/plugin-actions/e2e-version` (pinned to `e2e-version/v3.1.0`, see grafana/plugin-actions#212) so it can find `src/plugin.json` for plugins in a subdirectory. `playwright.yml` already had the input; `playwright-docker.yml` gains it, and `ci.yml` forwards it to both jobs.

Tested against a real monorepo plugin (`grafana-query-app`) via a temporary branch pointer, since reverted back to `@main`.