### PR TITLE
test(act): run the internal packages in CI

### DIFF
--- a/.github/workflows/pr-checks-test-ci.yml
+++ b/.github/workflows/pr-checks-test-ci.yml
@@ -98,10 +98,14 @@ jobs:
 
       - name: Run act tests
         run: |
+          # ./... so the internal packages are covered too, they were never run before.
+          # -p 1 keeps the package test binaries from running at the same time: the free
+          # port bookkeeping in internal/act is per-process, so a unit test reserving
+          # ports concurrently with a real act run could take one out from under it.
           go run gotest.tools/gotestsum@v1.13.0 \
             --junitfile "${RUNNER_TEMP}/act-tests.xml" \
             --format standard-verbose \
-            -- -timeout 1h
+            -- -timeout 1h -p 1 ./...
         working-directory: tests/act
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ act-lint:
 	cd tests/act && golangci-lint run
 
 act-test:
-	cd tests/act && go test -v -timeout 1h
+	cd tests/act && go test -v -timeout 1h -p 1 ./...
 
 actionlint:
 	actionlint

--- a/tests/act/internal/workflow/mock_test.go
+++ b/tests/act/internal/workflow/mock_test.go
@@ -214,7 +214,6 @@ func TestMockVaultSecretsStep(t *testing.T) {
 		}
 		mockedStep, err := MockVaultSecretsStep(step, vault)
 		require.NoError(t, err)
-		require.Equal(t, "Get Vault Secrets (mocked)", mockedStep.Name)
 		require.Contains(t, mockedStep.Run, bashOutput)
 		exp := `{"SECRET1":"value1","SECRET2":"value2"}`
 		require.Equal(t, exp, mockedStep.Env["SECRETS_JSON"])
@@ -233,7 +232,6 @@ func TestMockVaultSecretsStep(t *testing.T) {
 		}
 		mockedStep, err := MockVaultSecretsStep(step, vault)
 		require.NoError(t, err)
-		require.Equal(t, "Get Vault Secrets (mocked)", mockedStep.Name)
 		require.Contains(t, mockedStep.Run, bashOutput)
 		exp := `{"C":"value3","D":"value4"}`
 		require.Equal(t, exp, mockedStep.Env["SECRETS_JSON"])
@@ -256,7 +254,6 @@ func TestMockVaultSecretsStep(t *testing.T) {
 		}
 		mockedStep, err := MockVaultSecretsStep(step, vault)
 		require.NoError(t, err)
-		require.Equal(t, "Get Vault Secrets (mocked)", mockedStep.Name)
 		require.Contains(t, mockedStep.Run, bashOutput)
 		exp := `{"C":"value3","D":"value4","SECRET1":"value1","SECRET2":"value2"}`
 		require.Equal(t, exp, mockedStep.Env["SECRETS_JSON"])


### PR DESCRIPTION
`go test` in `tests/act` was never given a package pattern, so it only ever ran the root package. Everything under `internal/` has been going untested since test files first appeared there in January.

That is how `TestMockVaultSecretsStep` has been failing on main without anyone noticing. I ran it at `3b4cbcf`, the commit that introduced it, and it fails there too, so it has never passed.

The test asserts the mocked step's name on the value `MockVaultSecretsStep` returns. That is the wrong layer. Mock functions deliberately do not name their steps: `ReplaceStepAtIndex` fills the name in via `mockedName()` when the replacement step has none, and that also falls back to the step ID for steps without a name. Setting the name inside the mock would duplicate the framework and lose the ID fallback, so this drops the assertion instead of changing the mock.

`-p 1` stops the package test binaries running at the same time. The free port bookkeeping in `internal/act` is per-process, so once #1028 lands its unit tests would be reserving ports while a real act run is in progress and could take one out from under it. The act package dominates the runtime, so serialising costs a couple of seconds.

Two things I left alone, both pre-existing:

- `MockGCSUploadStep` sets `Name` itself, with `// TODO: remove so it's handled by mockedName(), in other WIP PR` above it. That WIP PR was #502, which merged two days *before* the TODO was written, so it has been stale from the start. Its two name assertions in `mock_test.go` pass only because of that redundant line. Worth a follow-up to remove both, but it is not in the way here.
- `mockedName()` and the naming behaviour in `ReplaceStepAtIndex` have no test of their own.

Split out of #1028, which is the port collision fix. They are independent, either can go first.