### PR TITLE
chore(deps): bump actions/upload-artifact to v7.0.1 and actions/download-artifact to v8.0.1

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -849,7 +849,7 @@ jobs:
       - name: Download GitHub artifact
         id: download-dist-artifacts
         continue-on-error: true
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.dist-artifacts-prefix }}dist-artifacts
           path: /tmp/dist-artifacts
@@ -1140,7 +1140,7 @@ jobs:
       - name: Download GitHub artifact
         id: download-dist-artifacts
         continue-on-error: true
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.dist-artifacts-prefix }}dist-artifacts
           path: /tmp/dist-artifacts
@@ -1361,7 +1361,7 @@ jobs:
       - name: Download GitHub artifact
         id: download-dist-artifacts
         continue-on-error: true
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.dist-artifacts-prefix }}dist-artifacts
           path: /tmp/dist-artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -700,7 +700,7 @@ jobs:
         shell: bash
 
       - name: Upload GitHub artifacts
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.dist-artifacts-prefix }}dist-artifacts
           path: ${{ inputs.plugin-directory }}/dist-artifacts/
@@ -823,7 +823,7 @@ jobs:
       - name: Download GitHub artifact
         id: download-dist-artifacts
         continue-on-error: true
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.dist-artifacts-prefix }}dist-artifacts
           path: /tmp/${{ inputs.dist-artifacts-prefix }}dist-artifacts

--- a/.github/workflows/playwright-docker.yml
+++ b/.github/workflows/playwright-docker.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Download GitHub artifact
         id: download-dist-artifacts
         continue-on-error: true
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist-artifacts
           path: /tmp/dist-artifacts
@@ -179,7 +179,7 @@ jobs:
           DOCKER_COMPOSE_FILE: ${{ inputs.grafana-compose-file }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ (inputs.upload-artifacts == true) && ((always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure')) }}
         with:
           name: playwright-report-${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -212,7 +212,7 @@ jobs:
       - name: Download GitHub artifact
         id: download-dist-artifacts
         continue-on-error: true
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist-artifacts
           path: /tmp/dist-artifacts
@@ -301,7 +301,7 @@ jobs:
         working-directory: ${{ inputs.plugin-directory }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ (inputs.upload-artifacts == true) && ((always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure')) }}
         with:
           name: playwright-report-${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}

--- a/actions/plugins/frontend-e2e-against-stack/action.yml
+++ b/actions/plugins/frontend-e2e-against-stack/action.yml
@@ -285,7 +285,7 @@ runs:
       shell: bash
 
     - name: Upload E2E report
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()
       with:
         name: ${{ inputs.upload-report-path }}
@@ -293,7 +293,7 @@ runs:
         retention-days: 30
 
     - name: Upload E2E videos
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()
       with:
         name: ${{ inputs.upload-videos-path }}

--- a/tests/act/main_dist_artifacts_test.go
+++ b/tests/act/main_dist_artifacts_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const uploadArtifactAction = "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" // v7.0.1
+
 func TestDistArtifactsUnavailable(t *testing.T) {
 	t.Parallel()
 
@@ -72,12 +74,15 @@ func TestDistArtifactsUnavailable(t *testing.T) {
 						InjectionStepID: "set-outputs",
 						Steps: workflow.Steps{
 							{
-								Run:   `mkdir -p /tmp/placeholder-artifact && echo placeholder > /tmp/placeholder-artifact/placeholder.txt`,
+								Run: workflow.Commands{
+									"mkdir -p /tmp/placeholder-artifact",
+									"echo placeholder > /tmp/placeholder-artifact/placeholder.txt",
+								}.String(),
 								Shell: "bash",
 							},
 							{
 								Name: "Upload placeholder artifact (act workaround)",
-								Uses: "actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4", // v5.0.0
+								Uses: uploadArtifactAction,
 								With: map[string]any{
 									"name": "placeholder-artifact",
 									"path": "/tmp/placeholder-artifact/",


### PR DESCRIPTION
Bumps actions/upload-artifact to v7.0.1 and actions/download-artifact to v8.0.1. These versions support Node 24 instead of Node 20, which will be deprecated on 20260602. No other breaking changes.