### PR TITLE
fix(ci): gate GCS upload on Playwright success

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -763,11 +763,21 @@ jobs:
     name: Upload to GCS
     runs-on: ubuntu-arm64-small
 
-    # Skip the GCS upload (no access to the bucket) for PRs when run in non-trusted context (forks)
-    if: ${{ fromJson(needs.test-and-build.outputs.workflow-context).isTrusted }}
+    # Skip the GCS upload (no access to the bucket) for PRs when run in non-trusted context (forks).
+    # If Playwright is enabled, only upload after the corresponding Playwright job succeeds.
+    if: >-
+      ${{
+        !cancelled()
+        && needs.test-and-build.result == 'success'
+        && fromJson(needs.test-and-build.outputs.workflow-context).isTrusted
+        && (!inputs.run-playwright || needs.playwright.result == 'success')
+        && (!inputs.run-playwright-docker || needs.playwright-docker.result == 'success')
+      }}
 
     needs:
       - test-and-build
+      - playwright
+      - playwright-docker
 
     outputs:
       zip-urls-latest: ${{ steps.outputs.outputs.zip_urls_latest }}

--- a/tests/act/main_workflow_consistency_test.go
+++ b/tests/act/main_workflow_consistency_test.go
@@ -97,6 +97,32 @@ func TestCDWorkflowCIJobPassesAllInputs(t *testing.T) {
 	})
 }
 
+func TestCIUploadToGCSWaitsForEnabledPlaywrightJobs(t *testing.T) {
+	t.Parallel()
+
+	ciWf, err := workflow.NewBaseWorkflowFromFile(filepath.Join(".github", "workflows", "ci.yml"))
+	require.NoError(t, err)
+
+	uploadToGCSJob := ciWf.Jobs["upload-to-gcs"]
+	require.NotNil(t, uploadToGCSJob, "ci.yml should have an 'upload-to-gcs' job")
+
+	require.ElementsMatch(t, []string{
+		"test-and-build",
+		"playwright",
+		"playwright-docker",
+	}, uploadToGCSJob.Needs)
+
+	for _, condition := range []string{
+		"!cancelled()",
+		"needs.test-and-build.result == 'success'",
+		"fromJson(needs.test-and-build.outputs.workflow-context).isTrusted",
+		"(!inputs.run-playwright || needs.playwright.result == 'success')",
+		"(!inputs.run-playwright-docker || needs.playwright-docker.result == 'success')",
+	} {
+		require.Contains(t, uploadToGCSJob.If, condition)
+	}
+}
+
 func TestExportedWorkflowsInSyncWithReleasePlease(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Make `upload-to-gcs` wait for both Playwright jobs.
- Keep Playwright gating conditional so skipped jobs do not block GCS upload when the corresponding input is disabled.
- Add a workflow consistency test for the `upload-to-gcs` dependency and condition wiring.

## Root Cause

`upload-to-gcs` only depended on `test-and-build`, so it could still run after a Playwright job failed as long as the build job succeeded and the context was trusted.

Fixes #56

## Validation

- `make actionlint`
- `git diff --check`
- `GOCACHE=/tmp/plugin-ci-go-cache GOMODCACHE=/tmp/plugin-ci-gomodcache GOTOOLCHAIN=auto go test -short -count=1 -run TestCIUploadToGCSWaitsForEnabledPlaywrightJobs ./...` from `tests/act`
- `GOCACHE=/tmp/plugin-ci-go-cache GOMODCACHE=/tmp/plugin-ci-gomodcache GOTOOLCHAIN=auto go test -short -count=1 -run "^$" ./...` from `tests/act`