### PR TITLE
fix(cd): stop sending provenance attestation to GCOM

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -268,7 +268,12 @@ on:
 
       # Feature toggle: Artifacts attestation for build provenance
       attestation:
-        description: Create a verifiable attestation for the plugin using Github OIDC.
+        description: |
+          Create a verifiable attestation for the plugin using Github OIDC.
+          NOTE: The resulting attestation reference is currently NOT sent to GCOM
+          when publishing (GCOM no longer consumes it, see grafana/grafana-com#18942).
+          The attestation is still generated and can be wired back into the publish
+          payload if needed.
         type: boolean
         required: false
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -128,7 +128,7 @@ on:
         default: false
       playwright-gar-registry:
         description: |
-          Optional address of a private GAR registry (e.g.: us-docker.pkg.dev) to authenticate to for pulling images 
+          Optional address of a private GAR registry (e.g.: us-docker.pkg.dev) to authenticate to for pulling images
           in the docker-compose setup for the Playwright E2E tests.
           If not specified, no authentication will be done.
         type: string
@@ -270,10 +270,8 @@ on:
       attestation:
         description: |
           Create a verifiable attestation for the plugin using Github OIDC.
-          NOTE: The resulting attestation reference is currently NOT sent to GCOM
-          when publishing (GCOM no longer consumes it, see grafana/grafana-com#18942).
-          The attestation is still generated and can be wired back into the publish
-          payload if needed.
+          NOTE: The resulting attestation reference is currently not sent to GCOM
+          when publishing.
         type: boolean
         required: false
 

--- a/actions/plugins/publish/publish/action.yml
+++ b/actions/plugins/publish/publish/action.yml
@@ -48,8 +48,11 @@ inputs:
     default: "false"
   provenance-attestation:
     description: |
-      Optional provenance attestation reference to include when publishing the plugin.
+      Optional provenance attestation reference for the plugin.
       Expected format: github#<owner>#sha256:<zip-sha256>.
+      NOTE: This value is currently NOT sent to GCOM when publishing
+      (GCOM no longer consumes it, see grafana/grafana-com#18942). The input is
+      kept so it can easily be wired back into the publish payload if needed.
     required: false
     default: ""
   gcom-api-url:

--- a/actions/plugins/publish/publish/action.yml
+++ b/actions/plugins/publish/publish/action.yml
@@ -50,9 +50,7 @@ inputs:
     description: |
       Optional provenance attestation reference for the plugin.
       Expected format: github#<owner>#sha256:<zip-sha256>.
-      NOTE: This value is currently NOT sent to GCOM when publishing
-      (GCOM no longer consumes it, see grafana/grafana-com#18942). The input is
-      kept so it can easily be wired back into the publish payload if needed.
+      NOTE: This value is currently NOT sent to GCOM when publishing.
     required: false
     default: ""
   gcom-api-url:

--- a/actions/plugins/publish/publish/publish.sh
+++ b/actions/plugins/publish/publish/publish.sh
@@ -92,7 +92,7 @@ curl_args=(
     "-H" "Accept: application/json"
     "-H" "User-Agent: github-actions-shared-workflows:/plugins/publish"
 )
-if [ "$has_iap" = true ]; then  
+if [ "$has_iap" = true ]; then
     if [ -z "$GCLOUD_AUTH_TOKEN" ]; then
         echo "GCLOUD_AUTH_TOKEN environment variable not set."
         exit 1
@@ -136,14 +136,9 @@ fi
 # Publish the plugin
 echo "Publishing to $gcom_api_url"
 json_download=$(json_obj "${jq_download_args[@]}")
-# NOTE: The provenance attestation is intentionally NOT sent to GCOM at the moment.
-# GCOM no longer consumes the "provenanceAttestation" field (see grafana/grafana-com#18942),
-# so we keep building the attestation (--provenance-attestation is still accepted and parsed)
-# but omit it from the publish payload.
-# To re-enable, add the following line back to the jq call below:
-#     --arg provenanceAttestation "$provenance_attestation" \
-# and restore the filter to:
-#     '$ARGS.named | if .provenanceAttestation == "" then del(.provenanceAttestation) else . end'
+if [ -n "$provenance_attestation" ]; then
+    echo "A provenance attestation was provided ($provenance_attestation), but it is currently NOT sent to GCOM (see grafana/grafana-com#18942); ignoring it."
+fi
 json_payload=$(jq -c -n \
     --argjson download "$json_download" \
     --arg url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
@@ -152,6 +147,9 @@ json_payload=$(jq -c -n \
     --argjson pending "$pending_param" \
     '$ARGS.named'
 )
+# For provenance attestation:
+# --arg provenanceAttestation "$provenance_attestation" \
+# '$ARGS.named | if .provenanceAttestation == "" then del(.provenanceAttestation) else . end'
 echo $json_payload | jq
 if [ "$dry_run" = true ]; then
     echo "Dry run enabled, skipping publish"

--- a/actions/plugins/publish/publish/publish.sh
+++ b/actions/plugins/publish/publish/publish.sh
@@ -139,6 +139,10 @@ json_download=$(json_obj "${jq_download_args[@]}")
 if [ -n "$provenance_attestation" ]; then
     echo "A provenance attestation was provided ($provenance_attestation), but it is currently NOT sent to GCOM (see grafana/grafana-com#18942); ignoring it."
 fi
+
+# For adding back the provenance attestation:
+# --arg provenanceAttestation "$provenance_attestation" \
+# '$ARGS.named | if .provenanceAttestation == "" then del(.provenanceAttestation) else . end'
 json_payload=$(jq -c -n \
     --argjson download "$json_download" \
     --arg url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
@@ -147,9 +151,6 @@ json_payload=$(jq -c -n \
     --argjson pending "$pending_param" \
     '$ARGS.named'
 )
-# For provenance attestation:
-# --arg provenanceAttestation "$provenance_attestation" \
-# '$ARGS.named | if .provenanceAttestation == "" then del(.provenanceAttestation) else . end'
 echo $json_payload | jq
 if [ "$dry_run" = true ]; then
     echo "Dry run enabled, skipping publish"

--- a/actions/plugins/publish/publish/publish.sh
+++ b/actions/plugins/publish/publish/publish.sh
@@ -16,6 +16,9 @@ gcs_zip_urls=()
 scopes=''
 dry_run=false
 publish_as_pending=false
+# provenance_attestation is still accepted via --provenance-attestation for backwards
+# compatibility, but it is currently NOT included in the GCOM publish payload
+# (see the note near the json_payload construction below).
 provenance_attestation=''
 while [[ "$#" -gt 0 ]]; do
     case $1 in
@@ -133,14 +136,21 @@ fi
 # Publish the plugin
 echo "Publishing to $gcom_api_url"
 json_download=$(json_obj "${jq_download_args[@]}")
+# NOTE: The provenance attestation is intentionally NOT sent to GCOM at the moment.
+# GCOM no longer consumes the "provenanceAttestation" field (see grafana/grafana-com#18942),
+# so we keep building the attestation (--provenance-attestation is still accepted and parsed)
+# but omit it from the publish payload.
+# To re-enable, add the following line back to the jq call below:
+#     --arg provenanceAttestation "$provenance_attestation" \
+# and restore the filter to:
+#     '$ARGS.named | if .provenanceAttestation == "" then del(.provenanceAttestation) else . end'
 json_payload=$(jq -c -n \
     --argjson download "$json_download" \
     --arg url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
     --arg commit "$sha" \
     --argjson scopes "$scopes" \
     --argjson pending "$pending_param" \
-    --arg provenanceAttestation "$provenance_attestation" \
-    '$ARGS.named | if .provenanceAttestation == "" then del(.provenanceAttestation) else . end'
+    '$ARGS.named'
 )
 echo $json_payload | jq
 if [ "$dry_run" = true ]; then

--- a/tests/act/main_cd_test.go
+++ b/tests/act/main_cd_test.go
@@ -1,11 +1,8 @@
 package main
 
 import (
-	"crypto/sha256"
 	"encoding/json"
-	"fmt"
 	"net/http"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -262,7 +259,12 @@ func TestCD(t *testing.T) {
 	}
 }
 
-func TestCD_PublishIncludesProvenanceAttestation(t *testing.T) {
+// TestCD_PublishOmitsProvenanceAttestation verifies that even when the attestation
+// feature is enabled (and the build-attestation job runs), the provenance attestation
+// reference is NOT included in the GCOM publish payload. GCOM no longer consumes this
+// field (see grafana/grafana-com#18942); the attestation is still generated so it can be
+// wired back into the payload later if needed.
+func TestCD_PublishOmitsProvenanceAttestation(t *testing.T) {
 	t.Parallel()
 
 	gitSha, err := getGitCommitSHA()
@@ -275,15 +277,6 @@ func TestCD_PublishIncludesProvenanceAttestation(t *testing.T) {
 		fakeGcomTokenDev = "dummy-gcom-api-key-dev"
 		fakeIapToken     = "dummy-iap-token"
 	)
-
-	zipBytes, err := os.ReadFile(workflow.LocalMockdataPath(
-		"dist-artifacts-unsigned",
-		pluginFolder,
-		anyZipFileName(pluginSlug, pluginVersion),
-	))
-	require.NoError(t, err)
-	zipSHA256 := sha256.Sum256(zipBytes)
-	expProvenanceAttestation := fmt.Sprintf("github#grafana#sha256:%x", zipSHA256)
 
 	mockVault := workflow.VaultSecrets{
 		DefaultValue: newPointer(""),
@@ -307,7 +300,7 @@ func TestCD_PublishIncludesProvenanceAttestation(t *testing.T) {
 
 		var body map[string]any
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&body), "should be able to decode json body")
-		require.Equal(t, expProvenanceAttestation, body["provenanceAttestation"])
+		require.NotContains(t, body, "provenanceAttestation", "provenance attestation should not be sent to GCOM")
 
 		w.WriteHeader(http.StatusOK)
 		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{

--- a/tests/act/main_cd_test.go
+++ b/tests/act/main_cd_test.go
@@ -259,11 +259,6 @@ func TestCD(t *testing.T) {
 	}
 }
 
-// TestCD_PublishOmitsProvenanceAttestation verifies that even when the attestation
-// feature is enabled (and the build-attestation job runs), the provenance attestation
-// reference is NOT included in the GCOM publish payload. GCOM no longer consumes this
-// field (see grafana/grafana-com#18942); the attestation is still generated so it can be
-// wired back into the payload later if needed.
 func TestCD_PublishOmitsProvenanceAttestation(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #814

GCOM no longer consumes the `provenanceAttestation` field (see grafana/grafana-com#18942), so this PR stops including it in the plugin publish payload. The input and provenance calculation steps are kept in case we decide to add it back. It's still possible to generate the attestation for the plugin in case it needs to be used for other reason (rather than POST-ing it to GCOM).