### PR TITLE
ci: migrate release-please to GATB

### DIFF
--- a/.github/workflows/release-please-pr-update-tagged-references.yml
+++ b/.github/workflows/release-please-pr-update-tagged-references.yml
@@ -63,26 +63,11 @@ jobs:
       }}
     runs-on: ubuntu-arm64-small
     steps:
-      - name: Get secrets from Vault
-        id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@f1614b210386ac420af6807a997ac7f6d96e477a # get-vault-secrets/v1.3.1
-        with:
-          common_secrets: |
-            GITHUB_APP_ID=plugins-platform-bot-app:app-id
-            GITHUB_APP_PRIVATE_KEY=plugins-platform-bot-app:private-key
-          export_env: false
-
       - name: Generate GitHub token
         id: generate-github-token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
         with:
-          app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
-          private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
-          permission-contents: write
-          permission-pull-requests: write
-          # Required or the following error is returned when trying to push:
-          # "refusing to allow a GitHub App to create or update workflow XYZ without `workflows` permission"
-          permission-workflows: write
+          github_app: plugins-platform-bot-app
 
       - name: Checkout PR branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -154,7 +139,7 @@ jobs:
         if: steps.switch-references.outputs.changed == 'true' || steps.switch-references-examples.outputs.changed == 'true'
         uses: grafana/plugin-ci-workflows/actions/internal/get-bot-user@main
         with:
-          app-slug: ${{ steps.generate-github-token.outputs.app-slug }}
+          app-slug: plugins-platform-bot-app
           token: ${{ steps.generate-github-token.outputs.token }}
 
       # Commit and push all changes to the PR

--- a/.github/workflows/release-please-restore-rolling-release.yml
+++ b/.github/workflows/release-please-restore-rolling-release.yml
@@ -34,26 +34,11 @@ jobs:
       id-token: write
     runs-on: ubuntu-arm64-small
     steps:
-      - name: Get secrets from Vault
-        id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@f1614b210386ac420af6807a997ac7f6d96e477a # get-vault-secrets/v1.3.1
-        with:
-          common_secrets: |
-            GITHUB_APP_ID=plugins-platform-bot-app:app-id
-            GITHUB_APP_PRIVATE_KEY=plugins-platform-bot-app:private-key
-          export_env: false
-
       - name: Generate GitHub token
         id: generate-github-token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
         with:
-          app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
-          private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
-          permission-contents: write
-          permission-pull-requests: write
-          # Required or the following error is returned when trying to push:
-          # "refusing to allow a GitHub App to create or update workflow XYZ without `workflows` permission"
-          permission-workflows: write
+          github_app: plugins-platform-bot-app
 
       - name: Checkout main branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -84,7 +69,7 @@ jobs:
         if: steps.switch-references.outputs.changed == 'true'
         uses: grafana/plugin-ci-workflows/actions/internal/get-bot-user@main
         with:
-          app-slug: ${{ steps.generate-github-token.outputs.app-slug }}
+          app-slug: plugins-platform-bot-app
           token: ${{ steps.generate-github-token.outputs.token }}
 
       - name: Create PR

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,24 +22,12 @@ jobs:
       id-token: write
 
     steps:
-      - name: Get secrets from Vault
-        id: get-secrets
-        if: ${{ env.IS_FORK == 'false' }}
-        uses: grafana/shared-workflows/actions/get-vault-secrets@f1614b210386ac420af6807a997ac7f6d96e477a # get-vault-secrets/v1.3.1
-        with:
-          common_secrets: |
-            GITHUB_APP_ID=plugins-platform-bot-app:app-id
-            GITHUB_APP_PRIVATE_KEY=plugins-platform-bot-app:private-key
-          export_env: false
-
       - name: Generate GitHub token
         id: generate-github-token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         if: ${{ env.IS_FORK == 'false' }}
+        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
         with:
-          app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
-          private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
+          github_app: plugins-platform-bot-app
 
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0


### PR DESCRIPTION
Update the release-please workflows internal to plugin-ci-workflows to use GitHub App Token Broker (short lived tokens) instead of secrets from GitHub app secret from Vault

Needs https://github.com/grafana/deployment_tools/pull/590443