### PR TITLE
fix(cd): install jq in publish-docs job

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1290,6 +1290,9 @@ jobs:
           ref: ${{ !github.event.act && needs.setup.outputs.commit-sha || github.sha }}
           persist-credentials: false
 
+      - name: Install jq
+        run: apt-get install -y jq
+
       - name: Generate GitHub token
         id: generate-github-token
         uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3


### PR DESCRIPTION
## Summary

- `publish-docs` job runs in `grafana/docs-base:latest` container which lacks `jq`
- `auth_vault.sh` in `create-github-app-token` action calls `jq` at line 22 to extract Vault token
- Adds `apt-get install -y jq` step before `Generate GitHub token`

Fixes #739

## Test plan

- [ ] Trigger a prod publish workflow on a plugin repo and verify the `publish-docs` job completes successfully