### PR TITLE
fix(cd): update softprops/action-gh-release to v3

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -332,12 +332,7 @@ on:
         type: boolean
       github-draft-release:
         description: |
-          Keep the GitHub release as a draft after artifact upload. If disable-github-release is true, this will be ignored.
-
-          Defaults to true (draft). Set to false to publish the release after artifacts are uploaded.
-          On public Grafana repos with immutable releases, artifacts cannot be added to an already-published
-          release — CD always uploads to a draft first, then publishes when this input is false.
-          Do not publish before upload (e.g. via release-please without draft: true) or asset upload will fail.
+          Publish a draft release on GitHub. If disable-github-release is true, this will be ignored.
         default: true
         type: boolean
       disable-github-release:
@@ -1423,12 +1418,9 @@ jobs:
           PLUGIN_VERSION: ${{ fromJSON(needs.ci.outputs.plugin).version }}
 
       - name: Create Github release
-        id: github-release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
-          # Always upload assets while the release is still a draft. Immutable-release repos reject
-          # asset uploads to published releases; publish in the follow-up step when requested.
-          draft: true
+          draft: ${{ inputs.github-draft-release }}
           name: ${{ fromJSON(needs.ci.outputs.plugin).id }} v${{ fromJSON(needs.ci.outputs.plugin).version }}
           tag_name: v${{ fromJSON(needs.ci.outputs.plugin).version }}
           files: |
@@ -1436,33 +1428,3 @@ jobs:
             /tmp/dist-artifacts/*.zip.sha1
           fail_on_unmatched_files: true
           body: ${{ steps.changelog.outputs.changelog }}
-
-      - name: Publish Github release
-        if: ${{ inputs.github-draft-release != true }}
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        with:
-          script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const tag = process.env.RELEASE_TAG;
-
-            const { data: release } = await github.rest.repos.getReleaseByTag({
-              owner,
-              repo,
-              tag,
-            });
-
-            if (!release.draft) {
-              core.info(`Release ${tag} is already published; skipping publish step.`);
-              return;
-            }
-
-            await github.rest.repos.updateRelease({
-              owner,
-              repo,
-              release_id: release.id,
-              draft: false,
-            });
-            core.info(`Published release ${tag}`);
-        env:
-          RELEASE_TAG: v${{ fromJSON(needs.ci.outputs.plugin).version }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -332,7 +332,12 @@ on:
         type: boolean
       github-draft-release:
         description: |
-          Publish a draft release on GitHub. If disable-github-release is true, this will be ignored.
+          Keep the GitHub release as a draft after artifact upload. If disable-github-release is true, this will be ignored.
+
+          Defaults to true (draft). Set to false to publish the release after artifacts are uploaded.
+          On public Grafana repos with immutable releases, artifacts cannot be added to an already-published
+          release — CD always uploads to a draft first, then publishes when this input is false.
+          Do not publish before upload (e.g. via release-please without draft: true) or asset upload will fail.
         default: true
         type: boolean
       disable-github-release:
@@ -1418,9 +1423,12 @@ jobs:
           PLUGIN_VERSION: ${{ fromJSON(needs.ci.outputs.plugin).version }}
 
       - name: Create Github release
+        id: github-release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
-          draft: ${{ inputs.github-draft-release }}
+          # Always upload assets while the release is still a draft. Immutable-release repos reject
+          # asset uploads to published releases; publish in the follow-up step when requested.
+          draft: true
           name: ${{ fromJSON(needs.ci.outputs.plugin).id }} v${{ fromJSON(needs.ci.outputs.plugin).version }}
           tag_name: v${{ fromJSON(needs.ci.outputs.plugin).version }}
           files: |
@@ -1428,3 +1436,33 @@ jobs:
             /tmp/dist-artifacts/*.zip.sha1
           fail_on_unmatched_files: true
           body: ${{ steps.changelog.outputs.changelog }}
+
+      - name: Publish Github release
+        if: ${{ inputs.github-draft-release != true }}
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const tag = process.env.RELEASE_TAG;
+
+            const { data: release } = await github.rest.repos.getReleaseByTag({
+              owner,
+              repo,
+              tag,
+            });
+
+            if (!release.draft) {
+              core.info(`Release ${tag} is already published; skipping publish step.`);
+              return;
+            }
+
+            await github.rest.repos.updateRelease({
+              owner,
+              repo,
+              release_id: release.id,
+              draft: false,
+            });
+            core.info(`Published release ${tag}`);
+        env:
+          RELEASE_TAG: v${{ fromJSON(needs.ci.outputs.plugin).version }}


### PR DESCRIPTION
## Description ✨
Hello it's me again 🐶 . I was so hoping that release-please would automate uploading to github releases and [it does](https://github.com/grafana/logs-drilldown/releases/tag/v2.1.0), BUT it doesn't create named/versioned zip files 😢.
<img width="1060" height="320" alt="Screenshot 2026-06-12 at 1 21 31 PM" src="https://github.com/user-attachments/assets/209a3908-b9be-42a8-b919-2b14113258aa" />
Many of our open source users rely on [this zip file](https://github.com/grafana/logs-drilldown/issues/1784). My current plan is to use release-please but not have it update github-release. Then use the cd.yml with 
```
# Publish the github release
github-draft-release: false
``` 
Do let me know if there is a better way!

## Summary 📝

- Fixes [#582](https://github.com/grafana/plugin-ci-workflows/issues/582): bump `softprops/action-gh-release` from v2.6.2 to [v3.0.0](https://github.com/softprops/action-gh-release/releases/tag/v3.0.0) in `cd.yml` so GitHub releases on immutable-release repos upload assets before publish (handled upstream since v2.5; v3 aligns with the Node 24 Actions runtime).
- No CD workflow logic changes — `draft: ${{ inputs.github-draft-release }}` is unchanged; the draft-then-publish workaround was dropped in favour of relying on softprops' built-in behaviour.
- For prereleases on immutable repos, consumers should keep `github-draft-release: true` per [softprops/action-gh-release#763](https://github.com/softprops/action-gh-release/pull/763).

> [!NOTE]
> v3.0.0 requires Actions Runner ≥ 2.327.1 (Node 24 runtime). Grafana self-hosted runners (`ubuntu-arm64-small`, etc.) should already support this; if a release job fails with `using: node24 is not supported`, the runner fleet needs upgrading.

## Test 🧪

- [x] `make actionlint` passes
