### PR TITLE
fix(ci): restrict GITHUB_TOKEN permissions in pr-checks-workflow-references

### DIFF
--- a/.github/workflows/pr-checks-workflow-references.yml
+++ b/.github/workflows/pr-checks-workflow-references.yml
@@ -19,6 +19,9 @@ jobs:
     # in order to create hermetic releases, so this action would always fail on those PRs.
     if: startsWith(github.event.pull_request.head.ref, 'release-please--branches--main--') == false
     runs-on: ubuntu-arm64-small
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
## Summary

- Add an explicit `permissions` block to the `check-references` job in `pr-checks-workflow-references.yml`
- Scope `GITHUB_TOKEN` to `contents: read` and `pull-requests: read` — the minimum required for checkout and the pull_request trigger context
- Fixes a `zizmor` `excessive-permissions` audit finding flagged in CI

Without this block the job inherits the org's default token permissions, which may be broader than needed. Explicit permissions make the scope clear and prevent the job from running with unintended write access if org defaults are ever widened.

## Test plan

- [ ] `Check @main workflow references` workflow still passes on a non-release-please PR
- [ ] `make actionlint` passes locally