### PR TITLE
docs: improve release-please example and action description

### DIFF
--- a/actions/plugins/release-please/action.yml
+++ b/actions/plugins/release-please/action.yml
@@ -9,7 +9,9 @@ description: |
     - `release-please-config.json` (config file)
 
   **Usage:**
-  Trigger with workflow_dispatch.
+  Trigger on push to main (to detect merged release PRs and create tags)
+  and optionally on workflow_dispatch. The calling workflow needs
+  `id-token: write` permission for Vault OIDC authentication.
 
   **Version Bumping:**
   Release-please automatically updates the npm version based on commit message prefixes.

--- a/examples/extra/release-please.yml
+++ b/examples/extra/release-please.yml
@@ -1,16 +1,55 @@
-name: release please
+# Opens (or updates) a release PR with the next version bump and CHANGELOG entries
+# based on conventional commits since the last tag.
+#
+# Merging the release PR creates a v* tag, which triggers the release workflow
+# (GitHub Release with signed plugin artifacts).
+#
+# Required repo files:
+#   .release-please-manifest.json  — e.g. { ".": "1.0.0" }
+#   release-please-config.json     — see below
+#
+# Recommended release-please-config.json for repos that have a separate
+# release.yml workflow (build-plugin creates the GitHub Release with signed
+# artifacts):
+#
+#   {
+#     "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+#     "include-v-in-tag": true,
+#     "include-component-in-tag": false,
+#     "packages": {
+#       ".": {
+#         "release-type": "node",
+#         "package-name": "my-plugin"
+#       }
+#     }
+#   }
+#
+# - include-component-in-tag: false — ensures tags are v1.2.3, not my-plugin-v1.2.3
+#
+# Note: do NOT use skip-github-release — it prevents tag creation and breaks
+# release-please state tracking. build-plugin (via softprops/action-gh-release)
+# safely updates the release that release-please already created.
+#
+# For more information, see
+# https://github.com/grafana/plugin-ci-workflows/tree/main/actions/plugins/release-please
+
+name: Release Please
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
-  run-release-please:
+  release-please:
     runs-on: ubuntu-latest
 
     steps:
-      - name: release please version bump changelog
+      - name: Run release-please
         uses: grafana/plugin-ci-workflows/actions/plugins/release-please@plugins-release-please/v1.0.1


### PR DESCRIPTION
## Summary

Improves the release-please example and action description based on real-world usage in grafana-cube-datasource:

- Add `push` to `main` trigger (release-please needs this to detect merged release PRs and create tags — `workflow_dispatch` alone isn't sufficient)
- Add `id-token: write` permission (required for Vault OIDC in the composite action)
- Add comments documenting the recommended `release-please-config.json` settings, including:
  - `include-component-in-tag: false` — ensures `v*` tags
  - Warning against `skip-github-release` which is [broken upstream](https://github.com/googleapis/release-please/issues/1561)
- Update the action description to mention the push trigger and OIDC requirement

## Test plan

- [x] actionlint passes in CI
- [ ] Example is consistent with the action's requirements