### PR TITLE
chore(renovate): extend shared grafana-catalog-team preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,10 +4,11 @@
         "github>grafana/grafana-renovate-config//presets/base",
         "github>grafana/grafana-renovate-config//presets/automerge",
         "github>grafana/grafana-renovate-config//presets/labels",
-        "github>grafana/grafana-renovate-config//presets/docker"
+        "github>grafana/grafana-renovate-config//presets/docker",
+        "github>grafana/grafana-renovate-config//presets/npm"
     ],
     "extends": [
-        "config:best-practices"
+        "github>grafana/grafana-catalog-team//renovate/renovate"
     ],
     "packageRules": [
         {
@@ -120,7 +121,5 @@
         }
     ],
     "dependencyDashboard": false,
-    "minimumReleaseAge": "14 days",
-    "prConcurrentLimit": 10,
-    "rebaseWhen": "behind-base-branch"
+    "prConcurrentLimit": 10
 }


### PR DESCRIPTION
Point extends at the shared team preset (github>grafana/grafana-catalog-team//renovate/renovate) instead of config:best-practices, which the org-wide self-hosted config already applies everywhere. Added the npm entry to the existing ignorePresets block so it covers the four team-standard presets (base, automerge, labels, npm), and kept the repo's existing docker entry. That block lives in this file because Renovate does not inherit ignorePresets from extended presets (renovate/renovate#14818). Removed the top-level minimumReleaseAge of 14 days (dead config: the org force block pins 3 days and overrides repo values) and rebaseWhen. The security-only dependabot.yml is left as is.

Part of grafana/grafana-catalog-team#1052.
