### PR TITLE
chore(ci): skip act tests for rolling release restore automated commits

### DIFF
--- a/.github/workflows/pr-checks-test-ci.yml
+++ b/.github/workflows/pr-checks-test-ci.yml
@@ -31,8 +31,23 @@ jobs:
           persist-credentials: true
           fetch-depth: 2
 
+      - name: Check if restore-rolling-release commit
+        id: is-restore
+        run: |
+          if [[ "${COMMIT_MESSAGE}" == "chore: update references to use 'main' branch" ]] && \
+             [[ "${ACTOR}" == "grafana-plugins-platform-bot[bot]" ]]; then
+            echo "skip=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "skip=false" >> "${GITHUB_OUTPUT}"
+          fi
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          ACTOR: ${{ github.actor }}
+        shell: bash
+
       - name: Check for relevant changes
         id: changed
+        if: steps.is-restore.outputs.skip != 'true'
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: |


### PR DESCRIPTION
Skip act tests for automated commits that restore rolling releases (e.g.: https://github.com/grafana/plugin-ci-workflows/pull/765). These PRs are automatically opened right after cutting a release and have no functional changes: they just swap the reference of the workflows from the release back to main. Since act tests take time to run, skip act tests for those automated commits to speed up the release process.

More info on the release process: https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/055-release-process/