### PR TITLE
feat(security)!: migrate ci-cd workflows to GitHub App auth to GATB

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1294,7 +1294,7 @@ jobs:
         id: generate-github-token
         uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
         with:
-          github_app: plugins-platform-bot-app
+          github_app: grafana-plugins-platform-bot
           permission_set: website-docs
 
       - name: Publish docs

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -757,7 +757,7 @@ jobs:
 
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@plugins-platform/gatb-create-github-app-token
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main
     needs:
       - setup
     with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -95,6 +95,14 @@ on:
         type: boolean
         required: false
         default: false
+      go-private-git-auth:
+        description: |
+          Whether to authenticate to GitHub when running Go commands, in case the plugin's Go modules include private GitHub repositories.
+          If true, the workflow will generate a GitHub token using the `grafana-plugins-platform-bot` GitHub App and use it to authenticate to GitHub when running Go commands.
+          This is only necessary if the plugin has a backend and uses private GitHub repositories in its Go modules.
+        type: boolean
+        required: false
+        default: false
       allow-unsigned:
         description: |
           Allow to publish unsigned plugins.
@@ -757,6 +765,7 @@ jobs:
       plugin-directory: ${{ inputs.plugin-directory }}
       plugin-version-suffix: ${{ needs.setup.outputs.plugin-version-suffix }}
       npm-registry-auth: ${{ inputs.npm-registry-auth }}
+      go-private-git-auth: ${{ inputs.go-private-git-auth }}
 
       go-version: ${{ inputs.go-version }}
       go-setup-caching: ${{ inputs.go-setup-caching }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -757,7 +757,7 @@ jobs:
 
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@plugins-platform/gatb-create-github-app-token
     needs:
       - setup
     with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1281,23 +1281,12 @@ jobs:
           ref: ${{ !github.event.act && needs.setup.outputs.commit-sha || github.sha }}
           persist-credentials: false
 
-      - name: Get secrets from Vault
-        id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@f1614b210386ac420af6807a997ac7f6d96e477a # get-vault-secrets/v1.3.1
-        with:
-          vault_instance: ${{ env.VAULT_INSTANCE }}
-          common_secrets: |
-            GITHUB_APP_ID=plugins-platform-bot-app:app-id
-            GITHUB_APP_PRIVATE_KEY=plugins-platform-bot-app:private-key
-          export_env: false
-
       - name: Generate GitHub token
         id: generate-github-token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
         with:
-          app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
-          private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
+          github_app: plugins-platform-bot-app
+          permission_set: website-docs
 
       - name: Publish docs
         uses: grafana/plugin-ci-workflows/actions/internal/plugins/docs/publish@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -495,7 +495,7 @@ jobs:
 
       - name: Generate GitHub token (private backend dependencies)
         id: generate-github-token
-        if: ${{ fromJson(steps.workflow-context.outputs.result).isTrusted && steps.check-for-backend.outputs.has-backend == 'true' && inputs.go-private-git-auth == 'true' }}
+        if: ${{ fromJson(steps.workflow-context.outputs.result).isTrusted && steps.check-for-backend.outputs.has-backend == 'true' && inputs.go-private-git-auth == true }}
         uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
         with:
           github_app: plugins-platform-bot-app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -495,7 +495,7 @@ jobs:
 
       - name: Generate GitHub token
         id: generate-github-token
-        if: ${{ fromJson(steps.workflow-context.outputs.result).isTrusted && steps.check-for-backend.outputs.has-backend == 'true' && inputs.go-private-git-auth }}
+        if: ${{ fromJson(steps.workflow-context.outputs.result).isTrusted && steps.check-for-backend.outputs.has-backend == 'true' && inputs.go-private-git-auth == 'true' }}
         uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
         with:
           github_app: plugins-platform-bot-app
@@ -545,7 +545,7 @@ jobs:
         if: ${{ steps.check-for-backend.outputs.has-backend == 'true' }}
         uses: grafana/plugin-ci-workflows/actions/internal/plugins/backend@main
         with:
-          github-token: ${{ steps.generate-github-token.outputs.token }}
+          github-token: ${{ steps.generate-github-token.outputs.token || '' }}
           plugin-directory: ${{ inputs.plugin-directory }}
           secrets: ${{ (fromJson(steps.workflow-context.outputs.result).isTrusted && inputs.backend-secrets != '') && inputs.backend-secrets || '' }}
           build-target: ${{ inputs.backend-build-target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,14 @@ on:
         type: boolean
         required: false
         default: false
+      go-private-git-auth:
+        description: |
+          Whether to authenticate to GitHub when running Go commands, in case the plugin's Go modules include private GitHub repositories.
+          If true, the workflow will generate a GitHub token using the `grafana-plugins-platform-bot` GitHub App and use it to authenticate to GitHub when running Go commands.
+          This is only necessary if the plugin has a backend and uses private GitHub repositories in its Go modules.
+        type: boolean
+        required: false
+        default: false
 
       # Playwright
       run-playwright:
@@ -466,6 +474,15 @@ jobs:
           golangci-lint-version: ${{ inputs.golangci-lint-version || env.DEFAULT_GOLANGCI_LINT_VERSION }}
           mage-version: ${{ inputs.mage-version || env.DEFAULT_MAGE_VERSION }}
 
+      - name: Check for backend
+        id: check-for-backend
+        run: |
+          r=false
+          [ -f "Magefile.go" ] && r=true
+          echo "has-backend=$r" >> "$GITHUB_OUTPUT"
+        shell: bash
+        working-directory: ${{ inputs.plugin-directory }}
+
       - name: Get secrets from Vault
         id: get-secrets
         if: ${{ fromJson(steps.workflow-context.outputs.result).isTrusted }}
@@ -478,7 +495,7 @@ jobs:
 
       - name: Generate GitHub token
         id: generate-github-token
-        if: ${{ fromJson(steps.workflow-context.outputs.result).isTrusted }}
+        if: ${{ fromJson(steps.workflow-context.outputs.result).isTrusted && steps.check-for-backend.outputs.has-backend == 'true' && inputs.go-private-git-auth }}
         uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
         with:
           github_app: plugins-platform-bot-app
@@ -514,15 +531,6 @@ jobs:
           PLUGIN_DIRECTORY: ${{ inputs.plugin-directory }}
           PLUGIN_VERSION_SUFFIX: ${{ inputs.plugin-version-suffix }}
         shell: bash
-
-      - name: Check for backend
-        id: check-for-backend
-        run: |
-          r=false
-          [ -f "Magefile.go" ] && r=true
-          echo "has-backend=$r" >> "$GITHUB_OUTPUT"
-        shell: bash
-        working-directory: ${{ inputs.plugin-directory }}
 
       - name: Test and build frontend
         id: frontend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -474,18 +474,15 @@ jobs:
           vault_instance: ${{ env.VAULT_INSTANCE }}
           common_secrets: |
             SIGN_PLUGIN_ACCESS_POLICY_TOKEN=plugins/sign-plugin-access-policy-token:token
-            GITHUB_APP_ID=plugins-platform-bot-app:app-id
-            GITHUB_APP_PRIVATE_KEY=plugins-platform-bot-app:private-key
           export_env: false
 
       - name: Generate GitHub token
         id: generate-github-token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         if: ${{ fromJson(steps.workflow-context.outputs.result).isTrusted }}
+        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
         with:
-          app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
-          private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
+          github_app: plugins-platform-bot-app
+          permission_set: plugin-repo
 
       - name: Spellcheck
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -493,13 +493,13 @@ jobs:
             SIGN_PLUGIN_ACCESS_POLICY_TOKEN=plugins/sign-plugin-access-policy-token:token
           export_env: false
 
-      - name: Generate GitHub token
+      - name: Generate GitHub token (private backend dependencies)
         id: generate-github-token
         if: ${{ fromJson(steps.workflow-context.outputs.result).isTrusted && steps.check-for-backend.outputs.has-backend == 'true' && inputs.go-private-git-auth == 'true' }}
         uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
         with:
           github_app: plugins-platform-bot-app
-          permission_set: plugin-repo
+          permission_set: go-private-dependencies
 
       - name: Spellcheck
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -498,7 +498,7 @@ jobs:
         if: ${{ fromJson(steps.workflow-context.outputs.result).isTrusted && steps.check-for-backend.outputs.has-backend == 'true' && inputs.go-private-git-auth == true }}
         uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
         with:
-          github_app: plugins-platform-bot-app
+          github_app: grafana-plugins-platform-bot
           permission_set: go-private-dependencies
 
       - name: Spellcheck

--- a/tests/act/internal/workflow/mock.go
+++ b/tests/act/internal/workflow/mock.go
@@ -15,7 +15,8 @@ const (
 	VaultSecretsAction = "grafana/shared-workflows/actions/get-vault-secrets"
 	ArgoWorkflowAction = "grafana/shared-workflows/actions/trigger-argo-workflow"
 
-	GitHubAppTokenAction = "actions/create-github-app-token"
+	GitHubAppTokenAction       = "grafana/shared-workflows/actions/create-github-app-token"
+	GitHubAppTokenLegacyAction = "actions/create-github-app-token"
 )
 
 // MockStepWithHTTPSpy creates a mocked step that POSTs the original step's inputs to an HTTPSpy server
@@ -390,8 +391,8 @@ func MockArgoWorkflowStep(originalStep Step, mockServerURL string) (Step, error)
 //
 // The mocked step outputs the `token` output expected by subsequent steps.
 func MockGitHubAppTokenStep(originalStep Step, token string) (Step, error) {
-	if !strings.HasPrefix(originalStep.Uses, GitHubAppTokenAction) {
-		return Step{}, fmt.Errorf("cannot mock github app token for a step that uses %q action, must be %q", originalStep.Uses, GitHubAppTokenAction)
+	if !strings.HasPrefix(originalStep.Uses, GitHubAppTokenAction) && !strings.HasPrefix(originalStep.Uses, GitHubAppTokenLegacyAction) {
+		return Step{}, fmt.Errorf("cannot mock github app token for a step that uses %q action, must be %q or %q", originalStep.Uses, GitHubAppTokenAction, GitHubAppTokenLegacyAction)
 	}
 	return Step{
 		Run: Commands{

--- a/tests/act/internal/workflow/testing.go
+++ b/tests/act/internal/workflow/testing.go
@@ -459,7 +459,7 @@ func WithMockedVault(t *testing.T, secrets VaultSecrets) TestingWorkflowOption {
 }
 
 // WithMockedGitHubAppToken modifies the workflow to mock the GitHub app token creation step
-// (which use the actions/create-github-app-token action)
+// (which use either the grafana/shared-workflows/actions/create-github-app-token or the actions/create-github-app-token action)
 // to instead return the provided mock token.
 // This allows testing GitHub app token creation functionality without actually creating a GitHub app.
 // Since GitHub app tokens are only used in trusted contexts, callers should most likely also use WithMockedWorkflowContext.
@@ -468,9 +468,11 @@ func WithMockedGitHubAppToken(t *testing.T, token ...string) TestingWorkflowOpti
 		token = []string{"MOCK_GITHUB_APP_TOKEN"}
 	}
 	return func(twf *TestingWorkflow) {
-		err := twf.MockAllStepsUsingAction(GitHubAppTokenAction, func(originalStep Step) (Step, error) {
-			return MockGitHubAppTokenStep(originalStep, token[0])
-		})
-		require.NoError(t, err)
+		for _, action := range []string{GitHubAppTokenAction, GitHubAppTokenLegacyAction} {
+			err := twf.MockAllStepsUsingAction(action, func(originalStep Step) (Step, error) {
+				return MockGitHubAppTokenStep(originalStep, token[0])
+			})
+			require.NoError(t, err)
+		}
 	}
 }


### PR DESCRIPTION
- Switches ci.yml and cd.yml from fetching `plugins-platform-bot-app` credentials directly from Vault to using `grafana/shared-workflows/actions/create-github-app-token`, which goes through the GitHub App Token Broker (GATB).
- Adds a new boolean input `go-private-git-auth`, which must be set to `true` (both in `push.yaml` and `publish.yaml`) if your plugin has private GitHub repositories under the `grafana` org as Go dependencies, inside `go.mod`.

## ⚠️ Breaking change


**Please follow the migration guide in EngHub for complete instructions: [here](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/070-gatb-migration/).**

You may have to set up GATB (GitHub App Token Broken) in deployment_tools for your repo if your plugin depends on any of the following features:

- Docs publishing to the [website](https://github.com/grafana/website/tree/master/content/docs/plugins)
- Using private repositories in your plugin's backend (private GitHub repositories under the grafana org as Go dependencies, inside go.mod). For this one in particular, you also need to set `go-private-git-auth: true`, both in `push.yaml` and `publish.yaml`
