### PR TITLE
feat: add playwright-config input to frontend-e2e-against-stack action

### DIFF
--- a/actions/plugins/frontend-e2e-against-stack/action.yml
+++ b/actions/plugins/frontend-e2e-against-stack/action.yml
@@ -282,7 +282,12 @@ runs:
       env:
         NODE_ENV: production
         PLAYWRIGHT_CONFIG: ${{ inputs.playwright-config }}
-      run: npx playwright test ${PLAYWRIGHT_CONFIG:+--config="$PLAYWRIGHT_CONFIG"}
+      run: |
+        if [[ -n "$PLAYWRIGHT_CONFIG" ]]; then
+          npx playwright test --config="$PLAYWRIGHT_CONFIG"
+        else
+          npx playwright test
+        fi
       working-directory: ${{ inputs.plugin-directory }}
 
     - name: Stop grafana docker

--- a/actions/plugins/frontend-e2e-against-stack/action.yml
+++ b/actions/plugins/frontend-e2e-against-stack/action.yml
@@ -53,6 +53,11 @@ inputs:
     required: false
     default: ""
 
+  playwright-config:
+    description: "Path to a custom Playwright config file, relative to the plugin directory. If empty (the default), Playwright resolves its own config (playwright.config.ts in the working dir). Useful when a repo has multiple Playwright configs and the stack tests need to target a specific one."
+    required: false
+    default: ""
+
 runs:
   using: "composite"
   steps:
@@ -276,7 +281,7 @@ runs:
       shell: bash
       env:
         NODE_ENV: production
-      run: npx playwright test
+      run: npx playwright test ${{ inputs.playwright-config != '' && format('--config={0}', inputs.playwright-config) || '' }}
       working-directory: ${{ inputs.plugin-directory }}
 
     - name: Stop grafana docker

--- a/actions/plugins/frontend-e2e-against-stack/action.yml
+++ b/actions/plugins/frontend-e2e-against-stack/action.yml
@@ -54,7 +54,7 @@ inputs:
     default: ""
 
   playwright-config:
-    description: "Path to a custom Playwright config file, relative to the plugin directory. If empty (the default), Playwright resolves its own config (playwright.config.ts in the working dir). Useful when a repo has multiple Playwright configs and the stack tests need to target a specific one."
+    description: "Path to a custom Playwright config file, relative to the plugin directory. If empty (the default), Playwright resolves its own config (playwright.config.ts in the working dir)."
     required: false
     default: ""
 

--- a/actions/plugins/frontend-e2e-against-stack/action.yml
+++ b/actions/plugins/frontend-e2e-against-stack/action.yml
@@ -281,7 +281,8 @@ runs:
       shell: bash
       env:
         NODE_ENV: production
-      run: npx playwright test ${{ inputs.playwright-config != '' && format('--config={0}', inputs.playwright-config) || '' }}
+        PLAYWRIGHT_CONFIG: ${{ inputs.playwright-config }}
+      run: npx playwright test ${PLAYWRIGHT_CONFIG:+--config="$PLAYWRIGHT_CONFIG"}
       working-directory: ${{ inputs.plugin-directory }}
 
     - name: Stop grafana docker


### PR DESCRIPTION
## Summary

Adds a new optional `playwright-config` input to `actions/plugins/frontend-e2e-against-stack` so callers can point the action at a specific Playwright config when their repo maintains more than one.

```yaml
- uses: grafana/plugin-ci-workflows/actions/plugins/frontend-e2e-against-stack@…
  with:
    stack-slug: my-stack
    env: dev-central
    playwright-config: e2e/assistant/playwright.config.ts
```

## Why

Today the action runs \`npx playwright test\` unconditionally, which falls back to Playwright's own resolution (`playwright.config.ts` in the working directory). That's fine for the single-config case but leaves no escape hatch when a repo has more than one Playwright config — typically when a stack-based integration suite has different workers / timeouts / project settings from the main e2e suite.

## Backwards compatibility

Empty default preserves current behaviour — existing callers see no change.

## Test plan

- [ ] Verify the action still runs cleanly for an existing caller that does NOT set `playwright-config` (e.g. via a release-please preview or a manual workflow_dispatch in a consumer repo)
- [ ] Verify a caller that DOES set `playwright-config: path/to/custom.config.ts` runs against that config
- [ ] Marking as Draft until at least one in-repo verification run — happy to take direction on how this project typically validates action changes (mirror PR in a consumer repo?)

🤖 Generated with [Claude Code](https://claude.com/claude-code)