### PR TITLE
chore: disable renovate dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -107,6 +107,7 @@
             "extractVersionTemplate": "^v?(?<version>.*)$"
         }
     ],
+    "dependencyDashboard": false,
     "minimumReleaseAge": "14 days",
     "prConcurrentLimit": 10,
     "rebaseWhen": "behind-base-branch"


### PR DESCRIPTION
Sets `dependencyDashboard: false` in renovate.json.

The `config:best-practices` preset we extend turns the dependency dashboard issue on by default. This disables it so Renovate stops opening/maintaining the dashboard issue.