### PR TITLE
docs: add EngHub URL to examples that require additional GitHub App permissions

### DIFF
--- a/examples/base/README.md
+++ b/examples/base/README.md
@@ -5,6 +5,8 @@
 > [!WARNING]
 >
 > Please [read the docs](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions) before using any of these workflows in your repository.
+>
+> If you intend to publish docs to the [Grafana website](https://github.com/grafana/website/tree/master/content/docs/plugins) (the CD workflow does this automatically when targeting `prod` and your repo has docs), or to depend on private `grafana` org repositories from your plugin's `go.mod`, you must first request `grafana-plugins-platform-bot` GitHub App permissions for your repo. See [GitHub App permissions](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/035-github-app-permissions/#updating-permissions-for-the-github-app) for instructions.
 
 This folder contains some examples on how to use the shared workflows (CI and CD) in various scenarios.
 

--- a/examples/base/README.tmpl
+++ b/examples/base/README.tmpl
@@ -5,6 +5,8 @@
 > [!WARNING]
 >
 > Please [read the docs](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions) before using any of these workflows in your repository.
+>
+> If you intend to publish docs to the [Grafana website](https://github.com/grafana/website/tree/master/content/docs/plugins) (the CD workflow does this automatically when targeting `prod` and your repo has docs), or to depend on private `grafana` org repositories from your plugin's `go.mod`, you must first request `grafana-plugins-platform-bot` GitHub App permissions for your repo. See [GitHub App permissions](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/035-github-app-permissions/#updating-permissions-for-the-github-app) for instructions.
 
 This folder contains some examples on how to use the shared workflows (CI and CD) in various scenarios.
 

--- a/examples/extra/release-please.yml
+++ b/examples/extra/release-please.yml
@@ -4,6 +4,12 @@
 # Merging the release PR creates a v* tag, which triggers the release workflow
 # (GitHub Release with signed plugin artifacts).
 #
+# IMPORTANT: This workflow requires the `grafana-plugins-platform-bot` GitHub App
+# to have permissions on your repository. Before using it, request permissions
+# by following the instructions here:
+#   https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/035-github-app-permissions/#updating-permissions-for-the-github-app
+# Skipping this step will cause this workflow to fail.
+#
 # Required repo files:
 #   .release-please-manifest.json  — e.g. { ".": "1.0.0" }
 #   release-please-config.json     — see below

--- a/examples/extra/version-bump-changelog.yml
+++ b/examples/extra/version-bump-changelog.yml
@@ -1,3 +1,12 @@
+# Bumps the npm version, creates a git tag and optionally generates a changelog
+# entry using conventional commits.
+#
+# IMPORTANT: This workflow requires the `grafana-plugins-platform-bot` GitHub App
+# to have permissions on your repository. Before using it, request permissions
+# by following the instructions here:
+#   https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/035-github-app-permissions/#updating-permissions-for-the-github-app
+# Skipping this step will cause this workflow to fail.
+
 name: Version bump, changelog
 
 on:


### PR DESCRIPTION
Updates the examples to link to the EngHub docs to request permissions for the grafana-plugins-platform-bot app.

The link returns a 404 now because the docs page is added in this PR, which hasn't been merged yet: https://github.com/grafana/grafana-catalog-team/pull/883