### PR TITLE
feat(ci): add disable-gcs-upload input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,6 +305,14 @@ on:
         type: number
         required: false
         default: 10
+      disable-gcs-upload:
+        description: |
+          If true, skip uploading the plugin ZIPs to the GCS artifacts bucket.
+          The ZIPs are still uploaded as GitHub artifacts. The `gcs-*` outputs will be empty and
+          publishing to the plugins catalog will not work, so this is not exposed on cd.yml.
+        type: boolean
+        required: false
+        default: false
       DO-NOT-USE-allow-pinned-commit-hashes:
         description: |
           FOR INTERNAL TESTING ONLY, DO NOT USE.
@@ -340,6 +348,7 @@ on:
       zips:
         value: ${{ jobs.test-and-build.outputs.zips }}
 
+      # All four gcs-* outputs are empty when the `disable-gcs-upload` input is true.
       gcs-zip-urls-latest:
         value: ${{ jobs.upload-to-gcs.outputs.zip-urls-latest }}
       gcs-zip-urls-commit:
@@ -812,10 +821,12 @@ jobs:
     runs-on: ubuntu-arm64-small
 
     # Skip the GCS upload (no access to the bucket) for PRs when run in non-trusted context (forks).
+    # Also skipped when the caller sets `disable-gcs-upload`.
     # If Playwright is enabled, only upload after the corresponding Playwright job succeeds.
     if: >-
       ${{
         !cancelled()
+        && !inputs.disable-gcs-upload
         && needs.test-and-build.result == 'success'
         && fromJson(needs.test-and-build.outputs.workflow-context).isTrusted
         && (!inputs.run-playwright || needs.playwright.result == 'success')

--- a/tests/act/internal/workflow/ci/ci.go
+++ b/tests/act/internal/workflow/ci/ci.go
@@ -114,6 +114,7 @@ type WorkflowInputs struct {
 	BackendBuildTarget *string
 
 	DistArtifactsRetentionDays *int
+	DisableGCSUpload           *bool
 }
 
 // SetCIInputs sets the inputs for the CI workflow.
@@ -142,6 +143,7 @@ func SetCIInputs(dst *workflow.Job, inputs WorkflowInputs) {
 	workflow.SetJobInput(dst, "backend-build-target", inputs.BackendBuildTarget)
 
 	workflow.SetJobInput(dst, "dist-artifacts-retention-days", inputs.DistArtifactsRetentionDays)
+	workflow.SetJobInput(dst, "disable-gcs-upload", inputs.DisableGCSUpload)
 }
 
 // WithWorkflowInputs sets the inputs for the CI workflow.

--- a/tests/act/main_workflow_consistency_test.go
+++ b/tests/act/main_workflow_consistency_test.go
@@ -42,6 +42,9 @@ var knownWorkflows = []workflowEntry{
 // ciOnlyInputs lists ci.yml inputs that are CI-only and should NOT be in cd.yml.
 var ciOnlyInputs = map[string]bool{
 	"testing": true,
+	// Publishing downloads the plugin from a GCS URL, so skipping the upload is
+	// incompatible with CD.
+	"disable-gcs-upload": true,
 }
 
 func TestCDWorkflowContainsAllCIInputs(t *testing.T) {


### PR DESCRIPTION
Adds an opt-in `disable-gcs-upload` input to `ci.yml` that skips the `upload-to-gcs` job, for repositories that need the built plugin ZIPs to stay in the repository.

Today the ZIPs are uploaded to the `integration-artifacts` bucket on every trusted run, including pull requests, and there is no way to turn that off.

## What it does

- `disable-gcs-upload: false` by default, so nothing changes for existing callers
- When true, `upload-to-gcs` is skipped. The ZIPs are still built, signed and uploaded as GitHub artifacts, so e2e tests and anything else consuming `dist-artifacts` are unaffected
- `upload-to-gcs` is a leaf job, nothing `needs` it, so skipping it does not cascade
- The four `gcs-*` workflow outputs are empty when it is set

## Not exposed on cd.yml

This departs from the AGENTS.md convention that new CI inputs get passed through from `cd.yml`, for two reasons:

1. Catalog publishing downloads the plugin from a GCS URL, so the two are incompatible by construction.
2. `upload-to-gcs-release` derives its upload glob from `needs.ci.outputs.gcs-universal-zip-url-commit` via `basename`. With that output empty, the glob collapses to a bare `*` and would upload the wrong file set rather than failing.

Worth fixing separately if the input is ever wanted on `cd.yml`. Deriving the filename from `fromJSON(needs.ci.outputs.plugin).id` and `.version`, both already in scope in that job, would remove the dependency on the CI GCS URL entirely.

## Testing

`make actionlint` clean. `go build ./...` and `go vet ./...` clean in `tests/act`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)