### PR TITLE
chore: group renovate GitHub Actions and CI tool updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,18 @@
             "matchManagers": [
                 "github-actions"
             ],
+            "groupName": "GitHub Actions"
+        },
+        {
+            "matchManagers": [
+                "custom.regex"
+            ],
+            "groupName": "CI tool versions"
+        },
+        {
+            "matchManagers": [
+                "github-actions"
+            ],
             "matchPackageNames": [
                 "grafana/plugin-actions"
             ],


### PR DESCRIPTION
Each GitHub Action bump (setup-node, harden-runner, checkout, golangci-lint-action, login-to-gar, ...) and each CLI tool bump from the custom regex managers (mage, golangci-lint, act, trufflehog, ...) currently opens its own PR.

This groups all `github-actions` updates into a single "GitHub Actions" PR and all `custom.regex` tool-version updates into a single "CI tool versions" PR. The existing pinDigests rules for grafana/plugin-actions and grafana/docs-base and the frontend-e2e-against-stack file group are unchanged — they're evaluated after the new groups so their behavior still wins.