### PR TITLE
test: classify renovate-approve.yml in workflow consistency test

### DIFF
--- a/tests/act/main_workflow_consistency_test.go
+++ b/tests/act/main_workflow_consistency_test.go
@@ -36,6 +36,7 @@ var knownWorkflows = []workflowEntry{
 	{path: "release-please-pr-update-tagged-references.yml", internal: true},
 	{path: "release-please-restore-rolling-release.yml", internal: true},
 	{path: "release-please.yml", internal: true},
+	{path: "renovate-approve.yml", internal: true},
 }
 
 // ciOnlyInputs lists ci.yml inputs that are CI-only and should NOT be in cd.yml.


### PR DESCRIPTION
#886 added renovate-approve.yml without registering it in knownWorkflows, so the Act tests fail on any PR that touches workflow files (first surfaced on #896). Classifies it as internal.