### PR TITLE
feat(playwright): add max-parallel and customizable timeouts, add docker logs on Grafana startup failure

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -756,7 +756,7 @@ jobs:
 
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@l2d2/feat-playwright-concurrency
     needs:
       - setup
     with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -763,7 +763,7 @@ jobs:
 
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@l2d2/feat-playwright-concurrency
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main
     needs:
       - setup
     with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -172,6 +172,12 @@ on:
         type: string
         required: false
         default: http://localhost:3000/
+      playwright-max-parallel:
+        description: |
+          Maximum number of Playwright matrix jobs to run in parallel.
+        required: false
+        type: number
+        default: 256
       playwright-secrets:
         description: |
           The secrets to use for Playwright tests.
@@ -450,7 +456,6 @@ on:
           Default is true.
         default: true
         type: boolean
-
 
       branch:
         description: |
@@ -774,6 +779,7 @@ jobs:
       playwright-docker-compose-file: ${{ inputs.playwright-docker-compose-file }}
       playwright-config: ${{ inputs.playwright-config }}
       playwright-grafana-url: ${{ inputs.playwright-grafana-url }}
+      playwright-max-parallel: ${{ inputs.playwright-max-parallel }}
       playwright-secrets: ${{ inputs.playwright-secrets }}
       playwright-gar-registry: ${{ inputs.playwright-gar-registry }}
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -172,6 +172,13 @@ on:
         type: string
         required: false
         default: http://localhost:3000/
+      playwright-grafana-startup-timeout:
+        description: |
+          Seconds to wait for Grafana to respond in Playwright jobs before failing.
+          Default is 60.
+        required: false
+        type: number
+        default: 60
       playwright-max-parallel:
         description: |
           Maximum number of Playwright matrix jobs to run in parallel.
@@ -779,6 +786,7 @@ jobs:
       playwright-docker-compose-file: ${{ inputs.playwright-docker-compose-file }}
       playwright-config: ${{ inputs.playwright-config }}
       playwright-grafana-url: ${{ inputs.playwright-grafana-url }}
+      playwright-grafana-startup-timeout: ${{ inputs.playwright-grafana-startup-timeout }}
       playwright-max-parallel: ${{ inputs.playwright-max-parallel }}
       playwright-secrets: ${{ inputs.playwright-secrets }}
       playwright-gar-registry: ${{ inputs.playwright-gar-registry }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -172,10 +172,17 @@ on:
         type: string
         required: false
         default: http://localhost:3000/
+      playwright-grafana-timeout:
+        description: |
+          Seconds to wait for the Grafana endpoint check in Playwright jobs.
+          Default is 60.
+        required: false
+        type: number
+        default: 60
       playwright-grafana-startup-timeout:
         description: |
-          Seconds to wait for Grafana to respond in Playwright jobs before failing.
-          Default is 60.
+          Seconds to wait for Grafana startup before endpoint checks begin in
+          Playwright jobs. Default is 60.
         required: false
         type: number
         default: 60
@@ -786,6 +793,7 @@ jobs:
       playwright-docker-compose-file: ${{ inputs.playwright-docker-compose-file }}
       playwright-config: ${{ inputs.playwright-config }}
       playwright-grafana-url: ${{ inputs.playwright-grafana-url }}
+      playwright-grafana-timeout: ${{ inputs.playwright-grafana-timeout }}
       playwright-grafana-startup-timeout: ${{ inputs.playwright-grafana-startup-timeout }}
       playwright-max-parallel: ${{ inputs.playwright-max-parallel }}
       playwright-secrets: ${{ inputs.playwright-secrets }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,10 +145,17 @@ on:
         type: string
         required: false
         default: http://localhost:3000/
+      playwright-grafana-timeout:
+        description: |
+          Seconds to wait for the Grafana endpoint check in Playwright jobs.
+          Default is 60.
+        required: false
+        type: number
+        default: 60
       playwright-grafana-startup-timeout:
         description: |
-          Seconds to wait for Grafana to respond in Playwright jobs before failing.
-          Default is 60.
+          Seconds to wait for Grafana startup before endpoint checks begin in
+          Playwright jobs. Default is 60.
         required: false
         type: number
         default: 60
@@ -746,6 +753,7 @@ jobs:
       playwright-config: ${{ inputs.playwright-config }}
       report-path: ${{ inputs.playwright-report-path }}
       grafana-url: ${{ inputs.playwright-grafana-url }}
+      grafana-timeout: ${{ inputs.playwright-grafana-timeout }}
       grafana-startup-timeout: ${{ inputs.playwright-grafana-startup-timeout }}
       max-parallel: ${{ inputs.playwright-max-parallel }}
       secrets: ${{ (fromJson(needs.test-and-build.outputs.workflow-context).isTrusted && inputs.playwright-secrets != '') && inputs.playwright-secrets || '' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,12 @@ on:
         type: string
         required: false
         default: http://localhost:3000/
+      playwright-max-parallel:
+        description: |
+          Maximum number of Playwright matrix jobs to run in parallel.
+        required: false
+        type: number
+        default: 256
       playwright-secrets:
         description: |
           The secrets to use for Playwright tests.
@@ -733,6 +739,7 @@ jobs:
       playwright-config: ${{ inputs.playwright-config }}
       report-path: ${{ inputs.playwright-report-path }}
       grafana-url: ${{ inputs.playwright-grafana-url }}
+      max-parallel: ${{ inputs.playwright-max-parallel }}
       secrets: ${{ (fromJson(needs.test-and-build.outputs.workflow-context).isTrusted && inputs.playwright-secrets != '') && inputs.playwright-secrets || '' }}
       node-version: ${{ inputs.node-version }}
       npm-registry-auth: ${{ inputs.npm-registry-auth }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -735,7 +735,7 @@ jobs:
 
   playwright:
     name: Playwright E2E tests
-    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@l2d2/feat-playwright-concurrency
+    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@main
     if: ${{ inputs.run-playwright == true }}
     needs:
       - test-and-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,13 @@ on:
         type: string
         required: false
         default: http://localhost:3000/
+      playwright-grafana-startup-timeout:
+        description: |
+          Seconds to wait for Grafana to respond in Playwright jobs before failing.
+          Default is 60.
+        required: false
+        type: number
+        default: 60
       playwright-max-parallel:
         description: |
           Maximum number of Playwright matrix jobs to run in parallel.
@@ -739,6 +746,7 @@ jobs:
       playwright-config: ${{ inputs.playwright-config }}
       report-path: ${{ inputs.playwright-report-path }}
       grafana-url: ${{ inputs.playwright-grafana-url }}
+      grafana-startup-timeout: ${{ inputs.playwright-grafana-startup-timeout }}
       max-parallel: ${{ inputs.playwright-max-parallel }}
       secrets: ${{ (fromJson(needs.test-and-build.outputs.workflow-context).isTrusted && inputs.playwright-secrets != '') && inputs.playwright-secrets || '' }}
       node-version: ${{ inputs.node-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -728,7 +728,7 @@ jobs:
 
   playwright:
     name: Playwright E2E tests
-    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@main
+    uses: grafana/plugin-ci-workflows/.github/workflows/playwright.yml@l2d2/feat-playwright-concurrency
     if: ${{ inputs.run-playwright == true }}
     needs:
       - test-and-build

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -66,6 +66,14 @@ on:
         type: string
         required: false
         default: http://localhost:3000/
+      max-parallel:
+        description: |
+          Maximum number of matrix jobs to run in parallel.
+          Defaults to 256 effectively unbounded. Lower values stagger Docker image pulls and Grafana
+          startup across runners, which can avoid wait-for-grafana flakes.
+        required: false
+        type: number
+        default: 256
       node-version:
         description: Node.js version to use
         type: string
@@ -108,6 +116,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false
+      max-parallel: ${{ inputs.max-parallel }}
       matrix:
         GRAFANA_IMAGE: ${{fromJson(needs.resolve-versions.outputs.matrix)}}
     name: e2e ${{ matrix.GRAFANA_IMAGE.name }}@${{ matrix.GRAFANA_IMAGE.VERSION }}
@@ -243,9 +252,24 @@ jobs:
           DOCKER_COMPOSE_FILE: ${{ inputs.docker-compose-file }}
 
       - name: Wait for Grafana to start
+        id: wait-for-grafana
         uses: grafana/plugin-actions/wait-for-grafana@wait-for-grafana/v1.0.2
         with:
           url: "${{ inputs.grafana-url }}"
+
+      - name: Capture Grafana logs on startup failure
+        if: ${{ failure() && steps.wait-for-grafana.outcome == 'failure' }}
+        shell: bash
+        working-directory: ${{ inputs.plugin-directory }}
+        run: |
+          echo "::group::docker compose ps"
+          docker compose ${DOCKER_COMPOSE_FILE:+-f "$DOCKER_COMPOSE_FILE"} ps -a || true
+          echo "::endgroup::"
+          echo "::group::docker compose logs"
+          docker compose ${DOCKER_COMPOSE_FILE:+-f "$DOCKER_COMPOSE_FILE"} logs --no-color --tail 500 || true
+          echo "::endgroup::"
+        env:
+          DOCKER_COMPOSE_FILE: ${{ inputs.docker-compose-file }}
 
       - name: Run Playwright tests
         id: run-tests

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -66,6 +66,14 @@ on:
         type: string
         required: false
         default: http://localhost:3000/
+      grafana-startup-timeout:
+        description: |
+          Seconds to wait for Grafana to respond with the expected status code
+          before failing the job. Increase this on contended runner pools where
+          Grafana may take longer than 60 seconds to start accepting requests.
+        type: number
+        required: false
+        default: 60
       max-parallel:
         description: |
           Maximum number of matrix jobs to run in parallel.
@@ -256,6 +264,7 @@ jobs:
         uses: grafana/plugin-actions/wait-for-grafana@wait-for-grafana/v1.0.2
         with:
           url: "${{ inputs.grafana-url }}"
+          timeout: "${{ inputs.grafana-startup-timeout }}"
 
       - name: Capture Grafana logs on startup failure
         if: ${{ failure() && steps.wait-for-grafana.outcome == 'failure' }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -66,11 +66,17 @@ on:
         type: string
         required: false
         default: http://localhost:3000/
+      grafana-timeout:
+        description: |
+          Seconds to wait for the HTTP endpoint check before timing out.
+          This maps to wait-for-grafana's `timeout` input.
+        type: number
+        required: false
+        default: 60
       grafana-startup-timeout:
         description: |
-          Seconds to wait for Grafana to respond with the expected status code
-          before failing the job. Increase this on contended runner pools where
-          Grafana may take longer than 60 seconds to start accepting requests.
+          Seconds to wait for Grafana startup before beginning endpoint checks.
+          This maps to wait-for-grafana's `startupTimeout` input.
         type: number
         required: false
         default: 60
@@ -261,10 +267,11 @@ jobs:
 
       - name: Wait for Grafana to start
         id: wait-for-grafana
-        uses: grafana/plugin-actions/wait-for-grafana@wait-for-grafana/v1.0.2
+        uses: grafana/plugin-actions/wait-for-grafana@wait-for-grafana/v1.0.3
         with:
           url: "${{ inputs.grafana-url }}"
-          timeout: "${{ inputs.grafana-startup-timeout }}"
+          timeout: "${{ inputs.grafana-timeout }}"
+          startupTimeout: "${{ inputs.grafana-startup-timeout }}"
 
       - name: Capture Grafana logs on startup failure
         if: ${{ failure() && steps.wait-for-grafana.outcome == 'failure' }}


### PR DESCRIPTION
## Description ✨ 
Attempt to fix playwright docker containers failing to startup, by allowing users to set a max-concurrency limit or add a longer grafana-startup-timeout.

Drilldown apps and Logs Drilldown in particular are experiencing playwright docker containers that are [failing to startup in under 60s](https://github.com/grafana/logs-drilldown/actions/runs/25447062688/job/74654493050?pr=1881). 7 matrix tests are running concurrently since we are obligated to work with grafana 11.6 and I believe this is causing the failure. 
<img width="1238" height="383" alt="Screenshot 2026-05-06 at 10 06 53 AM" src="https://github.com/user-attachments/assets/bc379445-b373-4b1e-8f44-406bac838544" />

## Summary 📝

- Added configurable Playwright grafana-startup-timeout by introducing `playwright-grafana-startup-timeout` in `cd.yml` and `ci.yml`, then forwarding it as `grafana-startup-timeout` into `playwright.yml`.
- Added configurable Playwright matrix concurrency by introducing `playwright-max-parallel` in `cd.yml` and `ci.yml`, then forwarding it as `max-parallel` into `playwright.yml`.
- Updated `playwright.yml` to apply `strategy.max-parallel: ${{ inputs.max-parallel }}` with a default of `256`, preserving existing behavior unless explicitly overridden.
- Added a failure-only diagnostics step after `wait-for-grafana` to print `docker compose ps -a` and recent `docker compose logs`, making startup/concurrency flakes actionable in CI logs.

## Test 🧪

- [x] Ran `make actionlint` successfully.
- [x] Tested extensively in https://github.com/grafana/logs-drilldown/pull/1883