### PR TITLE
fix(cd): pass provenance attestation to catalog publish

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1004,7 +1004,14 @@ jobs:
     needs:
       - ci
       - publish-to-catalog
-    if: ${{ inputs.grafana-cloud-deployment-type != '' && inputs.trigger-argo }}
+    if: >-
+      ${{
+        !cancelled()
+        && needs.ci.result == 'success'
+        && needs.publish-to-catalog.result == 'success'
+        && inputs.grafana-cloud-deployment-type != ''
+        && inputs.trigger-argo
+      }}
 
     steps:
       - name: Check deployment type

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -806,6 +806,7 @@ jobs:
       attestation-id: ${{ steps.attestation.outputs.attestation-id }}
       attestation-url: ${{ steps.attestation.outputs.attestation-url }}
       bundle-path: ${{ steps.attestation.outputs.bundle-path }}
+      provenance-attestation: ${{ steps.provenance-attestation.outputs.provenance-attestation }}
 
     steps:
       - name: Download GitHub artifact
@@ -832,13 +833,50 @@ jobs:
         with:
           subject-path: /tmp/dist-artifacts/*.zip
 
+      - name: Generate provenance attestation reference
+        if: ${{ inputs.attestation }}
+        id: provenance-attestation
+        run: |
+          shopt -s nullglob
+
+          universal_zip=""
+          for zip_path in "${DIST_ARTIFACTS_PATH}"/*.zip; do
+            zip_file="$(basename "${zip_path}")"
+            if [[ ! "${zip_file}" =~ \.[[:alnum:]]+_[[:alnum:]]+\.zip$ ]]; then
+              universal_zip="${zip_path}"
+              break
+            fi
+          done
+
+          if [ -z "${universal_zip}" ]; then
+            echo "::error::Could not find a universal plugin ZIP to reference in the provenance attestation."
+            exit 1
+          fi
+
+          sha256="$(sha256sum "${universal_zip}" | cut -d ' ' -f1)"
+          echo "provenance-attestation=github#${GITHUB_REPOSITORY_OWNER}#sha256:${sha256}" >> "${GITHUB_OUTPUT}"
+        shell: bash
+        env:
+          DIST_ARTIFACTS_PATH: /tmp/dist-artifacts
+
   publish-to-catalog:
     name: Publish to catalog (${{ matrix.environment }})
-    if: ${{ !inputs.docs-only && !inputs.gcs-only && needs.setup.outputs.environments != '[]' }}
+    if: >-
+      ${{
+        !cancelled()
+        && !inputs.docs-only
+        && !inputs.gcs-only
+        && needs.setup.result == 'success'
+        && needs.upload-to-gcs-release.result == 'success'
+        && needs.ci.result == 'success'
+        && (!inputs.attestation || needs.build-attestation.result == 'success')
+        && needs.setup.outputs.environments != '[]'
+      }}
     needs:
       - setup
       - upload-to-gcs-release
       - ci
+      - build-attestation
     strategy:
       # Allow each stage to be deployed independently, even if others fails
       fail-fast: false
@@ -945,6 +983,7 @@ jobs:
           gcloud-auth-token: ${{ steps.gcloud.outputs.id_token }}
           ignore-conflicts: ${{ steps.determine-continue.outputs.ignore_conflicts }}
           publish-as-pending: ${{ matrix.environment == 'prod-canary' || inputs.publish-to-catalog-as-pending }}
+          provenance-attestation: ${{ inputs.attestation && needs.build-attestation.outputs.provenance-attestation || '' }}
 
       - name: Print publish summary
         run: |

--- a/actions/plugins/publish/publish/action.yml
+++ b/actions/plugins/publish/publish/action.yml
@@ -46,6 +46,12 @@ inputs:
       Default is "false".
     required: false
     default: "false"
+  provenance-attestation:
+    description: |
+      Optional provenance attestation reference to include when publishing the plugin.
+      Expected format: github#<owner>#sha256:<zip-sha256>.
+    required: false
+    default: ""
   gcom-api-url:
     description: |
       FOR INTERNAL TESTING ONLY.
@@ -75,6 +81,10 @@ runs:
           publish_args+=(--publish-as-pending)
         fi
 
+        if [ -n "${PROVENANCE_ATTESTATION}" ]; then
+          publish_args+=(--provenance-attestation "${PROVENANCE_ATTESTATION}")
+        fi
+
         ${{ github.action_path }}/publish.sh \
           "${publish_args[@]}" \
           "${args[@]}"
@@ -90,4 +100,5 @@ runs:
 
         IGNORE_CONFLICTS: ${{ inputs.ignore-conflicts }}
         PUBLISH_AS_PENDING: ${{ inputs.publish-as-pending }}
+        PROVENANCE_ATTESTATION: ${{ inputs.provenance-attestation }}
       shell: bash

--- a/actions/plugins/publish/publish/publish.sh
+++ b/actions/plugins/publish/publish/publish.sh
@@ -5,7 +5,7 @@ if [[ "$RUNNER_DEBUG" == "1" ]]; then
 fi
 
 usage() {
-    echo "Usage: $0 --environment <dev|ops|staging|prod> [--scopes <comma_separated_scopes>] [--publish-as-pending] [--dry-run]  <plugin_zip_urls...>"
+    echo "Usage: $0 --environment <dev|ops|staging|prod> [--scopes <comma_separated_scopes>] [--publish-as-pending] [--provenance-attestation <attestation_reference>] [--dry-run]  <plugin_zip_urls...>"
 }
 
 json_obj() {
@@ -16,12 +16,14 @@ gcs_zip_urls=()
 scopes=''
 dry_run=false
 publish_as_pending=false
+provenance_attestation=''
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         --environment) gcom_env=$2; shift 2;;
         --scopes) scopes=$(echo $2 | jq -Rc 'split(",")'); shift 2;;
         --dry-run) dry_run=true; shift;;
         --publish-as-pending) publish_as_pending=true; shift;;
+        --provenance-attestation) provenance_attestation=$2; shift 2;;
         --help)
             usage
             exit 0
@@ -137,7 +139,8 @@ json_payload=$(jq -c -n \
     --arg commit "$sha" \
     --argjson scopes "$scopes" \
     --argjson pending "$pending_param" \
-    '$ARGS.named'
+    --arg provenanceAttestation "$provenance_attestation" \
+    '$ARGS.named | if .provenanceAttestation == "" then del(.provenanceAttestation) else . end'
 )
 echo $json_payload | jq
 if [ "$dry_run" = true ]; then

--- a/tests/act/internal/workflow/cd/cd.go
+++ b/tests/act/internal/workflow/cd/cd.go
@@ -115,25 +115,26 @@ type WorkflowInputs struct {
 	// CI options (shared between CI and CD)
 	CI ci.WorkflowInputs
 
-	Environment                *string
-	Branch                     *string
-	Scopes                     *string
-	GrafanaCloudDeploymentType *string
-	DisableDocsPublishing      *bool
-	DisableGitHubRelease       *bool
-	TriggerArgo                *bool
-	AutoMergeEnvironments      *string
-	ArgoWorkflowSlackChannel   *string
-	ArgoWorkflowSlackSilent            *bool
+	Environment                         *string
+	Branch                              *string
+	Scopes                              *string
+	GrafanaCloudDeploymentType          *string
+	DisableDocsPublishing               *bool
+	DisableGitHubRelease                *bool
+	TriggerArgo                         *bool
+	AutoMergeEnvironments               *string
+	ArgoWorkflowSlackChannel            *string
+	ArgoWorkflowSlackSilent             *bool
 	ArgoWorkflowSlackMentionTriggerUser *bool
-	ArgoWorkflowSlackExtraMentions     *string
-	AutoApproveDurations               *string
-	ProdTargetsAll                     *bool
+	ArgoWorkflowSlackExtraMentions      *string
+	AutoApproveDurations                *string
+	ProdTargetsAll                      *bool
 
 	ReleaseReferenceRegex    *string
 	DocsOnly                 *bool
 	AllowPublishingPRsToProd *bool
 	UploadGCSLatest          *bool
+	Attestation              *bool
 }
 
 // WithWorkflowInputs sets the inputs for the CD workflow.
@@ -159,6 +160,7 @@ func WithWorkflowInputs(inputs WorkflowInputs) WorkflowOption {
 		workflow.SetJobInput(job, "docs-only", inputs.DocsOnly)
 		workflow.SetJobInput(job, "allow-publishing-prs-to-prod", inputs.AllowPublishingPRsToProd)
 		workflow.SetJobInput(job, "upload-gcs-latest", inputs.UploadGCSLatest)
+		workflow.SetJobInput(job, "attestation", inputs.Attestation)
 	}
 }
 

--- a/tests/act/main_cd_test.go
+++ b/tests/act/main_cd_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"crypto/sha256"
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -257,6 +260,142 @@ func TestCD(t *testing.T) {
 			require.NoError(t, checkFilesExist(runner.GCS.Fs, expGCSFiles, checkFilesExistOptions{strict: true}), "GCS files should be present")
 		})
 	}
+}
+
+func TestCD_PublishIncludesProvenanceAttestation(t *testing.T) {
+	t.Parallel()
+
+	gitSha, err := getGitCommitSHA()
+	require.NoError(t, err)
+
+	const (
+		pluginVersion    = "1.0.0"
+		pluginFolder     = "simple-frontend"
+		pluginSlug       = "grafana-simplefrontend-panel"
+		fakeGcomTokenDev = "dummy-gcom-api-key-dev"
+		fakeIapToken     = "dummy-iap-token"
+	)
+
+	zipBytes, err := os.ReadFile(workflow.LocalMockdataPath(
+		"dist-artifacts-unsigned",
+		pluginFolder,
+		anyZipFileName(pluginSlug, pluginVersion),
+	))
+	require.NoError(t, err)
+	zipSHA256 := sha256.Sum256(zipBytes)
+	expProvenanceAttestation := fmt.Sprintf("github#grafana#sha256:%x", zipSHA256)
+
+	mockVault := workflow.VaultSecrets{
+		DefaultValue: newPointer(""),
+		CommonSecrets: map[string]string{
+			"plugins/gcom-publish-token:dev": fakeGcomTokenDev,
+		},
+	}
+
+	var publishCalls int
+	runner, err := act.NewRunner(t)
+	require.NoError(t, err)
+
+	runner.GCOM.HandleFunc("POST /api/plugins", func(w http.ResponseWriter, r *http.Request) {
+		publishCalls++
+
+		require.Subset(t, r.Header, http.Header{
+			"Accept":        []string{"application/json"},
+			"User-Agent":    []string{"github-actions-shared-workflows:/plugins/publish"},
+			"Authorization": []string{"Bearer " + fakeGcomTokenDev},
+		})
+
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body), "should be able to decode json body")
+		require.Equal(t, expProvenanceAttestation, body["provenanceAttestation"])
+
+		w.WriteHeader(http.StatusOK)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"plugin": map[string]any{"id": 1337},
+		}))
+	})
+
+	gcsZipURLs, err := json.Marshal([]string{gcsPublishURL(pluginSlug, pluginVersion, "any")})
+	require.NoError(t, err)
+	pluginOutput, err := json.Marshal(map[string]string{
+		"id":      pluginSlug,
+		"version": pluginVersion,
+	})
+	require.NoError(t, err)
+
+	wf, err := cd.NewWorkflow(
+		cd.WithWorkflowInputs(cd.WorkflowInputs{
+			CI: ci.WorkflowInputs{
+				PluginDirectory:     workflow.Input(filepath.Join("tests", pluginFolder)),
+				DistArtifactsPrefix: workflow.Input(pluginFolder + "-"),
+				Testing:             workflow.Input(false),
+			},
+			Attestation:           workflow.Input(true),
+			DisableDocsPublishing: workflow.Input(true),
+			DisableGitHubRelease:  workflow.Input(true),
+			Environment:           workflow.Input("dev"),
+			Scopes:                workflow.Input("universal"),
+		}),
+		cd.WithMockedGCOM(t, runner.GCOM),
+		cd.MutateAllWorkflows().With(
+			workflow.WithMockedVault(t, mockVault),
+		),
+		cd.MutateCDWorkflow().With(
+			workflow.WithOnlyOneJob(t, "publish-to-catalog", false),
+			workflow.WithNoOpJobWithOutputs(t, "setup", map[string]string{
+				"commit-sha":            gitSha,
+				"environments":          `["dev"]`,
+				"publish-docs":          "false",
+				"plugin-version-suffix": "",
+				"platforms":             `["any"]`,
+				"is-release-reference":  "true",
+			}),
+			workflow.WithNoOpJobWithOutputs(t, "ci", map[string]string{
+				"plugin": string(pluginOutput),
+			}),
+			workflow.WithNoOpJobWithOutputs(t, "upload-to-gcs-release", map[string]string{
+				"gcs-zip-urls": string(gcsZipURLs),
+			}),
+			workflow.WithReplacedStep(
+				t,
+				"build-attestation",
+				"download-dist-artifacts",
+				workflow.CopyMockFilesStep("dist-artifacts-unsigned/"+pluginFolder, "/tmp/dist-artifacts"),
+			),
+			workflow.WithReplacedStep(
+				t,
+				"build-attestation",
+				"attestation",
+				workflow.MockOutputsStep(map[string]string{
+					"attestation-id":  "attestation-id",
+					"attestation-url": "https://github.com/grafana/plugin-ci-workflows/attestations/attestation-id",
+					"bundle-path":     "/tmp/attestation.jsonl",
+				}),
+			),
+			workflow.WithEnvironment(t, "build-attestation", "provenance-attestation", map[string]string{
+				"GITHUB_REPOSITORY_OWNER": "grafana",
+			}),
+			workflow.WithNoOpStep(t, "publish-to-catalog", "check-and-create-stub"),
+			workflow.WithNoOpStep(t, "publish-to-catalog", "check-artifact-zips"),
+			workflow.WithReplacedStep(
+				t,
+				"publish-to-catalog",
+				"gcloud",
+				workflow.MockOutputsStep(map[string]string{
+					"id_token": fakeIapToken,
+				}),
+			),
+			workflow.WithMatrix("publish-to-catalog", map[string][]string{
+				"environment": {"dev"},
+			}),
+		),
+	)
+	require.NoError(t, err)
+
+	r, err := runner.Run(wf, act.NewPushEventPayload("main"))
+	require.NoError(t, err)
+	require.True(t, r.Success, "workflow should succeed")
+	require.Equal(t, 1, publishCalls, "GCOM API POST /plugins should be called exactly once")
 }
 
 func TestCD_GCSLatest(t *testing.T) {


### PR DESCRIPTION
## Summary

- Generate a GCOM-compatible provenance attestation reference from the attested universal plugin ZIP.
- Make catalog publishing wait for the attestation job when attestations are enabled.
- Pass the attestation through the publish action and include it as `provenanceAttestation` in the GCOM publish payload.
- Add a focused act test that enables attestation and asserts the mocked GCOM publish request includes `provenanceAttestation`.

## Root Cause

The CD workflow generated a build provenance attestation, but the publishing path did not depend on that job and the publish action had no input or request-field support for forwarding the attestation to GCOM.

Fixes #102

## Validation

- `make actionlint`
- `bash -n actions/plugins/publish/publish/publish.sh`
- YAML parse check for `.github/workflows/cd.yml` and `actions/plugins/publish/publish/action.yml`
- Publish script dry-runs with and without `--provenance-attestation`
- Shell check of the universal-ZIP attestation reference generation block
- `git diff --check`
- `GOCACHE=/tmp/plugin-ci-go-cache GOMODCACHE=/tmp/plugin-ci-gomodcache GOTOOLCHAIN=auto go test -short -count=1 -run "^$" ./...` from `tests/act`

Note: `SKIP_ACT_CACHE_WARMUP=1 GOTOOLCHAIN=auto go test -run TestCD_PublishIncludesProvenanceAttestation -count=1 -v` could not complete locally because Docker is not running (`Cannot connect to the Docker daemon at unix:///var/run/docker.sock`).

Also note: `make act-lint` could not run locally because the installed `golangci-lint` binary was built with Go 1.24 while `tests/act/go.mod` targets Go 1.25.4.