### PR TITLE
chore(setup): bump `pnpm/action-setup` from v5.0.0 to v6.0.8

### DIFF
--- a/actions/internal/plugins/setup/action.yml
+++ b/actions/internal/plugins/setup/action.yml
@@ -89,7 +89,7 @@ runs:
 
     - name: Install pnpm
       if: ${{ inputs.act-cache-warmup != 'true' && steps.package-manager.outputs.name == 'pnpm' }}
-      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       with:
         version: ${{ steps.package-manager.outputs.version }}
 


### PR DESCRIPTION
## What

Bumps `pnpm/action-setup` from v5.0.0 to v6.0.8 in `actions/internal/plugins/setup/action.yml`.

## Why

`pnpm/action-setup` v5 does not support pnpm v11. Plugins upgrading to pnpm v11 (e.g. metrics-drilldown) will fail in CI without this bump.

pnpm v11 enables supply chain protections by default:
- **`minimumReleaseAge`** defaults to 1 day - newly published packages won't resolve until they've been on the registry for 24 hours, reducing exposure to malicious publishes.
- **`blockExoticSubdeps`** defaults to `true` - only direct dependencies may use exotic sources (git repos, tarball URLs); transitive dependencies are blocked from pulling code from untrusted locations.
- **`strictDepBuilds`** defaults to `true` - installation fails if any dependency has unreviewed build/postinstall scripts, ensuring visibility before arbitrary scripts execute.
- **`pnpm audit signatures`** (v11.1) - new subcommand that verifies ECDSA registry signatures for installed packages to detect tampering.

## Impact

- **Backward compatible** - `pnpm/action-setup` v6 supports pnpm v5 through v11+.
- The `version` input is already read dynamically from each consumer's `packageManager` field, so no other changes are needed.
- This is the only file in the repo that references `pnpm/action-setup`.