### PR TITLE
chore(cd): default Slack notifications to #grafana-catalog-ci

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -393,9 +393,9 @@ on:
         description: |
           Slack channel to use for Argo Workflow deployment notifications.
           This is only used when Argo is triggered (when `trigger-argo` is true).
-          Default is '#grafana-plugins-platform-ci'.
+          Default is '#grafana-catalog-ci'.
           This should be changed to a Slack channel specific to your team.
-        default: "#grafana-plugins-platform-ci"
+        default: "#grafana-catalog-ci"
         type: string
       argo-workflow-slack-silent:
         description: |

--- a/examples/base/provisioned-plugin-auto-cd/publish.yaml
+++ b/examples/base/provisioned-plugin-auto-cd/publish.yaml
@@ -51,7 +51,7 @@ jobs:
       grafana-cloud-deployment-type: provisioned
       # Trigger Argo Workflow only when deploying from main branch (do not deploy PRs to the whole cluster)
       trigger-argo: ${{ github.event.inputs.branch == 'main' }}
-      argo-workflow-slack-channel: "#grafana-plugins-platform-ci" # TODO: Change with your own Slack channel
+      argo-workflow-slack-channel: "#grafana-catalog-ci" # TODO: Change with your own Slack channel
 
 
       # TODO: add here any other CI custom inputs you may need. You most likely also have to add the same options to push.yaml:

--- a/examples/base/provisioned-plugin-auto-cd/push.yaml
+++ b/examples/base/provisioned-plugin-auto-cd/push.yaml
@@ -38,7 +38,7 @@ jobs:
 
       # This will trigger the Argo Workflow to update your plugin version in Grafana Cloud via deployment_tools
       grafana-cloud-deployment-type: provisioned
-      argo-workflow-slack-channel: "#grafana-plugins-platform-ci" # TODO: Change with your own Slack channel
+      argo-workflow-slack-channel: "#grafana-catalog-ci" # TODO: Change with your own Slack channel
       # Grafana Cloud environment to deploy the provisioned plugin to.
       # - 'dev': dev
       # - 'ops': ops

--- a/examples/base/provisioned-plugin-manual-deployment/publish.yaml
+++ b/examples/base/provisioned-plugin-manual-deployment/publish.yaml
@@ -51,7 +51,7 @@ jobs:
       grafana-cloud-deployment-type: provisioned
       # Trigger Argo Workflow only when deploying from main branch (do not deploy PRs to the whole cluster)
       trigger-argo: ${{ github.event.inputs.branch == 'main' }}
-      argo-workflow-slack-channel: "#grafana-plugins-platform-ci" # TODO: Change with your own Slack channel
+      argo-workflow-slack-channel: "#grafana-catalog-ci" # TODO: Change with your own Slack channel
 
 
       # TODO: add here any other CI custom inputs you may need. You most likely also have to add the same options to push.yaml:


### PR DESCRIPTION
The team CI channel moved from #grafana-plugins-platform-ci to #grafana-catalog-ci. This updates the cd workflow's default argo-workflow-slack-channel and the example workflows. Repos that override the channel explicitly are updated separately.