### PR TITLE
fix: package every backend executable family

### DIFF
--- a/actions/internal/plugins/package/package.sh
+++ b/actions/internal/plugins/package/package.sh
@@ -77,60 +77,119 @@ if [ "$universal" = true ]; then
     exit 0
 fi
 
-# Identify apps with nested datasource
-ptype=$(jq -r .type plugin.json)
-exe=$(jq -r .executable plugin.json)
-backend_folder="."
-if [ "$ptype" == "app" ] && [ -d "datasource" ]; then
-    echo "Found nested datasource"
-    cd datasource
-    nested_exe=$(jq -r .executable plugin.json)
-    if [ "$nested_exe" != "null" ]; then
-        backend_folder="datasource"
-        exe="$backend_folder/$nested_exe"
+# Discover every backend executable family declared by a packaged plugin.json.
+# Executable paths are relative to the plugin.json that declares them.
+backend_executables=()
+while IFS= read -r -d '' plugin_json; do
+    executable=$(jq -r '.executable // empty' "$plugin_json")
+    if [ -z "$executable" ]; then
+        continue
     fi
-    cd ..
-fi
 
-if [ "$exe" == "null" ]; then
+    plugin_dir=$(dirname "$plugin_json")
+    if [ "$plugin_dir" = "." ]; then
+        backend_executables+=("$executable")
+    else
+        backend_executables+=("${plugin_dir#./}/$executable")
+    fi
+done < <(find . -type f -name plugin.json -print0)
+
+# Collect all executable files and the unique os/arch variants they provide.
+backend_files=()
+os_arches=()
+for executable in "${backend_executables[@]}"; do
+    executable_dir=$(dirname "$executable")
+    executable_basename=$(basename "$executable")
+
+    while IFS= read -r -d '' file; do
+        file=${file#./}
+        filename=$(basename "$file")
+        os_arch=${filename#"${executable_basename}_"}
+        os_arch=${os_arch%.exe}
+        if [[ ! "$os_arch" =~ ^[a-zA-Z0-9_]+$ ]]; then
+            continue
+        fi
+
+        backend_files+=("$file")
+        os_arches+=("$os_arch")
+    done < <(find "$executable_dir" -maxdepth 1 -type f -name "${executable_basename}_*" -print0)
+done
+
+if [ "${#backend_files[@]}" -eq 0 ]; then
     echo "No executable found in plugin.json"
     exit 0
 fi
 
-# Create os+arch zips
-exe_basename=$(basename $exe)
-for file in $(find "$backend_folder" -type f -name "${exe_basename}_*"); do
-    # Extract os+arch from the file name
-    os_arch=$(echo $(basename $file) | sed -E "s|${exe_basename}_([a-zA-Z0-9_]+)(.exe)?|\1|")
+unique_os_arches=()
+while IFS= read -r os_arch; do
+    if [ -n "$os_arch" ]; then
+        unique_os_arches+=("$os_arch")
+    fi
+done < <(printf '%s\n' "${os_arches[@]}" | sort -u)
 
-    # Temporary folder for the zip file
+selected_executable_path() {
+    local executable=$1
+    local os_arch=$2
+    local candidate="$dist/${executable}_${os_arch}"
+
+    if [ -f "$candidate" ]; then
+        printf '%s\n' "$candidate"
+    elif [ -f "${candidate}.exe" ]; then
+        printf '%s\n' "${candidate}.exe"
+    else
+        return 1
+    fi
+}
+
+# A tailored archive is only valid when every backend family supports its
+# platform. Fail before packaging instead of publishing an incomplete plugin.
+for os_arch in "${unique_os_arches[@]}"; do
+    for executable in "${backend_executables[@]}"; do
+        if ! selected_executable_path "$executable" "$os_arch" > /dev/null; then
+            echo "Executable '$executable' does not provide $os_arch, aborting."
+            exit 1
+        fi
+    done
+done
+
+# Create one zip per unique os+arch combination. Each zip copies all non-backend
+# files, then adds the selected executable from every backend family.
+for os_arch in "${unique_os_arches[@]}"; do
     tmp=$(mktemp -d)
-    pushd $tmp > /dev/null
+    pushd "$tmp" > /dev/null
     mkdir -p "$plugin_id"
 
-    # Copy all files but the executables, preserving permissions and mod times (similar to rsync)
     pushd "$dist" > /dev/null
-    # -name "${exe_basename}*" -prune: Ignore (prune) all executables
-    # -o -type f -print0: OR, print file name (NUL-terminated) for use with while read
-    # Copy with cp, preserving permissions and create any required parent directories to the dest folder
-    # Note: Using a while loop instead of xargs for macOS compatibility (BSD cp lacks --parents and -t)
-    find . -name "${exe_basename}*" -prune -o -type f -print0 | while IFS= read -r -d '' file; do
+    while IFS= read -r -d '' file; do
+        relative_file=${file#./}
+        is_backend_file=false
+        for backend_file in "${backend_files[@]}"; do
+            if [ "$relative_file" = "$backend_file" ]; then
+                is_backend_file=true
+                break
+            fi
+        done
+        if [ "$is_backend_file" = true ]; then
+            continue
+        fi
+
         dir=$(dirname "$file")
         mkdir -p "$tmp/$plugin_id/$dir"
         cp -p "$file" "$tmp/$plugin_id/$dir/"
-    done
+    done < <(find . -type f -print0)
     popd > /dev/null
 
-    # Copy only the current executable
-    cp "$dist/$file" "$tmp/$plugin_id/$backend_folder"
+    for executable in "${backend_executables[@]}"; do
+        selected_executable=$(selected_executable_path "$executable" "$os_arch")
+        executable_dest="$tmp/$plugin_id/$(dirname "$executable")"
+        mkdir -p "$executable_dest"
+        cp -p "$selected_executable" "$executable_dest/"
+    done
+
     os_arch_zip_fn="$plugin_id-$plugin_version.$os_arch.zip"
     echo "Creating package: $os_arch_zip_fn"
-
-    # Create the zip+sha256 files
     package "$out/$os_arch_zip_fn" "$plugin_id" "$SIGNATURE_TYPE"
 
-    # Cleanup temporary folder
     popd > /dev/null
-    rm -rf $tmp
+    rm -rf "$tmp"
 done
-

--- a/tests/act/main_package_test.go
+++ b/tests/act/main_package_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"archive/zip"
 	"encoding/json"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -198,4 +201,145 @@ func TestPackage(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPackageScriptMultipleBackendFamilies(t *testing.T) {
+	t.Parallel()
+
+	const (
+		pluginID      = "grafana-multibackend-app"
+		pluginVersion = "1.0.0"
+	)
+
+	tmp := t.TempDir()
+	dist := filepath.Join(tmp, "dist")
+	out := filepath.Join(tmp, "dist-artifacts")
+	require.NoError(t, os.MkdirAll(out, 0o755))
+
+	fixtureFiles := map[string]string{
+		"plugin.json": `{
+			"id": "grafana-multibackend-app",
+			"type": "app",
+			"executable": "bin/gpx_root",
+			"info": {"version": "1.0.0"}
+		}`,
+		"module.js":                               "root frontend",
+		"go_plugin_build_manifest":                "root manifest",
+		"bin/gpx_root_linux_amd64":                "root linux executable",
+		"bin/gpx_root_windows_amd64.exe":          "root windows executable",
+		"resources/config.json":                   `{"preserve": true}`,
+		"datasource/plugin.json":                  `{"id":"grafana-nested-datasource","type":"datasource","backend":true,"executable":"gpx_nested","info":{"version":"1.0.0"}}`,
+		"datasource/module.js":                    "nested frontend",
+		"datasource/go_plugin_build_manifest":     "nested manifest",
+		"datasource/gpx_nested_linux_amd64":       "nested linux executable",
+		"datasource/gpx_nested_windows_amd64.exe": "nested windows executable",
+	}
+	writePackageFixtureFiles(t, dist, fixtureFiles)
+
+	output, err := runPackageScript(dist, out)
+	require.NoError(t, err, string(output))
+	output, err = runPackageScript("--universal", dist, out)
+	require.NoError(t, err, string(output))
+
+	baseFiles := []string{
+		filepath.Join(pluginID, "plugin.json"),
+		filepath.Join(pluginID, "module.js"),
+		filepath.Join(pluginID, "go_plugin_build_manifest"),
+		filepath.Join(pluginID, "resources/config.json"),
+		filepath.Join(pluginID, "datasource/plugin.json"),
+		filepath.Join(pluginID, "datasource/module.js"),
+		filepath.Join(pluginID, "datasource/go_plugin_build_manifest"),
+	}
+	backendFiles := map[string][]string{
+		"linux_amd64": {
+			filepath.Join(pluginID, "bin/gpx_root_linux_amd64"),
+			filepath.Join(pluginID, "datasource/gpx_nested_linux_amd64"),
+		},
+		"windows_amd64": {
+			filepath.Join(pluginID, "bin/gpx_root_windows_amd64.exe"),
+			filepath.Join(pluginID, "datasource/gpx_nested_windows_amd64.exe"),
+		},
+	}
+
+	for _, tc := range []struct {
+		name          string
+		zipName       string
+		expectedFiles []string
+	}{
+		{
+			name:    "universal",
+			zipName: anyZipFileName(pluginID, pluginVersion),
+			expectedFiles: append(
+				append(append([]string{}, baseFiles...), backendFiles["linux_amd64"]...),
+				backendFiles["windows_amd64"]...,
+			),
+		},
+		{
+			name:          "linux amd64",
+			zipName:       pluginID + "-" + pluginVersion + ".linux_amd64.zip",
+			expectedFiles: append(append([]string{}, baseFiles...), backendFiles["linux_amd64"]...),
+		},
+		{
+			name:          "windows amd64",
+			zipName:       pluginID + "-" + pluginVersion + ".windows_amd64.zip",
+			expectedFiles: append(append([]string{}, baseFiles...), backendFiles["windows_amd64"]...),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			zr, err := zip.OpenReader(filepath.Join(out, tc.zipName))
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, zr.Close()) })
+
+			actualFiles := make([]string, 0, len(zr.File))
+			for _, file := range zr.File {
+				if !file.FileInfo().IsDir() {
+					actualFiles = append(actualFiles, file.Name)
+				}
+			}
+			require.ElementsMatch(t, tc.expectedFiles, actualFiles)
+		})
+	}
+}
+
+func TestPackageScriptRejectsMismatchedBackendPlatforms(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	dist := filepath.Join(tmp, "dist")
+	out := filepath.Join(tmp, "dist-artifacts")
+	require.NoError(t, os.MkdirAll(out, 0o755))
+
+	writePackageFixtureFiles(t, dist, map[string]string{
+		"plugin.json":                       `{"id":"grafana-multibackend-app","type":"app","executable":"gpx_root","info":{"version":"1.0.0"}}`,
+		"gpx_root_linux_amd64":              "root linux executable",
+		"gpx_root_windows_amd64.exe":        "root windows executable",
+		"datasource/plugin.json":            `{"id":"grafana-nested-datasource","type":"datasource","backend":true,"executable":"gpx_nested","info":{"version":"1.0.0"}}`,
+		"datasource/gpx_nested_linux_amd64": "nested linux executable",
+	})
+
+	output, err := runPackageScript(dist, out)
+	require.Error(t, err)
+	require.Contains(t, string(output), "Executable 'datasource/gpx_nested' does not provide windows_amd64, aborting.")
+
+	entries, err := os.ReadDir(out)
+	require.NoError(t, err)
+	require.Empty(t, entries, "validation should fail before creating tailored archives")
+}
+
+func writePackageFixtureFiles(t *testing.T, root string, files map[string]string) {
+	t.Helper()
+
+	for name, content := range files {
+		path := filepath.Join(root, filepath.FromSlash(name))
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o755))
+	}
+}
+
+func runPackageScript(args ...string) ([]byte, error) {
+	cmd := exec.Command("bash", append([]string{"actions/internal/plugins/package/package.sh"}, args...)...)
+	cmd.Env = append(os.Environ(), "GRAFANA_ACCESS_POLICY_TOKEN=", "SIGNATURE_TYPE=grafana")
+	return cmd.CombinedOutput()
 }


### PR DESCRIPTION
## What this changes

- Discover every backend executable family declared by a packaged `plugin.json`, resolving executable paths relative to that manifest.
- Build each tailored archive with the selected OS/architecture binary from every family and no binaries for other platforms.
- Reject mismatched backend platform matrices before creating incomplete tailored archives.
- Keep universal archive behavior and existing tailored archive naming unchanged.

## Why

The previous app-plugin path replaced the root executable family with a nested datasource executable. Tailored archives therefore filtered only the nested family and retained every platform binary from the root family.

This was observed in Odin's [development catalog publication job](https://github.com/grafana/hackathon-14-grafana-odin/actions/runs/30509388201/job/90767480397), where validation passed before the catalog API returned `InternalServer`. The oversized archives motivate this fix, but the catalog response alone does not establish that the failure was an OOM.

## Validation

- `go test -short -run '^TestPackageScript' -count=1 -v` (including macOS Bash 3.2)
- Direct existing single-backend validation: six tailored archives retain exactly one matching executable; universal retains all six
- `go vet ./...` in `tests/act`
- `shellcheck -e SC2086,SC2153 actions/internal/plugins/package/package.sh` (excluded findings predate this change)
- `git diff --check origin/main...HEAD`

Local environment limitations:

- `TestPackage` could not start because `act` is not installed.
- `make actionlint` and `make act-lint` could not start because `actionlint` and `golangci-lint` are not installed.
