### PR TITLE
feat: Make docs sync directory configurable

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -88,6 +88,15 @@ on:
         type: string
         required: false
         default: .
+      docs-source-directory:
+        description: |
+          Directory in the plugin repository, relative to the checkout root,
+          that contains the docs to test and publish. Defaults to
+          `docs/sources`. Set this to scope docs publishing to a subset of the
+          repository.
+        type: string
+        required: false
+        default: docs/sources
       npm-registry-auth:
         description: |
           Whether to authenticate to the npm registry in Google Artifact Registry.
@@ -786,6 +795,7 @@ jobs:
     with:
       branch: ${{ needs.setup.outputs.commit-sha }}
       plugin-directory: ${{ inputs.plugin-directory }}
+      docs-source-directory: ${{ inputs.docs-source-directory }}
       plugin-version-suffix: ${{ needs.setup.outputs.plugin-version-suffix }}
       npm-registry-auth: ${{ inputs.npm-registry-auth }}
       go-private-git-auth: ${{ inputs.go-private-git-auth }}
@@ -1328,6 +1338,7 @@ jobs:
           id: ${{ fromJSON(needs.ci.outputs.plugin).id }}
           version: ${{ fromJSON(needs.ci.outputs.plugin).version }}
           github-token: x-access-token:${{ steps.generate-github-token.outputs.token }}
+          docs-source-directory: ${{ inputs.docs-source-directory }}
 
   create-github-release:
     name: Create GitHub Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,15 @@ on:
         type: string
         required: false
         default: .
+      docs-source-directory:
+        description: |
+          Directory in the plugin repository, relative to the checkout root,
+          that contains the docs to test and later publish. Defaults to
+          `docs/sources`. Set this to scope docs publishing to a subset of the
+          repository.
+        type: string
+        required: false
+        default: docs/sources
       frontend-secrets:
         description: The secrets to use within frontend steps
         type: string
@@ -737,14 +746,18 @@ jobs:
 
       - name: Check docs exist
         id: exist
+        env:
+          DOCS_SOURCE_DIRECTORY: ${{ inputs.docs-source-directory }}
         run: |
           r=false
-          [ -d "docs/sources" ] && r=true
+          [ -d "${DOCS_SOURCE_DIRECTORY}" ] && r=true
           echo "exist=$r" >> "$GITHUB_OUTPUT"
         shell: bash
 
       - name: Test docs
         uses: grafana/plugin-ci-workflows/actions/internal/plugins/docs/test@main
+        with:
+          docs-source-directory: ${{ inputs.docs-source-directory }}
 
   playwright:
     name: Playwright E2E tests

--- a/actions/internal/plugins/docs/publish/action.yml
+++ b/actions/internal/plugins/docs/publish/action.yml
@@ -11,6 +11,13 @@ inputs:
   github-token:
     description: GitHub token for publishing to the website repository
     required: true
+  docs-source-directory:
+    description: |
+      Directory in the plugin repository, relative to the checkout root, that
+      contains the docs to publish. Defaults to `docs/sources`. Must be a
+      relative subpath. No absolute paths, or `..` segments.
+    required: false
+    default: docs/sources
 
 runs:
   using: composite
@@ -19,11 +26,12 @@ runs:
     - name: Prepare docs PR
       id: prepare-pr
       run: |
-        ${{ github.action_path }}/prepare-pr.sh "${PLUGIN_ID}" "${PLUGIN_VERSION}"
+        ${{ github.action_path }}/prepare-pr.sh "${PLUGIN_ID}" "${PLUGIN_VERSION}" "${DOCS_SOURCE_DIRECTORY}"
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         PLUGIN_ID: ${{ inputs.id }}
         PLUGIN_VERSION: ${{ inputs.version }}
+        DOCS_SOURCE_DIRECTORY: ${{ inputs.docs-source-directory }}
       shell: bash
 
     - name: Create docs PR
@@ -36,7 +44,7 @@ runs:
         branch: plugins-docs/${{ inputs.id }}-v${{ inputs.version }}
         delete-branch: true
         sign-commits: true
-        commit-message: "[plugins] Publish from ${{ github.repository }}:${{ github.ref_name }}/docs/sources"
+        commit-message: "[plugins] Publish from ${{ github.repository }}:${{ github.ref_name }}/${{ inputs.docs-source-directory }}"
         title: "[plugins] Publish docs for ${{ inputs.id }} v${{ inputs.version }}"
         body: |
           Automated docs publish for `${{ inputs.id }}` `v${{ inputs.version }}`

--- a/actions/internal/plugins/docs/publish/prepare-pr.sh
+++ b/actions/internal/plugins/docs/publish/prepare-pr.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-if [ $# -ne 2 ]; then
-    echo "Usage: $0 <plugin_id> <plugin_version>"
+if [ $# -lt 2 ] || [ $# -gt 3 ]; then
+    echo "Usage: $0 <plugin_id> <plugin_version> [docs_source_directory]"
     exit 1
 fi
 
@@ -16,6 +16,7 @@ apk add --no-cache rsync
 
 plugin_id="$1"
 plugin_version="$2"
+docs_source_directory="${3:-docs/sources}"
 
 case "$plugin_id" in
   (*[!a-zA-Z0-9-]*|'')
@@ -29,6 +30,21 @@ case "$plugin_version" in
     exit 1
     ;;
 esac
+
+# Reject absolute paths, '..' segments, and anything that isn't a relative
+# subpath of the plugin repository. This keeps rsync scoped to the checkout.
+case "$docs_source_directory" in
+  (/*|*..*|'')
+    echo "Invalid docs_source_directory: $docs_source_directory" >&2
+    exit 1
+    ;;
+esac
+
+docs_source_abs="${GITHUB_WORKSPACE}/${docs_source_directory}"
+if [ ! -d "$docs_source_abs" ]; then
+    echo "docs source directory not found: $docs_source_abs" >&2
+    exit 1
+fi
 
 # Accept either a raw token or one already prefixed with "x-access-token:"
 # so callers that pass "x-access-token:<token>" keep working.
@@ -51,7 +67,7 @@ git clone \
 
 docs_folder="${abs_clone_dir}/content/docs/plugins/$plugin_id/v$plugin_version"
 mkdir -p "$docs_folder"
-rsync -a --quiet --delete "$GITHUB_WORKSPACE/docs/sources/" "$docs_folder"
+rsync -a --quiet --delete "${docs_source_abs%/}/" "$docs_folder"
 
 # Expose the clone directory, relative to GITHUB_WORKSPACE, for the
 # create-pull-request step's `path` input. create-pull-request stages and

--- a/actions/internal/plugins/docs/test/action.yml
+++ b/actions/internal/plugins/docs/test/action.yml
@@ -1,14 +1,24 @@
 name: Plugins - Docs - Test
 description: Check whether docs can be successfully built.
 
+inputs:
+  docs-source-directory:
+    description: |
+      Directory in the plugin repository, relative to the checkout root, that
+      contains the docs to test. Defaults to `docs/sources`.
+    required: false
+    default: docs/sources
+
 runs:
   using: composite
   steps:
     - name: Test docs
+      env:
+        DOCS_SOURCE_DIRECTORY: ${{ inputs.docs-source-directory }}
       run: |
-        if [ -d docs/sources ]; then
-          ${{ github.action_path }}/script.sh
+        if [ -d "${DOCS_SOURCE_DIRECTORY}" ]; then
+          ${{ github.action_path }}/script.sh "${DOCS_SOURCE_DIRECTORY}"
         else
-          echo "❌ Docs do not exist."
+          echo "❌ Docs do not exist at ${DOCS_SOURCE_DIRECTORY}."
         fi
       shell: bash

--- a/actions/internal/plugins/docs/test/script.sh
+++ b/actions/internal/plugins/docs/test/script.sh
@@ -1,9 +1,13 @@
 set -e
 
-if [ ! -d docs/sources ]; then echo "docs/sources not found. skipping build." && exit 0; fi
+docs_source_directory="${1:-docs/sources}"
+
+if [ ! -d "${docs_source_directory}" ]; then
+  echo "${docs_source_directory} not found. skipping build." && exit 0
+fi
 
 mkdir -p /hugo/content/docs/plugins/temp-name/v1.0.0
-cp -r docs/sources /hugo/content/docs/plugins/temp-name/v1.0.0
+cp -r "${docs_source_directory}"/. /hugo/content/docs/plugins/temp-name/v1.0.0/
 make -C /hugo prod
 
 echo "✅ Docs can be successfuly built"


### PR DESCRIPTION
The LLM app in https://github.com/grafana/machine-learning is actually the plugin being documented but the plugin CI workflow syncs the entirety of docs/sources.

This lets them sync only the bit that relates to their plugin and not all their machine learning docs.

Closes #827
