### PR TITLE
feat(cd)!: publish plugin docs to latest/ instead of versioned dirs

### DIFF
--- a/actions/internal/plugins/docs/publish/prepare-pr.sh
+++ b/actions/internal/plugins/docs/publish/prepare-pr.sh
@@ -65,7 +65,7 @@ git clone \
     --depth 1 --single-branch --no-tags \
     https://github.com/grafana/website.git "$abs_clone_dir"
 
-docs_folder="${abs_clone_dir}/content/docs/plugins/$plugin_id/v$plugin_version"
+docs_folder="${abs_clone_dir}/content/docs/plugins/$plugin_id/latest"
 mkdir -p "$docs_folder"
 rsync -a --quiet --delete "${docs_source_abs%/}/" "$docs_folder"
 

--- a/actions/internal/plugins/docs/test/script.sh
+++ b/actions/internal/plugins/docs/test/script.sh
@@ -6,8 +6,8 @@ if [ ! -d "${docs_source_directory}" ]; then
   echo "${docs_source_directory} not found. skipping build." && exit 0
 fi
 
-mkdir -p /hugo/content/docs/plugins/temp-name/v1.0.0
-cp -r "${docs_source_directory}"/. /hugo/content/docs/plugins/temp-name/v1.0.0/
+mkdir -p /hugo/content/docs/plugins/temp-name/latest
+cp -r "${docs_source_directory}"/. /hugo/content/docs/plugins/temp-name/latest/
 make -C /hugo prod
 
 echo "✅ Docs can be successfuly built"


### PR DESCRIPTION
The website only serves /latest/ content now and this change prevents a build up of unused copies of the plugins documentation.

Needs https://github.com/grafana/website/pull/31693. 

Closes https://github.com/grafana/website/issues/29619