### PR TITLE
fix(cd): install jq via apk in publish-docs (docs-base is alpine)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1290,6 +1290,14 @@ jobs:
           ref: ${{ !github.event.act && needs.setup.outputs.commit-sha || github.sha }}
           persist-credentials: false
 
+      # TEMPORARY: grafana/docs-base (alpine + node) doesn't ship jq, which
+      # the create-github-app-token action's bash scripts depend on.
+      # Remove this step once grafana/shared-workflows#1948 is released and
+      # the create-github-app-token ref above is bumped past it.
+      - name: Install jq (docs-base workaround)
+        shell: sh
+        run: apk add --no-cache jq
+
       - name: Generate GitHub token
         id: generate-github-token
         uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3


### PR DESCRIPTION
## Summary

Same intent as #740 but uses `apk add --no-cache jq` instead of `apt-get install -y jq`. `grafana/docs-base:latest` is built `FROM node:18.16.1-alpine`, so `apt-get` isn't available and #740 would still exit 127.

A comment in the YAML points at grafana/shared-workflows#1948, which removes the `jq` dependency upstream — once that's released and the action ref is bumped, this step can be deleted.

## Test plan

- [ ] Trigger a prod publish workflow on a plugin repo (e.g. business-calendar) and verify `publish-docs` completes