### PR TITLE
chore: update readme team handle to @grafana/grafana-catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Can be [found here](https://github.com/grafana/plugin-ci-workflows/tree/main/exa
 
 ## 🤝 Contributing
 
-This repository is maintained by the Grafana Plugins Platform team (`@grafana/plugins-platform`).
+This repository is maintained by the Grafana Catalog team (`@grafana/grafana-catalog`).
 
 ### Development Workflow
 


### PR DESCRIPTION
## Summary

- Update the README maintainer reference from "Grafana Plugins Platform team (`@grafana/plugins-platform`)" to "Grafana Catalog team (`@grafana/grafana-catalog`)".
- Part of grafana/grafana-catalog-team#870 follow-up cleanup.
- Note: line 30 still links to the EngHub component at `grafana-plugins-platform`. Left as-is since the EngHub component rename is a separate decision.

## Test plan

- [x] No functional impact — README-only change.