### PR TITLE
fix(ci): trust grafana-oss-big-tent so release-please releases can sign

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -436,7 +436,10 @@ jobs:
               'dependabot[bot]',
               'renovate-sh-app[bot]',
               // Used by other shared workflows such as the version bump workflow
-              'grafana-plugins-platform-bot[bot]'
+              'grafana-plugins-platform-bot[bot]',
+              // Creates releases via release-please in datasource repos, so it is the
+              // actor of their release-event publish runs, which sign the plugin
+              'grafana-oss-big-tent[bot]'
             ].map((s) => s.toLowerCase());
 
             const isPR = context.eventName === 'pull_request';


### PR DESCRIPTION
Datasource repos enrolled in release-please create their GitHub releases with the `grafana-oss-big-tent` app, so that bot is the actor of every release-event run of the shared CI. The trust check treats unlisted bot actors as untrusted, which skips the Vault fetch for `SIGN_PLUGIN_ACCESS_POLICY_TOKEN`, and the prod-environment package step then fails with "Packaging unsigned plugins is not allowed".

First occurrence: [grafana-elasticsearch-datasource run 33068162903](https://github.com/grafana/grafana-elasticsearch-datasource/actions/runs/33068162903), the docs publish for the first release-please release (v12.8.1). The same gate affects every release-event `cd.yml`/`ci.yml` run in repos where this app publishes releases.

This adds the app to `trustedBots`, alongside `grafana-plugins-platform-bot[bot]` which is trusted for the same class of shared-workflow automation. The app is org-controlled and its token grants are scoped per repository and workflow.
