### PR TITLE
fix(tests): stop mock servers taking ports reserved for act

### DIFF
--- a/tests/act/internal/act/act.go
+++ b/tests/act/internal/act/act.go
@@ -667,19 +667,39 @@ func getDockerHostIP() string {
 	return "172.17.0.1"
 }
 
-// takenPorts keeps track of ports that have been given out by getFreePort and not yet marked as free by markPortAsFree.
+// takenPorts keeps track of ports that are in use by this process, either because
+// getFreePort handed them out for an act artifact server that has not bound them yet,
+// or because listenFreePort has an open listener on them.
+//
+// Every port this process binds must go through getFreePort or listenFreePort.
+// A listener created directly with net.Listen on port 0 bypasses the map and can be
+// handed a port that getFreePort has already promised to an act artifact server, which
+// then fails to start with "bind: address already in use".
 var takenPorts sync.Map
 
+// freePortAddr is the address probed when looking for a free port.
+//
+// This is deliberately the wildcard address and not localhost: act binds its artifact
+// server to the host's outbound IP (see getDockerHostIP), and the mock servers bind all
+// interfaces so containers can reach them. A port that is free on 127.0.0.1 can still be
+// taken on those addresses, so probing localhost would report ports that cannot be used.
+const freePortAddr = "0.0.0.0:0"
+
+// maxFreePortRetries is how many times to retry when a probed port is already reserved.
+const maxFreePortRetries = 10
+
 // getFreePort asks the kernel for a free open port that is ready to use.
-// The returned port is registered locally and will be considered taken by other calls
-// to getFreePort until markPortAsFree is called with the port number.
-// This avoids TOCTOU races where parallel tests get the same port.
-// The port can be used right away: no listener will be bound to that port when the function returns.
-// The caller must call markPortAsFree with the returned value to mark the port as free again, when it's no longer needed.
+// The returned port is registered in takenPorts and will be considered taken by other
+// calls to getFreePort and listenFreePort until markPortAsFree is called with it.
+// The port can be used right away: no listener is bound to it when the function returns.
+//
+// Use this for ports handed to another process (act's artifact server). If you need a
+// listener in this process, use listenFreePort instead: it never leaves the port unbound.
+//
+// The caller must call markPortAsFree with the returned value when the port is no longer needed.
 func getFreePort() (int, error) {
-	const maxRetries = 10
-	for retry := 0; retry < maxRetries; retry++ {
-		addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	for range maxFreePortRetries {
+		addr, err := net.ResolveTCPAddr("tcp", freePortAddr)
 		if err != nil {
 			continue
 		}
@@ -703,7 +723,46 @@ func getFreePort() (int, error) {
 		}
 		return port, nil
 	}
-	return 0, fmt.Errorf("could not find a free port after retrying %d times", maxRetries)
+	return 0, fmt.Errorf("could not find a free port after retrying %d times", maxFreePortRetries)
+}
+
+// listenFreePort binds a TCP listener to a free port on all interfaces, so that containers
+// started by act can reach it, and registers the port in takenPorts for as long as the
+// listener is open. Closing the returned listener releases the registration.
+//
+// Unlike getFreePort the port is never left unbound, so there is no window in which the
+// kernel can hand it to somebody else.
+func listenFreePort() (net.Listener, error) {
+	for range maxFreePortRetries {
+		listener, err := net.Listen("tcp", freePortAddr)
+		if err != nil {
+			return nil, fmt.Errorf("listen on %s: %w", freePortAddr, err)
+		}
+		port := listener.Addr().(*net.TCPAddr).Port
+		if _, ok := takenPorts.LoadOrStore(port, struct{}{}); ok {
+			// Reserved for an act artifact server that has not bound it yet. Try again.
+			if err := listener.Close(); err != nil {
+				fmt.Fprintf(os.Stderr, "listenFreePort: close listener on port %d: %v\n", port, err)
+			}
+			continue
+		}
+		return &reservedListener{Listener: listener, port: port}, nil
+	}
+	return nil, fmt.Errorf("could not find a free port after retrying %d times", maxFreePortRetries)
+}
+
+// reservedListener is a net.Listener that releases its takenPorts registration on Close.
+type reservedListener struct {
+	net.Listener
+	port int
+	once sync.Once
+}
+
+// Close closes the underlying listener and marks its port as free.
+func (l *reservedListener) Close() error {
+	err := l.Listener.Close()
+	l.once.Do(func() { markPortAsFree(l.port) })
+	return err
 }
 
 // markPortAsFree marks the given port as free again by deleting it from the takenPorts map.

--- a/tests/act/internal/act/act_test.go
+++ b/tests/act/internal/act/act_test.go
@@ -1,0 +1,122 @@
+package act
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestPortAllocationDoesNotOverlap checks that a port reserved by getFreePort for an act
+// artifact server is never handed to a listener created by listenFreePort.
+//
+// The mock servers used to bind their ports with net.Listen on port 0, which does not
+// consult takenPorts. The kernel could hand them a port that getFreePort had already
+// promised to an act artifact server that had not bound it yet, and act then died with
+// "bind: address already in use".
+func TestPortAllocationDoesNotOverlap(t *testing.T) {
+	t.Parallel()
+
+	// Reserve a batch of ports the way the act runner does: registered, but not bound.
+	const reserved = 16
+	reservedPorts := make(map[int]struct{}, reserved)
+	for range reserved {
+		port, err := getFreePort()
+		require.NoError(t, err)
+		require.NotContains(t, reservedPorts, port, "getFreePort handed out the same port twice")
+		reservedPorts[port] = struct{}{}
+		t.Cleanup(func() { markPortAsFree(port) })
+	}
+
+	// Now take listeners the way the mock servers do. None may land on a reserved port.
+	for range 64 {
+		listener, err := listenFreePort()
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = listener.Close() })
+
+		port := listener.Addr().(*net.TCPAddr).Port
+		require.NotContains(
+			t, reservedPorts, port,
+			"listenFreePort took port %d, which is reserved for an act artifact server", port,
+		)
+	}
+
+	// Every reserved port must still be bindable, which is what act does with it.
+	for port := range reservedPorts {
+		listener, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", port))
+		require.NoError(t, err, "reserved port %d was not free when act tried to bind it", port)
+		require.NoError(t, listener.Close())
+	}
+}
+
+// TestListenFreePortReleasesOnClose checks that closing a listener returned by
+// listenFreePort releases its takenPorts registration, so the port can be reused.
+func TestListenFreePortReleasesOnClose(t *testing.T) {
+	t.Parallel()
+
+	listener, err := listenFreePort()
+	require.NoError(t, err)
+	port := listener.Addr().(*net.TCPAddr).Port
+
+	_, taken := takenPorts.Load(port)
+	require.True(t, taken, "port should be registered while the listener is open")
+
+	require.NoError(t, listener.Close())
+
+	_, taken = takenPorts.Load(port)
+	require.False(t, taken, "port should be released once the listener is closed")
+}
+
+// TestPortAllocationIsConcurrencySafe hammers both allocators from many goroutines and
+// checks that no port is ever handed out twice.
+func TestPortAllocationIsConcurrencySafe(t *testing.T) {
+	t.Parallel()
+
+	const goroutines = 32
+
+	var (
+		mu    sync.Mutex
+		seen  = map[int]string{}
+		wg    sync.WaitGroup
+		claim = func(port int, via string) {
+			mu.Lock()
+			defer mu.Unlock()
+			previous, dup := seen[port]
+			require.False(t, dup, "port %d handed out by both %s and %s", port, previous, via)
+			seen[port] = via
+		}
+	)
+
+	wg.Add(goroutines * 2)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			port, err := getFreePort()
+			if !assertNoError(t, err) {
+				return
+			}
+			claim(port, "getFreePort")
+		}()
+		go func() {
+			defer wg.Done()
+			listener, err := listenFreePort()
+			if !assertNoError(t, err) {
+				return
+			}
+			claim(listener.Addr().(*net.TCPAddr).Port, "listenFreePort")
+		}()
+	}
+	wg.Wait()
+}
+
+// assertNoError reports err as a test failure from a goroutine and returns whether it was nil.
+func assertNoError(t *testing.T, err error) bool {
+	t.Helper()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+		return false
+	}
+	return true
+}

--- a/tests/act/internal/act/gcom.go
+++ b/tests/act/internal/act/gcom.go
@@ -25,8 +25,10 @@ type GCOM struct {
 func newGCOM(t *testing.T) *GCOM {
 	mux := http.NewServeMux()
 
-	// Create a listener on all interfaces (0.0.0.0) so Docker containers can reach it
-	listener, err := net.Listen("tcp", "0.0.0.0:0")
+	// Create a listener on all interfaces (0.0.0.0) so Docker containers can reach it.
+	// This must go through listenFreePort so the port is not one that getFreePort has
+	// already reserved for an act artifact server.
+	listener, err := listenFreePort()
 	if err != nil {
 		t.Fatalf("failed to create listener for GCOM mock: %v", err)
 	}

--- a/tests/act/internal/act/httpspy.go
+++ b/tests/act/internal/act/httpspy.go
@@ -52,8 +52,10 @@ func NewHTTPSpy(t *testing.T, outputs map[string]string) *HTTPSpy {
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /", spy.handleRequest)
 
-	// Create a listener on all interfaces (0.0.0.0) so Docker containers can reach it
-	listener, err := net.Listen("tcp", "0.0.0.0:0")
+	// Create a listener on all interfaces (0.0.0.0) so Docker containers can reach it.
+	// This must go through listenFreePort so the port is not one that getFreePort has
+	// already reserved for an act artifact server.
+	listener, err := listenFreePort()
 	if err != nil {
 		t.Fatalf("failed to create listener for HTTPSpy: %v", err)
 	}


### PR DESCRIPTION
Act tests fail every so often with a test that dies in under a second on `workflow should succeed`, and the log just above it says:

```
[] Start server on http://172.16.218.67:45945
[] listen tcp 172.16.218.67:45945: bind: address already in use
```

`getFreePort` picks a port for act's artifact server and records it in `takenPorts`, but it closes its probe socket before returning, so nothing actually holds the port until act binds it. The GCOM and HTTPSpy mocks took their own ports with `net.Listen("tcp", "0.0.0.0:0")`, which never looks at that map. When a mock got created in the window between the reservation and act binding, the kernel could hand it the exact port act was about to use.

Both mocks now go through `listenFreePort`, which binds first and then checks the map, retrying if the port is reserved. It keeps the port registered while the listener is open and releases it on `Close`, so there is no unbound window at all.

The probe also moves from `localhost` to `0.0.0.0`. act binds its artifact server on the host's outbound IP and the mocks bind every interface, so a port that is only known to be free on 127.0.0.1 does not tell us whether act can use it.

I scanned 261 of the 267 act test runs since 2026-06-09 that either failed or got retried. 57 of them died on this. That is about 22% of all act test failures in that window, and it is the single biggest cause.

This has been patched twice before, in #601 and #753. Both times the fix stayed inside `getFreePort` and neither noticed that the mock servers allocate ports without going through it, so I added unit tests for the invariant this time. Happy to drop them given the note in AGENTS.md about not adding tests to `tests/act`, but a concurrency bug on its third fix felt worth a guard.

Verified by reproducing it locally: with the old `net.Listen` path a mock takes a reserved port under enough churn, with `listenFreePort` it does not.

Unrelated, `TestMockVaultSecretsStep/common_+_repo_secrets` in `internal/workflow` already fails on main. Not touched here.