### PR TITLE
fix!: prevent unsigned plugins from reaching dev, allow grafana-plugins-platform-bot[bot] to sign plugins

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -103,7 +103,7 @@ on:
         default: false
       allow-unsigned-in-dev:
         description: |
-          Escape hatch: when true, restore the pre-v8 behaviour of auto-allowing unsigned dev builds in untrusted contexts.
+          Escape hatch: when true, allowing unsigned dev builds in untrusted contexts.
           Defaults to false (untrusted dev builds hard-fail). See ci.yml for details.
         type: boolean
         required: false

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -101,6 +101,13 @@ on:
         type: boolean
         required: false
         default: false
+      allow-unsigned-in-dev:
+        description: |
+          Escape hatch: when true, restore the pre-v8 behaviour of auto-allowing unsigned dev builds in untrusted contexts.
+          Defaults to false (untrusted dev builds hard-fail). See ci.yml for details.
+        type: boolean
+        required: false
+        default: false
       signature-type:
         description: Specify signature type to use when signing the plugin
         type: string
@@ -789,6 +796,7 @@ jobs:
       environment: ${{ inputs.environment }}
 
       allow-unsigned: ${{ inputs.allow-unsigned }}
+      allow-unsigned-in-dev: ${{ inputs.allow-unsigned-in-dev }}
       signature-type: ${{ inputs.signature-type }}
 
       dist-artifacts-prefix: ${{ inputs.dist-artifacts-prefix }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,13 @@ on:
         type: boolean
         required: false
         default: false
+      allow-unsigned-in-dev:
+        description: |
+          Escape hatch: when true, restore the pre-v8 behaviour of auto-allowing unsigned dev builds in untrusted contexts.
+          Defaults to false (untrusted dev builds hard-fail). PR/fork builds (env=`none`|`''`) keep the fallback either way.
+        type: boolean
+        required: false
+        default: false
       signature-type:
         description: Specify signature type to use when signing the plugin
         type: string
@@ -381,7 +388,9 @@ jobs:
               'dependabot[bot]',
               'renovate-sh-app[bot]',
               // Used by other shared workflows such as the version bump workflow
-              'grafana-plugins-platform-bot[bot]'
+              'grafana-plugins-platform-bot[bot]',
+              // Only the actor on post-merge pushes from the queue, which already required maintainer approval.
+              'github-merge-queue[bot]'
             ].map((s) => s.toLowerCase());
 
             const isPR = context.eventName === 'pull_request';
@@ -540,6 +549,8 @@ jobs:
           secrets: ${{ (fromJson(steps.workflow-context.outputs.result).isTrusted && inputs.backend-secrets != '') && inputs.backend-secrets || '' }}
           build-target: ${{ inputs.backend-build-target }}
 
+      # Auto-allow-unsigned applies only to untrusted contexts AND envs where shipping unsigned is acceptable:
+      # `none`/`''` (CI-only) and, opt-in via `allow-unsigned-in-dev`, `dev`. Untrusted dev otherwise hard-fails here.
       - name: Package universal ZIP
         id: universal-zip
         uses: grafana/plugin-ci-workflows/actions/internal/plugins/package@main
@@ -548,7 +559,7 @@ jobs:
           dist-folder: ${{ inputs.plugin-directory }}/dist
           output-folder: ${{ inputs.plugin-directory }}/dist-artifacts
           access-policy-token: ${{ fromJson(steps.workflow-context.outputs.result).isTrusted && fromJSON(steps.get-secrets.outputs.secrets).SIGN_PLUGIN_ACCESS_POLICY_TOKEN || '' }}
-          allow-unsigned: ${{ ((inputs.environment == 'dev' || inputs.environment == '' || inputs.environment == 'none') && !(fromJson(steps.workflow-context.outputs.result).isTrusted)) || inputs.allow-unsigned }}
+          allow-unsigned: ${{ ((inputs.environment == '' || inputs.environment == 'none' || (inputs.environment == 'dev' && inputs.allow-unsigned-in-dev)) && !(fromJson(steps.workflow-context.outputs.result).isTrusted)) || inputs.allow-unsigned }}
           signature-type: ${{ inputs.signature-type }}
 
       - name: Package os/arch ZIPs
@@ -559,7 +570,7 @@ jobs:
           dist-folder: ${{ inputs.plugin-directory }}/dist
           output-folder: ${{ inputs.plugin-directory }}/dist-artifacts
           access-policy-token: ${{ fromJson(steps.workflow-context.outputs.result).isTrusted && fromJSON(steps.get-secrets.outputs.secrets).SIGN_PLUGIN_ACCESS_POLICY_TOKEN || '' }}
-          allow-unsigned: ${{ ((inputs.environment == 'dev' || inputs.environment == '' || inputs.environment == 'none') && !(fromJson(steps.workflow-context.outputs.result).isTrusted)) || inputs.allow-unsigned }}
+          allow-unsigned: ${{ ((inputs.environment == '' || inputs.environment == 'none' || (inputs.environment == 'dev' && inputs.allow-unsigned-in-dev)) && !(fromJson(steps.workflow-context.outputs.result).isTrusted)) || inputs.allow-unsigned }}
           signature-type: ${{ inputs.signature-type }}
 
       - name: Trufflehog secrets scanning

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,7 @@ on:
         default: false
       allow-unsigned-in-dev:
         description: |
-          Escape hatch: when true, restore the pre-v8 behaviour of auto-allowing unsigned dev builds in untrusted contexts.
+          Escape hatch: when true, allow unsigned dev builds in untrusted contexts.
           Defaults to false (untrusted dev builds hard-fail). PR/fork builds (env=`none`|`''`) keep the fallback either way.
         type: boolean
         required: false

--- a/tests/act/internal/workflow/ci/ci.go
+++ b/tests/act/internal/workflow/ci/ci.go
@@ -110,6 +110,7 @@ type WorkflowInputs struct {
 	RunTruffleHog *bool
 
 	AllowUnsigned      *bool
+	AllowUnsignedInDev *bool
 	Testing            *bool
 	BackendBuildTarget *string
 
@@ -138,6 +139,7 @@ func SetCIInputs(dst *workflow.Job, inputs WorkflowInputs) {
 	workflow.SetJobInput(dst, "run-trufflehog", inputs.RunTruffleHog)
 
 	workflow.SetJobInput(dst, "allow-unsigned", inputs.AllowUnsigned)
+	workflow.SetJobInput(dst, "allow-unsigned-in-dev", inputs.AllowUnsignedInDev)
 	workflow.SetJobInput(dst, "testing", inputs.Testing)
 	workflow.SetJobInput(dst, "backend-build-target", inputs.BackendBuildTarget)
 

--- a/tests/act/internal/workflow/ci/ci_test.go
+++ b/tests/act/internal/workflow/ci/ci_test.go
@@ -1,0 +1,67 @@
+package ci
+
+import (
+	"testing"
+
+	"github.com/grafana/plugin-ci-workflows/tests/act/internal/workflow"
+	"github.com/stretchr/testify/require"
+)
+
+// newJobWithEmptyInputs returns a fresh Job with an initialized With map.
+// SetCIInputs writes into job.With, so callers must ensure it is non-nil.
+func newJobWithEmptyInputs() *workflow.Job {
+	return &workflow.Job{With: map[string]any{}}
+}
+
+func TestSetCIInputs_AllowUnsignedInDev(t *testing.T) {
+	t.Parallel()
+
+	const inputKey = "allow-unsigned-in-dev"
+
+	t.Run("nil leaves input unset (workflow default applies)", func(t *testing.T) {
+		t.Parallel()
+
+		job := newJobWithEmptyInputs()
+		SetCIInputs(job, WorkflowInputs{})
+
+		require.NotContains(t, job.With, inputKey,
+			"unset AllowUnsignedInDev should not propagate %q so the workflow's default (false) applies", inputKey)
+	})
+
+	t.Run("true is forwarded as the escape-hatch opt-in", func(t *testing.T) {
+		t.Parallel()
+
+		job := newJobWithEmptyInputs()
+		SetCIInputs(job, WorkflowInputs{
+			AllowUnsignedInDev: workflow.Input(true),
+		})
+
+		require.Equal(t, true, job.With[inputKey],
+			"AllowUnsignedInDev=true must propagate as %q=true to opt back into the pre-v8 untrusted-dev fallback", inputKey)
+	})
+
+	t.Run("false is forwarded explicitly", func(t *testing.T) {
+		t.Parallel()
+
+		job := newJobWithEmptyInputs()
+		SetCIInputs(job, WorkflowInputs{
+			AllowUnsignedInDev: workflow.Input(false),
+		})
+
+		require.Equal(t, false, job.With[inputKey],
+			"AllowUnsignedInDev=false must propagate as %q=false to keep the hard-fail default", inputKey)
+	})
+
+	t.Run("does not collide with allow-unsigned", func(t *testing.T) {
+		t.Parallel()
+
+		job := newJobWithEmptyInputs()
+		SetCIInputs(job, WorkflowInputs{
+			AllowUnsigned:      workflow.Input(true),
+			AllowUnsignedInDev: workflow.Input(false),
+		})
+
+		require.Equal(t, true, job.With["allow-unsigned"], "AllowUnsigned should map to %q", "allow-unsigned")
+		require.Equal(t, false, job.With[inputKey], "AllowUnsignedInDev should map to %q", inputKey)
+	})
+}


### PR DESCRIPTION
This pull request introduces a new workflow input, `allow-unsigned-in-dev`, to both the CI and CD GitHub Actions workflows. This input serves as an "escape hatch" to optionally restore the previous behavior of allowing unsigned plugin builds in untrusted development contexts, which is now disabled by default. The changes also update the logic for when unsigned builds are permitted and add support for a new GitHub Actions actor. The most important changes are as follows:

**Workflow Input and Logic Updates:**

* Added a new boolean input `allow-unsigned-in-dev` to `.github/workflows/ci.yml` and `.github/workflows/cd.yml`, allowing maintainers to opt-in to the old behavior of permitting unsigned dev builds in untrusted contexts. This is now false by default, so untrusted dev builds will hard-fail unless explicitly enabled. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR232-R238) [[2]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18R104-R110)
* Updated the logic for the `allow-unsigned` parameter in both workflows to only allow unsigned builds in untrusted `dev` environments if `allow-unsigned-in-dev` is set to true. This further restricts when unsigned builds are permitted. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL551-R562) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL562-R573) [[3]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18R799)

**Documentation and Comments:**

* Added and updated descriptions and comments in the workflow files to clarify the behavior and intent of the new `allow-unsigned-in-dev` input, including its default value and usage scenarios. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR232-R238) [[2]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18R104-R110) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR552-R553)

**CI Workflow Actor Update:**

* Added `github-merge-queue[bot]` to the list of trusted actors in the CI workflow, recognizing it as a maintainer-approved actor for post-merge pushes.

**Test Workflow Support:**

* Updated the test workflow code (`tests/act/internal/workflow/ci/ci.go`) to include support for the new `AllowUnsignedInDev` input, ensuring test coverage for this new workflow parameter. [[1]](diffhunk://#diff-1b7beed9e840fa29b809f511d7251ff975af9066d2ef447ae7034dc091fcb152R113) [[2]](diffhunk://#diff-1b7beed9e840fa29b809f511d7251ff975af9066d2ef447ae7034dc091fcb152R142)