### PR TITLE
feat(playwright): add playwright-browsers input for E2E installs

### DIFF
--- a/.github/workflows/CHANGELOG.md
+++ b/.github/workflows/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 ### Added
 
-- `playwright-multi-browser` boolean input on `cd.yml`, `ci.yml`, and `playwright.yml`. When true, installs Firefox and WebKit alongside Chromium for multi-browser E2E.
-- `playwright-multi-browser-blocking` boolean (default false). When false, additional browser installs are best-effort (non-blocking). When true, install failures fail the build.
+- `playwright-multi-browser` boolean input on `cd.yml`, `ci.yml`, and `playwright.yml`. When true, installs Firefox and WebKit alongside Chromium for multi-browser E2E. WebKit install is best-effort (`continue-on-error`) when system deps are unavailable on runners.
 
 ## [9.0.0](https://github.com/grafana/plugin-ci-workflows/compare/ci-cd-workflows/v8.0.1...ci-cd-workflows/v9.0.0) (2026-05-28)
 

--- a/.github/workflows/CHANGELOG.md
+++ b/.github/workflows/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- `playwright-browsers` input on `cd.yml`, `ci.yml`, and `playwright.yml` so plugins can install browsers beyond Chromium (e.g. `chromium firefox` for multi-browser E2E).
+
 ## [9.0.0](https://github.com/grafana/plugin-ci-workflows/compare/ci-cd-workflows/v8.0.1...ci-cd-workflows/v9.0.0) (2026-05-28)
 
 

--- a/.github/workflows/CHANGELOG.md
+++ b/.github/workflows/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- `playwright-browsers` input on `cd.yml`, `ci.yml`, and `playwright.yml`. Space-, newline-, or semicolon-separated list of browsers to install before Playwright E2E (default `chromium`). Values are validated against an allowlist (`chromium`, `firefox`, `webkit`) via env — no workflow input is interpolated into shell. WebKit install is best-effort when listed. Example consumer usage: `playwright-browsers: chromium firefox` in the plugin's `ci-cd.yml`.
+- `playwright-browsers` input on `cd.yml`, `ci.yml`, and `playwright.yml` to choose which Playwright browsers to install before E2E (default `chromium`; `chromium`, `firefox`, `webkit`).
 
 ## [9.0.0](https://github.com/grafana/plugin-ci-workflows/compare/ci-cd-workflows/v8.0.1...ci-cd-workflows/v9.0.0) (2026-05-28)
 

--- a/.github/workflows/CHANGELOG.md
+++ b/.github/workflows/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Added
 
-- `playwright-browsers` input on `cd.yml`, `ci.yml`, and `playwright.yml` so plugins can install browsers beyond Chromium (e.g. `chromium firefox` for multi-browser E2E).
+- `playwright-multi-browser` boolean input on `cd.yml`, `ci.yml`, and `playwright.yml`. When true, installs Firefox and WebKit alongside Chromium for multi-browser E2E.
+- `playwright-multi-browser-blocking` boolean (default false). When false, additional browser installs are best-effort (non-blocking). When true, install failures fail the build.
 
 ## [9.0.0](https://github.com/grafana/plugin-ci-workflows/compare/ci-cd-workflows/v8.0.1...ci-cd-workflows/v9.0.0) (2026-05-28)
 

--- a/.github/workflows/CHANGELOG.md
+++ b/.github/workflows/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- `playwright-multi-browser` boolean input on `cd.yml`, `ci.yml`, and `playwright.yml`. When true, installs Firefox and WebKit alongside Chromium for multi-browser E2E. WebKit install is best-effort (`continue-on-error`) when system deps are unavailable on runners.
+- `playwright-browsers` input on `cd.yml`, `ci.yml`, and `playwright.yml`. Space-, newline-, or semicolon-separated list of browsers to install before Playwright E2E (default `chromium`). Values are validated against an allowlist (`chromium`, `firefox`, `webkit`) via env — no workflow input is interpolated into shell. WebKit install is best-effort when listed. Example consumer usage: `playwright-browsers: chromium firefox` in the plugin's `ci-cd.yml`.
 
 ## [9.0.0](https://github.com/grafana/plugin-ci-workflows/compare/ci-cd-workflows/v8.0.1...ci-cd-workflows/v9.0.0) (2026-05-28)
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -205,6 +205,12 @@ on:
         required: false
         type: number
         default: 256
+      playwright-browsers:
+        description: |
+          Space-separated browsers for `playwright install --with-deps` in Playwright E2E jobs.
+        type: string
+        required: false
+        default: chromium
       playwright-secrets:
         description: |
           The secrets to use for Playwright tests.
@@ -813,6 +819,7 @@ jobs:
       playwright-max-parallel: ${{ inputs.playwright-max-parallel }}
       playwright-secrets: ${{ inputs.playwright-secrets }}
       playwright-gar-registry: ${{ inputs.playwright-gar-registry }}
+      playwright-browsers: ${{ inputs.playwright-browsers }}
 
       run-trufflehog: ${{ inputs.run-trufflehog }}
       trufflehog-version: ${{ inputs.trufflehog-version }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -205,13 +205,15 @@ on:
         required: false
         type: number
         default: 256
-      playwright-multi-browser:
+      playwright-browsers:
         description: |
-          When true, Playwright E2E jobs install additional browsers beyond Chromium.
-          Enable when the plugin runs non-Chromium browser projects on CI.
-        type: boolean
+          Browsers to install before Playwright E2E tests. Space-, newline-, or semicolon-separated.
+          Allowed values: chromium, firefox, webkit. Defaults to chromium (unchanged behaviour).
+          Set when the plugin runs non-Chromium browser projects on CI. Example: `chromium firefox`.
+          Which browsers actually run remains configured in the plugin's playwright.config.ts.
+        type: string
         required: false
-        default: false
+        default: chromium
       playwright-secrets:
         description: |
           The secrets to use for Playwright tests.
@@ -820,7 +822,7 @@ jobs:
       playwright-max-parallel: ${{ inputs.playwright-max-parallel }}
       playwright-secrets: ${{ inputs.playwright-secrets }}
       playwright-gar-registry: ${{ inputs.playwright-gar-registry }}
-      playwright-multi-browser: ${{ inputs.playwright-multi-browser }}
+      playwright-browsers: ${{ inputs.playwright-browsers }}
 
       run-trufflehog: ${{ inputs.run-trufflehog }}
       trufflehog-version: ${{ inputs.trufflehog-version }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -212,14 +212,6 @@ on:
         type: boolean
         required: false
         default: false
-      playwright-multi-browser-blocking:
-        description: |
-          When true, failures in additional browser installs (Firefox, WebKit) fail the build.
-          When false (default), those installs are best-effort and the plugin config skips
-          any browser that didn't install.
-        type: boolean
-        required: false
-        default: false
       playwright-secrets:
         description: |
           The secrets to use for Playwright tests.
@@ -829,7 +821,6 @@ jobs:
       playwright-secrets: ${{ inputs.playwright-secrets }}
       playwright-gar-registry: ${{ inputs.playwright-gar-registry }}
       playwright-multi-browser: ${{ inputs.playwright-multi-browser }}
-      playwright-multi-browser-blocking: ${{ inputs.playwright-multi-browser-blocking }}
 
       run-trufflehog: ${{ inputs.run-trufflehog }}
       trufflehog-version: ${{ inputs.trufflehog-version }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -205,12 +205,21 @@ on:
         required: false
         type: number
         default: 256
-      playwright-browsers:
+      playwright-multi-browser:
         description: |
-          Space-separated browsers for `playwright install --with-deps` in Playwright E2E jobs.
-        type: string
+          When true, Playwright E2E jobs install additional browsers beyond Chromium.
+          Enable when the plugin runs non-Chromium browser projects on CI.
+        type: boolean
         required: false
-        default: chromium
+        default: false
+      playwright-multi-browser-blocking:
+        description: |
+          When true, failures in additional browser installs (Firefox, WebKit) fail the build.
+          When false (default), those installs are best-effort and the plugin config skips
+          any browser that didn't install.
+        type: boolean
+        required: false
+        default: false
       playwright-secrets:
         description: |
           The secrets to use for Playwright tests.
@@ -819,7 +828,8 @@ jobs:
       playwright-max-parallel: ${{ inputs.playwright-max-parallel }}
       playwright-secrets: ${{ inputs.playwright-secrets }}
       playwright-gar-registry: ${{ inputs.playwright-gar-registry }}
-      playwright-browsers: ${{ inputs.playwright-browsers }}
+      playwright-multi-browser: ${{ inputs.playwright-multi-browser }}
+      playwright-multi-browser-blocking: ${{ inputs.playwright-multi-browser-blocking }}
 
       run-trufflehog: ${{ inputs.run-trufflehog }}
       trufflehog-version: ${{ inputs.trufflehog-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,12 +178,21 @@ on:
         required: false
         type: number
         default: 256
-      playwright-browsers:
+      playwright-multi-browser:
         description: |
-          Space-separated browsers for `playwright install --with-deps` in Playwright E2E jobs.
-        type: string
+          When true, Playwright E2E jobs install additional browsers beyond Chromium.
+          Enable when the plugin runs non-Chromium browser projects on CI.
+        type: boolean
         required: false
-        default: chromium
+        default: false
+      playwright-multi-browser-blocking:
+        description: |
+          When true, failures in additional browser installs (Firefox, WebKit) fail the build.
+          When false (default), those installs are best-effort and the plugin config skips
+          any browser that didn't install.
+        type: boolean
+        required: false
+        default: false
       playwright-secrets:
         description: |
           The secrets to use for Playwright tests.
@@ -775,7 +784,8 @@ jobs:
       secrets: ${{ (fromJson(needs.test-and-build.outputs.workflow-context).isTrusted && inputs.playwright-secrets != '') && inputs.playwright-secrets || '' }}
       node-version: ${{ inputs.node-version }}
       npm-registry-auth: ${{ inputs.npm-registry-auth }}
-      playwright-browsers: ${{ inputs.playwright-browsers }}
+      playwright-multi-browser: ${{ inputs.playwright-multi-browser }}
+      playwright-multi-browser-blocking: ${{ inputs.playwright-multi-browser-blocking }}
 
   playwright-docker:
     name: Plugins - Dockerized Playwright E2E tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,14 +185,6 @@ on:
         type: boolean
         required: false
         default: false
-      playwright-multi-browser-blocking:
-        description: |
-          When true, failures in additional browser installs (Firefox, WebKit) fail the build.
-          When false (default), those installs are best-effort and the plugin config skips
-          any browser that didn't install.
-        type: boolean
-        required: false
-        default: false
       playwright-secrets:
         description: |
           The secrets to use for Playwright tests.
@@ -785,7 +777,6 @@ jobs:
       node-version: ${{ inputs.node-version }}
       npm-registry-auth: ${{ inputs.npm-registry-auth }}
       playwright-multi-browser: ${{ inputs.playwright-multi-browser }}
-      playwright-multi-browser-blocking: ${{ inputs.playwright-multi-browser-blocking }}
 
   playwright-docker:
     name: Plugins - Dockerized Playwright E2E tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,13 +178,15 @@ on:
         required: false
         type: number
         default: 256
-      playwright-multi-browser:
+      playwright-browsers:
         description: |
-          When true, Playwright E2E jobs install additional browsers beyond Chromium.
-          Enable when the plugin runs non-Chromium browser projects on CI.
-        type: boolean
+          Browsers to install before Playwright E2E tests. Space-, newline-, or semicolon-separated.
+          Allowed values: chromium, firefox, webkit. Defaults to chromium (unchanged behaviour).
+          Set when the plugin runs non-Chromium browser projects on CI. Example: `chromium firefox`.
+          Which browsers actually run remains configured in the plugin's playwright.config.ts.
+        type: string
         required: false
-        default: false
+        default: chromium
       playwright-secrets:
         description: |
           The secrets to use for Playwright tests.
@@ -776,7 +778,7 @@ jobs:
       secrets: ${{ (fromJson(needs.test-and-build.outputs.workflow-context).isTrusted && inputs.playwright-secrets != '') && inputs.playwright-secrets || '' }}
       node-version: ${{ inputs.node-version }}
       npm-registry-auth: ${{ inputs.npm-registry-auth }}
-      playwright-multi-browser: ${{ inputs.playwright-multi-browser }}
+      playwright-browsers: ${{ inputs.playwright-browsers }}
 
   playwright-docker:
     name: Plugins - Dockerized Playwright E2E tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,12 @@ on:
         required: false
         type: number
         default: 256
+      playwright-browsers:
+        description: |
+          Space-separated browsers for `playwright install --with-deps` in Playwright E2E jobs.
+        type: string
+        required: false
+        default: chromium
       playwright-secrets:
         description: |
           The secrets to use for Playwright tests.
@@ -769,6 +775,7 @@ jobs:
       secrets: ${{ (fromJson(needs.test-and-build.outputs.workflow-context).isTrusted && inputs.playwright-secrets != '') && inputs.playwright-secrets || '' }}
       node-version: ${{ inputs.node-version }}
       npm-registry-auth: ${{ inputs.npm-registry-auth }}
+      playwright-browsers: ${{ inputs.playwright-browsers }}
 
   playwright-docker:
     name: Plugins - Dockerized Playwright E2E tests

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -105,13 +105,22 @@ on:
         type: boolean
         required: false
         default: false
-      playwright-browsers:
+      playwright-multi-browser:
         description: |
-          Space-separated browsers passed to `playwright install --with-deps`.
-          Match the browser projects in the plugin's playwright.config.ts (e.g. `chromium firefox`).
-        type: string
+          When true, install additional browsers (Firefox and WebKit) alongside Chromium.
+          Enable when the plugin runs non-Chromium browser projects on CI.
+          Which browsers actually run is controlled by the plugin's playwright.config.ts.
+        type: boolean
         required: false
-        default: chromium
+        default: false
+      playwright-multi-browser-blocking:
+        description: |
+          When false, failures in the additional browser install steps (Firefox, WebKit)
+          are non-blocking — the job continues and the plugin config skips browsers that
+          didn't install. Set to true if additional browsers must succeed or fail the build.
+        type: boolean
+        required: false
+        default: false
 permissions:
   contents: read
   id-token: write
@@ -212,8 +221,20 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ steps.version.outputs.version }}
 
-      - name: Install Playwright Browsers
-        run: ${{ steps.setup.outputs.node-package-manager-exec-local-cmd }} playwright install --with-deps ${{ inputs.playwright-browsers }}
+      - name: Install Playwright Chromium
+        run: ${{ steps.setup.outputs.node-package-manager-exec-local-cmd }} playwright install --with-deps chromium
+        shell: bash
+
+      - name: Install Playwright Firefox
+        if: inputs.playwright-multi-browser
+        continue-on-error: ${{ inputs.playwright-multi-browser-blocking == false }}
+        run: ${{ steps.setup.outputs.node-package-manager-exec-local-cmd }} playwright install --with-deps firefox
+        shell: bash
+
+      - name: Install Playwright WebKit
+        if: inputs.playwright-multi-browser
+        continue-on-error: ${{ inputs.playwright-multi-browser-blocking == false }}
+        run: ${{ steps.setup.outputs.node-package-manager-exec-local-cmd }} playwright install --with-deps webkit
         shell: bash
 
       - name: Download GitHub artifact

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -105,6 +105,13 @@ on:
         type: boolean
         required: false
         default: false
+      playwright-browsers:
+        description: |
+          Space-separated browsers passed to `playwright install --with-deps`.
+          Match the browser projects in the plugin's playwright.config.ts (e.g. `chromium firefox`).
+        type: string
+        required: false
+        default: chromium
 permissions:
   contents: read
   id-token: write
@@ -206,7 +213,7 @@ jobs:
           key: playwright-${{ steps.version.outputs.version }}
 
       - name: Install Playwright Browsers
-        run: ${{ steps.setup.outputs.node-package-manager-exec-local-cmd }} playwright install --with-deps chromium
+        run: ${{ steps.setup.outputs.node-package-manager-exec-local-cmd }} playwright install --with-deps ${{ inputs.playwright-browsers }}
         shell: bash
 
       - name: Download GitHub artifact

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -105,14 +105,16 @@ on:
         type: boolean
         required: false
         default: false
-      playwright-multi-browser:
+      playwright-browsers:
         description: |
-          When true, install additional browsers (Firefox and WebKit) alongside Chromium.
-          Enable when the plugin runs non-Chromium browser projects on CI.
-          Which browsers actually run is controlled by the plugin's playwright.config.ts.
-        type: boolean
+          Browsers to install before Playwright E2E tests. Space-, newline-, or semicolon-separated.
+          Allowed values: chromium, firefox, webkit. Defaults to chromium (unchanged behaviour).
+          Only controls install; which browsers actually run is set in the plugin's playwright.config.ts.
+          Enable when CI runs non-Chromium Playwright projects. Example: `chromium firefox` or `chromium;firefox`.
+          WebKit install is best-effort when listed (system deps may be missing on self-hosted runners).
+        type: string
         required: false
-        default: false
+        default: chromium
 permissions:
   contents: read
   id-token: write
@@ -213,21 +215,39 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ steps.version.outputs.version }}
 
-      - name: Install Playwright Chromium
-        run: ${{ steps.setup.outputs.node-package-manager-exec-local-cmd }} playwright install --with-deps chromium
+      - name: Install Playwright browsers
         shell: bash
-
-      - name: Install Playwright Firefox
-        if: inputs.playwright-multi-browser
-        run: ${{ steps.setup.outputs.node-package-manager-exec-local-cmd }} playwright install --with-deps firefox
-        shell: bash
-
-      # WebKit needs system libs that may be missing on self-hosted runners; install is best-effort.
-      - name: Install Playwright WebKit
-        if: inputs.playwright-multi-browser
-        continue-on-error: true
-        run: ${{ steps.setup.outputs.node-package-manager-exec-local-cmd }} playwright install --with-deps webkit
-        shell: bash
+        env:
+          PLAYWRIGHT_BROWSERS: ${{ inputs.playwright-browsers }}
+          NPM_EXEC_CMD: ${{ steps.setup.outputs.node-package-manager-exec-local-cmd }}
+        run: |
+          # Input is passed via PLAYWRIGHT_BROWSERS env; each token is validated against the allowlist below.
+          set -euo pipefail
+          allowed="chromium firefox webkit"
+          normalized=$(printf '%s' "$PLAYWRIGHT_BROWSERS" | tr ';\r\n\t,' ' ' | sed 's/  */ /g' | xargs)
+          if [ -z "$normalized" ]; then
+            normalized="chromium"
+          fi
+          seen=""
+          for token in $normalized; do
+            case " $allowed " in
+              *" $token "*) ;;
+              *)
+                echo "::error::Unsupported Playwright browser '$token'. Allowed: chromium, firefox, webkit"
+                exit 1
+                ;;
+            esac
+            case " $seen " in
+              *" $token "*) continue ;;
+            esac
+            seen="$seen $token"
+            if [ "$token" = "webkit" ]; then
+              # WebKit needs system libs that may be missing on self-hosted runners.
+              $NPM_EXEC_CMD playwright install --with-deps webkit || echo "::warning::WebKit install failed; continuing"
+            else
+              $NPM_EXEC_CMD playwright install --with-deps "$token"
+            fi
+          done
 
       - name: Download GitHub artifact
         id: download-dist-artifacts

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -208,18 +208,11 @@ jobs:
         env:
           PLUGIN_DIRECTORY: ${{ inputs.plugin-directory }}
 
-      - name: Cache Playwright
-        id: cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ steps.version.outputs.version }}
-
-      - name: Install Playwright browsers
+      - name: Resolve Playwright browsers
+        id: browsers
         shell: bash
         env:
           PLAYWRIGHT_BROWSERS: ${{ inputs.playwright-browsers }}
-          NPM_EXEC_CMD: ${{ steps.setup.outputs.node-package-manager-exec-local-cmd }}
         run: |
           # Input is passed via PLAYWRIGHT_BROWSERS env; each token is validated against the allowlist below.
           set -euo pipefail
@@ -241,6 +234,26 @@ jobs:
               *" $token "*) continue ;;
             esac
             seen="$seen $token"
+          done
+          list=$(echo "$seen" | xargs)
+          cache_key=$(echo "$list" | tr ' ' '\n' | sort | paste -sd '-' -)
+          echo "list=$list" >> "$GITHUB_OUTPUT"
+          echo "cache-key=$cache_key" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright
+        id: cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ steps.version.outputs.version }}-${{ steps.browsers.outputs.cache-key }}
+
+      - name: Install Playwright browsers
+        shell: bash
+        env:
+          NPM_EXEC_CMD: ${{ steps.setup.outputs.node-package-manager-exec-local-cmd }}
+        run: |
+          set -euo pipefail
+          for token in ${{ steps.browsers.outputs.list }}; do
             if [ "$token" = "webkit" ]; then
               # WebKit needs system libs that may be missing on self-hosted runners.
               $NPM_EXEC_CMD playwright install --with-deps webkit || echo "::warning::WebKit install failed; continuing"

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -250,10 +250,11 @@ jobs:
       - name: Install Playwright browsers
         shell: bash
         env:
+          PLAYWRIGHT_BROWSERS_LIST: ${{ steps.browsers.outputs.list }}
           NPM_EXEC_CMD: ${{ steps.setup.outputs.node-package-manager-exec-local-cmd }}
         run: |
           set -euo pipefail
-          for token in ${{ steps.browsers.outputs.list }}; do
+          for token in $PLAYWRIGHT_BROWSERS_LIST; do
             if [ "$token" = "webkit" ]; then
               # WebKit needs system libs that may be missing on self-hosted runners.
               $NPM_EXEC_CMD playwright install --with-deps webkit || echo "::warning::WebKit install failed; continuing"

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -113,14 +113,6 @@ on:
         type: boolean
         required: false
         default: false
-      playwright-multi-browser-blocking:
-        description: |
-          When false, failures in the additional browser install steps (Firefox, WebKit)
-          are non-blocking — the job continues and the plugin config skips browsers that
-          didn't install. Set to true if additional browsers must succeed or fail the build.
-        type: boolean
-        required: false
-        default: false
 permissions:
   contents: read
   id-token: write
@@ -227,13 +219,13 @@ jobs:
 
       - name: Install Playwright Firefox
         if: inputs.playwright-multi-browser
-        continue-on-error: ${{ inputs.playwright-multi-browser-blocking == false }}
         run: ${{ steps.setup.outputs.node-package-manager-exec-local-cmd }} playwright install --with-deps firefox
         shell: bash
 
+      # WebKit needs system libs that may be missing on self-hosted runners; install is best-effort.
       - name: Install Playwright WebKit
         if: inputs.playwright-multi-browser
-        continue-on-error: ${{ inputs.playwright-multi-browser-blocking == false }}
+        continue-on-error: true
         run: ${{ steps.setup.outputs.node-package-manager-exec-local-cmd }} playwright install --with-deps webkit
         shell: bash
 


### PR DESCRIPTION
## Summary

Adds a `playwright-browsers` input (default `chromium`) to `cd.yml`, `ci.yml`, and `playwright.yml`. Plugins list exactly which browsers to install before Playwright E2E tests — space-, newline-, or semicolon-separated (e.g. `chromium firefox`).

The upper-level workflows (`cd.yml`, `ci.yml`) only pass through that one string. Browser-specific install logic (allowlist validation, per-browser install) lives entirely in `playwright.yml`.

## Problem

The shared workflows only install **Chromium** via `playwright install --with-deps chromium`. This can silently work for plugins that also run Firefox tests — self-hosted runners sometimes have an old Firefox binary cached from previous jobs.

When **Renovate bumps `@playwright/test`** (e.g. 1.59 → 1.60), Playwright expects **new browser builds** under new cache paths (like `firefox-1522` for 1.60). CI downloads Chromium for the new version, but never downloads Firefox. The old cached Firefox from 1.59 doesn't match anymore. Every Firefox test fails with:

```
browserType.launch: Executable doesn't exist at /home/ubuntu/.cache/ms-playwright/firefox-1522/firefox/firefox
```

Chrome tests pass fine. This is what happened on [grafana-collector-app#1698](https://github.com/grafana/grafana-collector-app/pull/1698) — 51 Firefox failures, 68 Chromium passes.

## Design

| Layer | What it knows |
|-------|---------------|
| `cd.yml` | `playwright-browsers: string` — pass-through only |
| `ci.yml` | Same |
| `playwright.yml` | Parses input, validates tokens, installs each listed browser |

**Install behavior in `playwright.yml`:**

| Browser | When listed | On install failure |
|---------|-------------|-------------------|
| `chromium` | Default; always if list is empty | Job fails |
| `firefox` | When listed | Job fails |
| `webkit` | When listed | **Best-effort** — system libs (GTK4, GStreamer) may be missing on self-hosted runners |

Which browsers actually **run** is still controlled by each plugin's `playwright.config.ts` (e.g. collector-app skips WebKit when `CI` is set).

## Why an allowlisted string, not raw interpolation

An earlier draft interpolated a free-form string directly into `run:`, which is a script-injection risk. The final design passes the input via `PLAYWRIGHT_BROWSERS` env and validates each token against `chromium`, `firefox`, `webkit` before running hardcoded `playwright install` commands.

Per [review feedback](https://github.com/grafana/plugin-ci-workflows/pull/772#pullrequestreview-4436700206), an explicit browser list is preferred over a single on/off flag so plugins install only what they need.

## Consumer change (after this is tagged)

```yaml
# In the plugin's ci-cd.yml
uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/vX.Y.Z
with:
  playwright-browsers: chromium firefox
```

Plugins pin shared CI to a release tag. Merging this doesn't help consumers until a new tag is cut.

## Test plan

- [x] Input wiring: `cd.yml` → `ci.yml` → `playwright.yml` passes `playwright-browsers` through.
- [x] Default (`chromium`): only Chromium installs — existing behavior for all consumers.
- [x] `playwright-browsers: chromium firefox`: Firefox install runs; Firefox failure fails the job.
- [x] `playwright-browsers: chromium webkit`: WebKit install is best-effort; job continues on WebKit failure.
- [x] Invalid token (e.g. `chrome`): job fails with allowlist error.
- [x] Cache key includes Playwright version and sorted browser list (e.g. `playwright-1.60.0-chromium-firefox`).
- [ ] After tag: verify on grafana-collector-app that E2E Firefox matrix passes with `playwright-browsers: chromium firefox`.
