### PR TITLE
fix: expose playwright grafana wait timeout

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -177,6 +177,11 @@ on:
         type: string
         required: false
         default: http://localhost:3000/
+      playwright-grafana-timeout:
+        description: Timeout in seconds when waiting for Grafana to start before Playwright tests
+        type: number
+        required: false
+        default: 90
       playwright-secrets:
         description: |
           The secrets to use for Playwright tests.
@@ -780,6 +785,7 @@ jobs:
       playwright-docker-compose-file: ${{ inputs.playwright-docker-compose-file }}
       playwright-config: ${{ inputs.playwright-config }}
       playwright-grafana-url: ${{ inputs.playwright-grafana-url }}
+      playwright-grafana-timeout: ${{ inputs.playwright-grafana-timeout }}
       playwright-secrets: ${{ inputs.playwright-secrets }}
       playwright-gar-registry: ${{ inputs.playwright-gar-registry }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,11 @@ on:
         type: string
         required: false
         default: http://localhost:3000/
+      playwright-grafana-timeout:
+        description: Timeout in seconds when waiting for Grafana to start before Playwright tests
+        type: number
+        required: false
+        default: 90
       playwright-secrets:
         description: |
           The secrets to use for Playwright tests.
@@ -738,6 +743,7 @@ jobs:
       playwright-config: ${{ inputs.playwright-config }}
       report-path: ${{ inputs.playwright-report-path }}
       grafana-url: ${{ inputs.playwright-grafana-url }}
+      grafana-timeout: ${{ inputs.playwright-grafana-timeout }}
       secrets: ${{ (fromJson(needs.test-and-build.outputs.workflow-context).isTrusted && inputs.playwright-secrets != '') && inputs.playwright-secrets || '' }}
       node-version: ${{ inputs.node-version }}
       npm-registry-auth: ${{ inputs.npm-registry-auth }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -72,6 +72,11 @@ on:
         type: string
         required: false
         default: http://localhost:3000/
+      grafana-timeout:
+        description: Timeout in seconds when waiting for Grafana to start
+        type: number
+        required: false
+        default: 90
       node-version:
         description: Node.js version to use
         type: string
@@ -252,6 +257,7 @@ jobs:
         uses: grafana/plugin-actions/wait-for-grafana@wait-for-grafana/v1.0.2
         with:
           url: "${{ inputs.grafana-url }}"
+          timeout: ${{ inputs.grafana-timeout }}
 
       - name: Run Playwright tests
         id: run-tests


### PR DESCRIPTION
## Summary
- add a `grafana-timeout` input to the Playwright reusable workflow, defaulting to 90 seconds
- pass the timeout to `grafana/plugin-actions/wait-for-grafana`
- expose the setting through the top-level CI/CD workflow inputs as `playwright-grafana-timeout`

Fixes #682

## Verification
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest`
- `git diff --check`
