### PR TITLE
feat(ci)!: use `package_json_file` in `pnpm/action-setup`

### DIFF
--- a/actions/internal/plugins/setup/action.yml
+++ b/actions/internal/plugins/setup/action.yml
@@ -90,6 +90,8 @@ runs:
     - name: Install pnpm
       if: ${{ inputs.act-cache-warmup != 'true' && steps.package-manager.outputs.name == 'pnpm' }}
       uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      with:
+        package_json_file: ${{ inputs.plugin-directory }}/package.json
 
     - name: Node
       id: node

--- a/actions/internal/plugins/setup/action.yml
+++ b/actions/internal/plugins/setup/action.yml
@@ -90,8 +90,6 @@ runs:
     - name: Install pnpm
       if: ${{ inputs.act-cache-warmup != 'true' && steps.package-manager.outputs.name == 'pnpm' }}
       uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-      with:
-        version: ${{ steps.package-manager.outputs.version }}
 
     - name: Node
       id: node


### PR DESCRIPTION
## ⚠️  Breaking change

If your plugin is using pnpm and is in a subdirectory, the plugin's `package.json` file **must** specify a `packageManager` property.

**The `packageManager` in the root `package.json` is ignored.**

You can use `corepack use pnpm@latest` in the plugin's directory to populate this field.

--- 

I'm running into issues when migrating to v8.0.1 – CI fails with pnpm sha pinned via `packageManager` field in the `package.json` (hashes match):
```
  Error: Error: Multiple versions of pnpm specified:
    - version 11.1.1+sha512.d1fdf5f73c617b64fa1a56a81c3c8dfe0e966e33a6010aa256b517ae77be21d93e05affc0de1a83b0e4f29d569f68b446ae8f068cd7247c0bb3df0fb4d7bdf9a in the GitHub Action config with the key "version"
    - version pnpm@11.1.1+sha512.d1fdf5f73c617b64fa1a56a81c3c8dfe0e966e33a6010aa256b517ae77be21d93e05affc0de1a83b0e4f29d569f68b446ae8f068cd7247c0bb3df0fb4d7bdf9a in the package.json with the key "packageManager"
  Remove one of these versions to avoid version mismatch errors like ERR_PNPM_BAD_PM_VERSION
```
I believe we're hitting this issue: https://github.com/pnpm/action-setup/issues/158 ([code](https://github.com/pnpm/action-setup/blob/0e279bb959325dab635dd2c09392533439d90093/src/install-pnpm/run.ts#L132-L145))

`pnpm/action-setup` v6 reads `packageManager` from `package.json` on its own. When we're passing version here we're hitting that issue when only one side is normalized.

Please see https://github.com/pnpm/action-setup/issues/105#issuecomment-2066247531. More background in https://github.com/pnpm/action-setup/pull/256 (this is why it surfaced IIUC: `pnpm/action-setup` bumped to v6.0.8 in v8.0.1, bringing this change)