### PR TITLE
feat: enable race detector by default

### DIFF
--- a/actions/internal/plugins/backend/action.yml
+++ b/actions/internal/plugins/backend/action.yml
@@ -17,7 +17,7 @@ inputs:
     required: false
     type: boolean
     description: Whether to run the tests with the race detector
-    default: false
+    default: "true"
   build-target:
     required: false
     type: string
@@ -68,4 +68,3 @@ runs:
       shell: bash
       env:
         BUILD_TARGET: ${{ inputs.build-target }}
-


### PR DESCRIPTION
I don't think there's any drawback to having this enabled by default, and doing so could catch some unexpected issues.