### PR TITLE
ci: add manual trigger to release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds a workflow_dispatch trigger to the release-please workflow so it can be run manually from main, without waiting for the next push.