### PR TITLE
feat(security)!: migrate release-please workflow to GitHub App auth to GATB

### DIFF
--- a/actions/plugins/release-please/action.yml
+++ b/actions/plugins/release-please/action.yml
@@ -28,25 +28,12 @@ description: |
 runs:
   using: composite
   steps:
-    - name: Get secrets from Vault
-      id: get-secrets
-      uses: grafana/shared-workflows/actions/get-vault-secrets@f1614b210386ac420af6807a997ac7f6d96e477a # get-vault-secrets/v1.3.1
-      env:
-        VAULT_INSTANCE: ops
-      with:
-        vault_instance: ${{ env.VAULT_INSTANCE }}
-        common_secrets: |
-          GITHUB_APP_ID=plugins-platform-bot-app:app-id
-          GITHUB_APP_PRIVATE_KEY=plugins-platform-bot-app:private-key
-        export_env: false
-
     - name: Generate GitHub token
       id: generate-github-token
-      uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+      uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
       with:
-        app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
-        private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
-        owner: ${{ github.repository_owner }}
+        github_app: plugins-platform-bot-app
+        permission_set: release-please
 
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/examples/extra/release-please.yml
+++ b/examples/extra/release-please.yml
@@ -5,9 +5,9 @@
 # (GitHub Release with signed plugin artifacts).
 #
 # IMPORTANT: This workflow requires the `grafana-plugins-platform-bot` GitHub App
-# to have permissions on your repository. Before using it, request permissions
-# by following the instructions here:
-#   https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/035-github-app-permissions/#updating-permissions-for-the-github-app
+# to have permissions on your repository and GATB (GitHub App Token Broker) setup in deployment_tools.
+# Before using it, request permissions by following the instructions here:
+#   https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/035-github-app-permissions
 # Skipping this step will cause this workflow to fail.
 #
 # Required repo files:


### PR DESCRIPTION
Migrates the release-please extra action to GATB.

## ⚠️ Breaking change

You must set up GATB (GitHub App Token Broken) in deployment_tools for your repo or the workflow will fail.

Please follow the instructions in EngHub: [here](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/070-gatb-migration/).