### PR TITLE
ci(act-tests): publish test results to the run summary

### DIFF
--- a/.github/workflows/pr-checks-test-ci.yml
+++ b/.github/workflows/pr-checks-test-ci.yml
@@ -98,10 +98,25 @@ jobs:
 
       - name: Run act tests
         run: |
-          go test -v -timeout 1h
+          go run gotest.tools/gotestsum@v1.13.0 \
+            --junitfile "${RUNNER_TEMP}/act-tests.xml" \
+            --format standard-verbose \
+            -- -timeout 1h
         working-directory: tests/act
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Publish per-test results (incl. failure messages) to the run summary,
+      # so failures can be read without digging through the raw act logs.
+      - name: Publish test report
+        if: ${{ !cancelled() }}
+        uses: mikepenz/action-junit-report@d9f48fc87bc235f7e214acf696ca5abc0a986f16 # v6.4.2
+        with:
+          report_paths: ${{ runner.temp }}/act-tests.xml
+          detailed_summary: true
+          include_passed: true
+          annotate_only: true
+          require_tests: false
 
   act-tests-result:
     name: Act tests result


### PR DESCRIPTION
# What

Act test failures currently only live in the raw job log, which for these tests means scrolling through the streamed act/Docker output to find the assertion that failed. This wraps `go test` in gotestsum to produce a JUnit report and publishes it to the workflow run summary with mikepenz/action-junit-report (SHA-pinned), so per-test results and failure messages show up directly on the run page.

`gotestsum --format standard-verbose` keeps the job log output identical to `go test -v`, and local runs are unaffected.

`annotate_only` avoids needing `checks: write`, and `require_tests: false` keeps the report step from failing the job when the test run dies before producing the XML (the gate job already handles the failure).

Once merged, a good live demo is any push to #883, which fails a packaging test on purpose.